### PR TITLE
Add casino champagne gacha interaction

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,1040 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>カジノナイト・シャンパン演出ガチャ</title>
+  <style>
+    :root {
+      --bg-dark: #0b0b0f;
+      --accent-gold: #e3c572;
+      --accent-red: #b4202a;
+      --text-muted: #9b9bb5;
+      --cork-size: min(22vw, 120px);
+      --bottle-width: min(38vw, 280px);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: 'Segoe UI', 'Hiragino Kaku Gothic ProN', 'Yu Gothic', sans-serif;
+      background: radial-gradient(circle at top, rgba(227, 197, 114, 0.35), transparent 45%), var(--bg-dark);
+      color: #fff;
+      min-height: 100vh;
+    }
+
+    #app {
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+    }
+
+    .screen {
+      flex: 1;
+      display: none;
+      padding: 24px clamp(16px, 5vw, 64px);
+      position: relative;
+    }
+
+    .screen.active {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: clamp(16px, 3vh, 40px);
+      text-align: center;
+      transition: opacity 0.4s ease;
+      opacity: 1;
+    }
+
+    h1, h2 {
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    h1 {
+      font-size: clamp(1.8rem, 3.6vw, 3.2rem);
+      margin-bottom: 0.5em;
+      text-shadow: 0 10px 30px rgba(227, 197, 114, 0.35);
+    }
+
+    p {
+      margin: 0;
+      line-height: 1.6;
+      color: var(--text-muted);
+    }
+
+    button {
+      font: inherit;
+      cursor: pointer;
+      background: linear-gradient(135deg, var(--accent-red), #831219);
+      color: #fff;
+      border: none;
+      padding: 14px 32px;
+      border-radius: 12px;
+      min-width: 160px;
+      min-height: 44px;
+      letter-spacing: 0.08em;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+      box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+    }
+
+    button:hover,
+    button:focus-visible {
+      outline: 2px solid rgba(227, 197, 114, 0.85);
+      transform: translateY(-2px);
+      box-shadow: 0 14px 30px rgba(180, 32, 42, 0.45);
+    }
+
+    button:active {
+      transform: translateY(1px);
+    }
+
+    .intro-copy {
+      max-width: 620px;
+    }
+
+    .bunny-silhouette {
+      width: min(60vw, 280px);
+      height: min(60vw, 320px);
+      background: radial-gradient(circle at 30% 20%, rgba(255, 255, 255, 0.18), transparent 55%),
+        linear-gradient(160deg, rgba(180, 32, 42, 0.6), rgba(11, 11, 15, 0.1));
+      border-radius: 48% 48% 40% 40% / 50% 50% 46% 46%;
+      position: relative;
+      box-shadow: 0 28px 60px rgba(0, 0, 0, 0.6);
+    }
+
+    .bunny-silhouette::before,
+    .bunny-silhouette::after {
+      content: '';
+      position: absolute;
+      background: rgba(255, 255, 255, 0.08);
+      border-radius: 50%;
+    }
+
+    .bunny-silhouette::before {
+      width: 36%;
+      height: 38%;
+      top: -14%;
+      left: 22%;
+      transform: rotate(-12deg);
+      box-shadow: 4px 24px 40px rgba(227, 197, 114, 0.12);
+    }
+
+    .bunny-silhouette::after {
+      width: 18%;
+      height: 48%;
+      top: -28%;
+      right: 24%;
+      transform: rotate(8deg);
+    }
+
+    .play-layout {
+      width: 100%;
+      display: grid;
+      grid-template-columns: 1fr;
+      place-items: center;
+      gap: clamp(18px, 3vh, 36px);
+    }
+
+    .play-layout .instructions {
+      max-width: 540px;
+      background: rgba(17, 17, 24, 0.6);
+      border: 1px solid rgba(227, 197, 114, 0.2);
+      border-radius: 16px;
+      padding: 18px 24px;
+      text-align: left;
+      line-height: 1.5;
+    }
+
+    .play-layout .instructions ul {
+      padding-left: 1.1em;
+      margin: 0;
+      color: var(--text-muted);
+    }
+
+    .play-layout .arena {
+      position: relative;
+      width: min(420px, 70vw);
+      aspect-ratio: 3 / 5;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: radial-gradient(circle at top, rgba(227, 197, 114, 0.15), transparent 65%);
+    }
+
+    .champagne-bottle {
+      position: relative;
+      width: var(--bottle-width);
+      max-width: 320px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      touch-action: none;
+    }
+
+    .bottle-body {
+      width: 100%;
+      aspect-ratio: 3/8;
+      background: linear-gradient(170deg, rgba(20, 20, 32, 0.85), rgba(8, 8, 12, 0.95));
+      border-radius: 50% 50% 18% 18% / 22% 22% 82% 82%;
+      position: relative;
+      overflow: hidden;
+      border: 1px solid rgba(227, 197, 114, 0.18);
+      box-shadow: inset 0 0 36px rgba(227, 197, 114, 0.08), 0 28px 60px rgba(0, 0, 0, 0.6);
+    }
+
+    .bottle-body::after {
+      content: '';
+      position: absolute;
+      inset: 8% 14% 40% 14%;
+      border-radius: 50% 50% 10% 10% / 20% 20% 78% 78%;
+      background: linear-gradient(160deg, rgba(227, 197, 114, 0.22), transparent 65%);
+    }
+
+    .bottle-neck {
+      width: 34%;
+      height: clamp(120px, 18vh, 160px);
+      background: linear-gradient(180deg, rgba(54, 54, 72, 0.92), rgba(18, 18, 28, 0.92));
+      border-radius: 20px;
+      margin-top: -14%;
+      border: 1px solid rgba(227, 197, 114, 0.22);
+      position: relative;
+      display: flex;
+      justify-content: center;
+    }
+
+    .cork-wrapper {
+      position: absolute;
+      top: -16%;
+      width: 120%;
+      height: 120px;
+      display: flex;
+      justify-content: center;
+      pointer-events: none;
+    }
+
+    .cork-hit-area {
+      position: relative;
+      width: clamp(64px, 20vw, 120px);
+      height: clamp(64px, 20vw, 120px);
+      pointer-events: auto;
+    }
+
+    .cork {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 50% 50% 42% 42%;
+      background: linear-gradient(160deg, #784a24, #9c6635 55%, #3f2210 100%);
+      box-shadow: 0 12px 18px rgba(0, 0, 0, 0.45);
+      cursor: grab;
+      transition: transform 0.12s ease-out;
+      touch-action: none;
+    }
+
+    .cork::after {
+      content: '';
+      width: 68%;
+      height: 68%;
+      border-radius: 50%;
+      background: radial-gradient(circle, rgba(255, 255, 255, 0.35), rgba(120, 74, 36, 0.6));
+      opacity: 0.7;
+    }
+
+    .cork.grabbing {
+      cursor: grabbing;
+      box-shadow: 0 18px 32px rgba(0, 0, 0, 0.6);
+      transform: scale(1.03);
+    }
+
+    .cork.snap {
+      transition: transform 0.32s cubic-bezier(0.19, 1, 0.22, 1);
+    }
+
+    .glow-beam {
+      position: absolute;
+      width: 160%;
+      height: 60%;
+      top: -36%;
+      background: radial-gradient(circle, rgba(227, 197, 114, 0.2), transparent 70%);
+      filter: blur(16px);
+      opacity: 0;
+      transition: opacity 0.6s ease;
+      pointer-events: none;
+    }
+
+    .play-screen.pop-started .glow-beam {
+      opacity: 1;
+    }
+
+    .bubble-field {
+      position: absolute;
+      bottom: 20%;
+      width: 100%;
+      height: 50%;
+      overflow: visible;
+      pointer-events: none;
+    }
+
+    .bubble {
+      position: absolute;
+      bottom: 0;
+      border-radius: 50%;
+      background: rgba(255, 255, 255, 0.55);
+      animation: bubble-rise 1.8s ease-out forwards;
+      filter: blur(0.3px);
+    }
+
+    @keyframes bubble-rise {
+      0% {
+        transform: translateY(0) scale(0.6);
+        opacity: 0;
+      }
+      10% {
+        opacity: 1;
+      }
+      80% {
+        opacity: 1;
+      }
+      100% {
+        transform: translateY(-160%) scale(1.2);
+        opacity: 0;
+      }
+    }
+
+    .light-shaft {
+      position: absolute;
+      inset: 10% 25% 0 25%;
+      background: conic-gradient(from 160deg, rgba(227, 197, 114, 0.35), transparent 80%);
+      filter: blur(18px);
+      opacity: 0;
+      transition: opacity 0.5s ease;
+      mix-blend-mode: screen;
+    }
+
+    .play-screen.pop-started .light-shaft {
+      opacity: 0.75;
+      animation: pulseLight 1.6s ease-in-out infinite;
+    }
+
+    @keyframes pulseLight {
+      0%, 100% { opacity: 0.35; }
+      50% { opacity: 0.9; }
+    }
+
+    .draw-feed {
+      width: min(560px, 92vw);
+      max-width: 620px;
+      background: rgba(17, 17, 24, 0.7);
+      border-radius: 18px;
+      border: 1px solid rgba(227, 197, 114, 0.22);
+      padding: 24px 28px;
+      text-align: left;
+      box-shadow: 0 18px 36px rgba(0, 0, 0, 0.45);
+      opacity: 0;
+      transform: translateY(12px);
+      transition: opacity 0.4s ease, transform 0.4s ease;
+    }
+
+    .play-screen.pop-complete .draw-feed {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    .draw-feed h3 {
+      margin-top: 0;
+      margin-bottom: 12px;
+      color: var(--accent-gold);
+      letter-spacing: 0.12em;
+    }
+
+    .event-log {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      font-size: 0.95rem;
+    }
+
+    .event-log li {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      background: rgba(12, 12, 18, 0.9);
+      border-radius: 12px;
+      padding: 12px 16px;
+      border: 1px solid rgba(227, 197, 114, 0.16);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .event-log li::before {
+      content: '';
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      background: radial-gradient(circle, var(--accent-gold), rgba(227, 197, 114, 0.3));
+      box-shadow: 0 0 16px rgba(227, 197, 114, 0.4);
+    }
+
+    .event-log li.event-upgrade::after {
+      content: 'UP!';
+      position: absolute;
+      right: 12px;
+      top: 8px;
+      font-size: 0.75rem;
+      color: rgba(227, 197, 114, 0.85);
+      letter-spacing: 0.2em;
+    }
+
+    .result-screen {
+      align-items: flex-start;
+      padding-top: clamp(32px, 10vh, 120px);
+      gap: 28px;
+    }
+
+    .result-card {
+      width: min(700px, 96vw);
+      margin: 0 auto;
+      background: rgba(12, 12, 18, 0.88);
+      border-radius: 20px;
+      padding: clamp(24px, 4vw, 40px);
+      border: 1px solid rgba(227, 197, 114, 0.24);
+      box-shadow: 0 28px 64px rgba(0, 0, 0, 0.5);
+      text-align: center;
+    }
+
+    .rarity-tag {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 8px 22px;
+      border-radius: 999px;
+      font-size: 0.95rem;
+      letter-spacing: 0.12em;
+      margin-bottom: 16px;
+      color: #0b0b0f;
+      font-weight: 700;
+      text-transform: uppercase;
+      box-shadow: 0 14px 32px rgba(227, 197, 114, 0.25);
+    }
+
+    .rarity-0 { background: linear-gradient(135deg, #eaeaea, #bcbcbc); }
+    .rarity-1 { background: linear-gradient(135deg, #d8e4ff, #8aa0ff); }
+    .rarity-2 { background: linear-gradient(135deg, #fff3c4, #e3c572); }
+    .rarity-3 { background: linear-gradient(135deg, #ffe3fd, #b994ff 40%, #57f4ff 100%); }
+
+    .result-title {
+      font-size: clamp(2rem, 4vw, 3.4rem);
+      margin: 0 0 12px;
+      text-shadow: 0 20px 40px rgba(227, 197, 114, 0.45);
+    }
+
+    .result-items {
+      margin: 32px auto 0;
+      display: grid;
+      gap: 16px;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      text-align: left;
+    }
+
+    .result-item {
+      background: rgba(18, 18, 26, 0.9);
+      border-radius: 14px;
+      padding: 16px;
+      border: 1px solid rgba(227, 197, 114, 0.2);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .result-item::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, rgba(227, 197, 114, 0.16), transparent 60%);
+      opacity: 0;
+      transition: opacity 0.3s ease;
+    }
+
+    .result-item:hover::after {
+      opacity: 1;
+    }
+
+    .result-item h4 {
+      margin: 0 0 6px;
+      font-size: 1.05rem;
+      color: var(--accent-gold);
+    }
+
+    .result-item p {
+      font-size: 0.9rem;
+      color: var(--text-muted);
+    }
+
+    .firework-layer {
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      display: none;
+      z-index: 10;
+      mix-blend-mode: screen;
+    }
+
+    .firework-layer.active {
+      display: block;
+    }
+
+    .firework {
+      position: absolute;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: radial-gradient(circle, #fff, rgba(255, 255, 255, 0));
+      animation: burst 1.6s ease-out forwards;
+    }
+
+    @keyframes burst {
+      0% { transform: scale(0); opacity: 0.9; }
+      60% { opacity: 1; }
+      100% { transform: scale(14); opacity: 0; }
+    }
+
+    .jackpot-text {
+      font-size: clamp(2rem, 6vw, 4.6rem);
+      letter-spacing: 0.35em;
+      color: #fff4c7;
+      text-shadow: 0 0 18px rgba(227, 197, 114, 0.9), 0 0 40px rgba(255, 94, 0, 0.6);
+      animation: jackpotPulse 1.3s ease-in-out infinite;
+    }
+
+    @keyframes jackpotPulse {
+      0%, 100% { transform: scale(1); opacity: 0.8; }
+      50% { transform: scale(1.06); opacity: 1; }
+    }
+
+    @media (max-width: 640px) {
+      .play-layout {
+        gap: 14px;
+      }
+
+      .play-layout .instructions {
+        padding: 16px 18px;
+      }
+
+      .draw-feed {
+        padding: 20px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div id="app">
+    <section class="screen intro-screen active" aria-labelledby="intro-title">
+      <div class="intro-copy">
+        <h1 id="intro-title">Casino Night Champagne Gacha</h1>
+        <p>カジノナイトのVIPラウンジへようこそ。バニーガールがお届けするシャンパンの栓を抜き、豪奢な演出とともに豪華アイテムを解放しましょう。上方向のフリックやドラッグで栓を抜くと抽選が始まります。</p>
+      </div>
+      <div class="bunny-silhouette" aria-hidden="true"></div>
+      <button id="startButton" type="button">演出を開始</button>
+    </section>
+
+    <section class="screen play-screen" aria-live="polite">
+      <div class="play-layout">
+        <div class="instructions" tabindex="0">
+          <h2>シャンパンの栓を抜こう</h2>
+          <ul>
+            <li>スマホ：コルクをタッチして<strong>上方向へ素早くフリック</strong></li>
+            <li>PC：コルクをクリックで掴んで<strong>上方向にドラッグ</strong></li>
+            <li>キーボード：操作画面にフォーカスしながら <kbd>Space</kbd> または <kbd>↑</kbd> で即ポップ</li>
+          </ul>
+        </div>
+
+        <div class="arena">
+          <div class="glow-beam"></div>
+          <div class="champagne-bottle" aria-label="シャンパンボトル">
+            <div class="bottle-neck">
+              <div class="cork-wrapper">
+                <div class="cork-hit-area" role="button" aria-label="シャンパンのコルク" tabindex="0">
+                  <div class="cork" id="cork"></div>
+                </div>
+              </div>
+            </div>
+            <div class="bottle-body"></div>
+            <div class="bubble-field" id="bubbleField"></div>
+            <div class="light-shaft"></div>
+          </div>
+        </div>
+
+        <div class="draw-feed" id="drawFeed" aria-live="assertive" aria-atomic="true">
+          <h3>抽選ログ</h3>
+          <ul class="event-log" id="eventLog"></ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="screen result-screen" aria-labelledby="resultTitle">
+      <div class="result-card">
+        <div class="rarity-tag" id="rarityTag">RARITY</div>
+        <h2 class="result-title" id="resultTitle">結果を待機中...</h2>
+        <p id="resultFlavor">シャンパンの泡が煌めきを増している…</p>
+        <div class="result-items" id="resultItems"></div>
+        <div style="margin-top:32px; display:flex; gap:16px; justify-content:center; flex-wrap:wrap;">
+          <button type="button" id="replayButton">もう一度抜栓</button>
+          <button type="button" id="backIntroButton" style="background:linear-gradient(135deg,#434355,#1c1c26); color:#fff;">タイトルへ戻る</button>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <div class="firework-layer" id="fireworkLayer" aria-hidden="true"></div>
+
+  <script>
+    const screens = {
+      intro: document.querySelector('.intro-screen'),
+      play: document.querySelector('.play-screen'),
+      result: document.querySelector('.result-screen')
+    };
+    const startButton = document.getElementById('startButton');
+    const replayButton = document.getElementById('replayButton');
+    const backIntroButton = document.getElementById('backIntroButton');
+    const cork = document.getElementById('cork');
+    const corkHitArea = document.querySelector('.cork-hit-area');
+    const eventLog = document.getElementById('eventLog');
+    const drawFeed = document.getElementById('drawFeed');
+    const resultTag = document.getElementById('rarityTag');
+    const resultTitle = document.getElementById('resultTitle');
+    const resultFlavor = document.getElementById('resultFlavor');
+    const resultItems = document.getElementById('resultItems');
+    const bubbleField = document.getElementById('bubbleField');
+    const fireworkLayer = document.getElementById('fireworkLayer');
+
+    const POP_DISTANCE_PX = (() => {
+      const vh = window.innerHeight * 0.06;
+      return Math.min(Math.max(vh, 72), 120);
+    })();
+    const FLICK_VELOCITY_PX_PER_MS = 0.8;
+    const MAX_DOWN_DRAG = 12;
+
+    const state = {
+      dragging: false,
+      pointerId: null,
+      startY: 0,
+      lastY: 0,
+      lastT: 0,
+      dy: 0,
+      vy: 0,
+      popped: false
+    };
+
+    const rarities = [
+      { name: 'ホワイト', level: 0, flavor: '静かな煌めき。まだ序章に過ぎない。', jackpot: false },
+      { name: 'シルバー', level: 1, flavor: '銀の泡がカジノフロアへ舞い上がる。', jackpot: false },
+      { name: 'ゴールド', level: 2, flavor: '黄金色の祝福。VIPルームがざわめく。', jackpot: false },
+      { name: 'レインボー', level: 3, flavor: '伝説の虹色シャンパン! JACKPOT達成!', jackpot: true }
+    ];
+
+    const slotEvents = [
+      { label: 'スロット大当たり', upgrade: 1, description: '光のリールが揃い、泡がさらに弾けた!' },
+      { label: 'ポーカー フルハウス', upgrade: () => (Math.random() < 0.4 ? 2 : 1), description: 'バニーの巧みなディールでレア度上昇!' },
+      { label: 'ジャックポット', upgrade: 'rainbow', description: 'シャンパンが虹を描く! 一気に伝説級へ!' }
+    ];
+
+    let drawTimeouts = [];
+
+    function switchScreen(target) {
+      Object.values(screens).forEach(section => section.classList.remove('active'));
+      target.classList.add('active');
+    }
+
+    function resetPlayState() {
+      state.dragging = false;
+      state.pointerId = null;
+      state.dy = 0;
+      state.vy = 0;
+      state.popped = false;
+      cork.style.transition = '';
+      cork.style.transform = 'translateY(0)';
+      cork.classList.remove('grabbing', 'snap');
+      eventLog.innerHTML = '';
+      drawFeed.style.opacity = '0';
+      drawFeed.style.transform = 'translateY(12px)';
+      screens.play.classList.remove('pop-started', 'pop-complete');
+      fireworkLayer.classList.remove('active');
+      fireworkLayer.innerHTML = '';
+      drawTimeouts.forEach(clearTimeout);
+      drawTimeouts = [];
+    }
+
+    function switchToPlay() {
+      switchScreen(screens.play);
+      resetPlayState();
+      setTimeout(() => {
+        document.querySelector('.instructions').focus();
+      }, 80);
+    }
+
+    startButton.addEventListener('click', () => {
+      switchToPlay();
+    });
+
+    replayButton.addEventListener('click', () => {
+      switchToPlay();
+    });
+
+    backIntroButton.addEventListener('click', () => {
+      switchScreen(screens.intro);
+    });
+
+    function addEventLog(text, type) {
+      const li = document.createElement('li');
+      li.textContent = text;
+      if (type === 'upgrade') {
+        li.classList.add('event-upgrade');
+      }
+      eventLog.appendChild(li);
+      li.animate([
+        { opacity: 0, transform: 'translateY(8px)' },
+        { opacity: 1, transform: 'translateY(0)' }
+      ], {
+        duration: 320,
+        easing: 'ease-out'
+      });
+    }
+
+    function spawnBubbles(multiplier = 1) {
+      const count = Math.floor(18 * multiplier);
+      for (let i = 0; i < count; i++) {
+        const bubble = document.createElement('div');
+        bubble.className = 'bubble';
+        const size = Math.random() * 14 * multiplier + 6;
+        bubble.style.width = `${size}px`;
+        bubble.style.height = `${size}px`;
+        bubble.style.left = `${Math.random() * 80 + 10}%`;
+        bubble.style.animationDuration = `${1.6 + Math.random() * 0.6}s`;
+        bubble.style.animationDelay = `${Math.random() * 0.2}s`;
+        bubbleField.appendChild(bubble);
+        setTimeout(() => bubble.remove(), 2100);
+      }
+    }
+
+    function createFireworks() {
+      fireworkLayer.innerHTML = '';
+      fireworkLayer.classList.add('active');
+      const bursts = 6;
+      for (let i = 0; i < bursts; i++) {
+        const firework = document.createElement('div');
+        firework.className = 'firework';
+        firework.style.left = `${15 + Math.random() * 70}%`;
+        firework.style.top = `${20 + Math.random() * 50}%`;
+        firework.style.animationDuration = `${1.2 + Math.random() * 0.8}s`;
+        fireworkLayer.appendChild(firework);
+        setTimeout(() => firework.remove(), 1800);
+      }
+    }
+
+    function playPopSound() {
+      try {
+        const ctx = new (window.AudioContext || window.webkitAudioContext)();
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.type = 'triangle';
+        osc.frequency.setValueAtTime(220, ctx.currentTime);
+        osc.frequency.exponentialRampToValueAtTime(880, ctx.currentTime + 0.12);
+        gain.gain.setValueAtTime(0.0001, ctx.currentTime);
+        gain.gain.exponentialRampToValueAtTime(0.25, ctx.currentTime + 0.02);
+        gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.32);
+        osc.connect(gain).connect(ctx.destination);
+        osc.start();
+        osc.stop(ctx.currentTime + 0.34);
+      } catch (error) {
+        // audio is optional
+      }
+    }
+
+    function vibrate() {
+      try {
+        navigator.vibrate?.(30);
+      } catch (error) {
+        // ignore
+      }
+    }
+
+    function getPointerY(event) {
+      if (event.touches && event.touches[0]) {
+        return event.touches[0].clientY;
+      }
+      return event.clientY;
+    }
+
+    function onPointerDown(event) {
+      if (state.popped) return;
+      if (state.dragging) return;
+      state.dragging = true;
+      state.pointerId = event.pointerId !== undefined ? event.pointerId : 'mouse';
+      const y = getPointerY(event);
+      state.startY = y;
+      state.lastY = y;
+      state.lastT = performance.now();
+      state.dy = 0;
+      state.vy = 0;
+      cork.classList.add('grabbing');
+      cork.classList.remove('snap');
+      if (event.pointerId !== undefined && cork.setPointerCapture) {
+        cork.setPointerCapture(event.pointerId);
+      }
+    }
+
+    function onPointerMove(event) {
+      if (!state.dragging) return;
+      if (event.pointerId !== undefined && state.pointerId !== null && event.pointerId !== state.pointerId) {
+        return;
+      }
+      const y = getPointerY(event);
+      const t = performance.now();
+      state.dy = y - state.startY;
+      const dyStep = y - state.lastY;
+      const dt = t - state.lastT || 1;
+      state.vy = dyStep / dt;
+      state.lastY = y;
+      state.lastT = t;
+      const clamped = Math.min(MAX_DOWN_DRAG, Math.min(0, state.dy));
+      cork.style.transform = `translateY(${clamped}px)`;
+      event.preventDefault();
+    }
+
+    function snapBack() {
+      cork.classList.add('snap');
+      cork.style.transform = 'translateY(0)';
+      setTimeout(() => {
+        cork.classList.remove('snap');
+        cork.classList.remove('grabbing');
+      }, 360);
+    }
+
+    function handlePointerUp(event) {
+      if (!state.dragging) return;
+      if (event.pointerId !== undefined && state.pointerId !== null && event.pointerId !== state.pointerId) {
+        return;
+      }
+      state.dragging = false;
+      cork.classList.remove('grabbing');
+      const poppedByDistance = state.dy <= -POP_DISTANCE_PX;
+      const poppedByFlick = state.vy <= -FLICK_VELOCITY_PX_PER_MS;
+      if (poppedByDistance || poppedByFlick) {
+        popCork();
+      } else {
+        snapBack();
+      }
+    }
+
+    function popCork() {
+      if (state.popped) return;
+      state.popped = true;
+      cork.style.transition = 'transform 0.28s cubic-bezier(0.11, 0.68, 0.32, 1.28)';
+      cork.style.transform = `translateY(${-POP_DISTANCE_PX - 40}px)`;
+      setTimeout(() => {
+        cork.style.opacity = '0';
+      }, 180);
+      playPopSound();
+      vibrate();
+      screens.play.classList.add('pop-started');
+      spawnBubbles();
+      beginDrawSequence();
+    }
+
+    function beginDrawSequence() {
+      drawFeed.style.opacity = '1';
+      drawFeed.style.transform = 'translateY(0)';
+      addEventLog('泡が弾け、抽選がスタート!', 'info');
+
+      const baseIndex = weightedBaseRarity();
+      let currentLevel = baseIndex;
+      let jackpotTriggered = false;
+
+      function schedule(fn, delay) {
+        const id = setTimeout(fn, delay);
+        drawTimeouts.push(id);
+      }
+
+      schedule(() => {
+        addEventLog(`初期レアリティ：${rarities[currentLevel].name}`, 'info');
+        spawnBubbles(1.2);
+      }, 400);
+
+      const upgradeCount = determineUpgradeCount(currentLevel);
+      let cumulativeDelay = 1100;
+
+      for (let i = 0; i < upgradeCount && currentLevel < rarities.length - 1; i++) {
+        schedule(() => {
+          const event = pickUpgradeEvent();
+          let upgradeValue = 0;
+          if (event.upgrade === 'rainbow') {
+            currentLevel = rarities.length - 1;
+            jackpotTriggered = true;
+          } else {
+            upgradeValue = typeof event.upgrade === 'function' ? event.upgrade() : event.upgrade;
+            currentLevel = Math.min(rarities.length - 1, currentLevel + upgradeValue);
+          }
+          addEventLog(`${event.label}！ ${event.description}`, 'upgrade');
+          spawnBubbles(1.2 + i * 0.2);
+          if (currentLevel === rarities.length - 1) {
+            jackpotTriggered = true;
+          }
+        }, cumulativeDelay);
+        cumulativeDelay += 900;
+      }
+
+      schedule(() => {
+        finalizeResult(currentLevel, jackpotTriggered);
+      }, cumulativeDelay + 500);
+    }
+
+    function weightedBaseRarity() {
+      const weights = [0.5, 0.3, 0.18, 0.02];
+      const r = Math.random();
+      let cumulative = 0;
+      for (let i = 0; i < weights.length; i++) {
+        cumulative += weights[i];
+        if (r < cumulative) {
+          return i;
+        }
+      }
+      return 0;
+    }
+
+    function determineUpgradeCount(currentLevel) {
+      if (currentLevel >= rarities.length - 1) return 0;
+      const chance = Math.random();
+      if (chance < 0.55) return 1;
+      if (chance < 0.8) return 2;
+      return 0;
+    }
+
+    function pickUpgradeEvent() {
+      const idx = Math.floor(Math.random() * slotEvents.length);
+      return slotEvents[idx];
+    }
+
+    function finalizeResult(level, jackpot) {
+      screens.play.classList.add('pop-complete');
+      addEventLog(`最終レアリティ：${rarities[level].name}`, 'upgrade');
+      const rarity = rarities[level];
+      const label = `RANK: ${rarity.name}`;
+      resultTag.textContent = label;
+      resultTag.className = `rarity-tag rarity-${rarity.level}`;
+      resultTitle.textContent = rarity.jackpot ? '虹色ジャックポット獲得!' : `${rarity.name}シャンパン解放!`;
+      resultFlavor.textContent = rarity.flavor;
+      const items = generateItems(level);
+      renderItems(items);
+      if (jackpot) {
+        spawnBubbles(1.6);
+        spawnBubbles(1.6);
+        createFireworks();
+        addEventLog('虹色の光がVIPラウンジを包み込む!', 'upgrade');
+      }
+      setTimeout(() => {
+        switchScreen(screens.result);
+        if (jackpot) {
+          const jackpotHeading = document.createElement('div');
+          jackpotHeading.className = 'jackpot-text';
+          jackpotHeading.textContent = 'JACKPOT!';
+          resultTag.insertAdjacentElement('afterend', jackpotHeading);
+          setTimeout(() => jackpotHeading.remove(), 4000);
+        }
+      }, 900);
+    }
+
+    function generateItems(level) {
+      const pool = [
+        'VIP バニーチップ',
+        'クリスタルダイス',
+        'ラグジュアリースーツ',
+        'ミッドナイト・カクテルセット',
+        'ルーレット・プレミアムトークン',
+        '煌めくトランプデッキ',
+        'ゴールドプレート招待状',
+        'プラチナ・シャンパングラス'
+      ];
+      const items = [];
+      const count = 3 + Math.min(level, 2);
+      for (let i = 0; i < count; i++) {
+        const index = Math.floor(Math.random() * pool.length);
+        items.push({
+          name: pool[index],
+          description: itemFlavor(pool[index], level)
+        });
+        pool.splice(index, 1);
+      }
+      return items;
+    }
+
+    function itemFlavor(name, level) {
+      const tierTexts = [
+        'スタンダードな魅力が光るアイテム。',
+        '上質な輝きでテーブルが沸き立つ。',
+        'VIPのみが触れられる逸品。',
+        '伝説級の価値が宿る究極のトロフィー。'
+      ];
+      return `${name}：${tierTexts[level] || tierTexts[tierTexts.length - 1]}`;
+    }
+
+    function renderItems(items) {
+      resultItems.innerHTML = '';
+      items.forEach(item => {
+        const div = document.createElement('div');
+        div.className = 'result-item';
+        const title = document.createElement('h4');
+        title.textContent = item.name;
+        const desc = document.createElement('p');
+        desc.textContent = item.description;
+        div.appendChild(title);
+        div.appendChild(desc);
+        resultItems.appendChild(div);
+      });
+    }
+
+    corkHitArea.addEventListener('pointerdown', onPointerDown);
+    window.addEventListener('pointermove', onPointerMove);
+    window.addEventListener('pointerup', handlePointerUp);
+    window.addEventListener('pointercancel', handlePointerUp);
+
+    corkHitArea.addEventListener('keydown', (event) => {
+      if (event.code === 'Space' || event.code === 'ArrowUp') {
+        event.preventDefault();
+        if (!state.popped) {
+          popCork();
+        }
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (!screens.play.classList.contains('active')) return;
+      if (event.code === 'Space' || event.code === 'ArrowUp') {
+        event.preventDefault();
+        if (!state.popped) {
+          popCork();
+        }
+      }
+    });
+
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'hidden') {
+        drawTimeouts.forEach(clearTimeout);
+        drawTimeouts = [];
+      }
+    });
+
+    window.addEventListener('resize', () => {
+      // Responsive adjustments if needed in future.
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build a single-page casino-themed champagne gacha experience covering intro, interaction, and result screens
- implement cork popping via pointer drag/flick and keyboard shortcuts with snapback behavior
- orchestrate animated draw events with bubbles, upgrades, and jackpot fireworks leading to item rewards

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d27ff4c7e083298d9ac055cf5b1a60