### PR TITLE
Add neon-themed skill tree todo prototype

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Skill Tree TODO</title>
+  </head>
+  <body class="bg-[#0B1020] text-[#E6EDF8]">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "skill-tree-todo",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "clsx": "^2.1.0",
+    "cytoscape": "^3.27.0",
+    "cytoscape-cola": "^2.5.1",
+    "framer-motion": "^10.16.4",
+    "lucide-react": "^0.303.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.21.1",
+    "zustand": "^4.4.7"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.46",
+    "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.3.0",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.6",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.10"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,93 @@
+import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom';
+import { Flame, LayoutGrid, Map as MapIcon, ListCheck, Gift, Bot, Settings, LogOut } from 'lucide-react';
+import { useEffect } from 'react';
+import { useUIStore } from './stores/ui';
+import { useTasksStore } from './stores/tasks';
+import { useRewardsStore } from './stores/rewards';
+import { RewardModal } from './components/RewardModal';
+
+const navItems = [
+  { to: '/', label: 'ダッシュボード', icon: LayoutGrid },
+  { to: '/tree', label: 'スキルツリー', icon: MapIcon },
+  { to: '/tasks', label: 'タスク', icon: ListCheck },
+  { to: '/rewards', label: '報酬', icon: Gift },
+  { to: '/suggestions', label: '提案', icon: Bot },
+  { to: '/settings', label: '設定', icon: Settings }
+];
+
+export const AppLayout = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const theme = useUIStore((state) => state.theme);
+  const streak = useTasksStore((state) => state.streak);
+  const pendingUnlock = useRewardsStore((state) => state.pendingUnlock);
+  const closeUnlockModal = useRewardsStore((state) => state.dismissPending);
+
+  useEffect(() => {
+    if (location.pathname === '/login') {
+      navigate('/');
+    }
+  }, [location.pathname, navigate]);
+
+  const currentNav = navItems.find((item) => location.pathname === item.to);
+
+  return (
+    <div className={`min-h-screen bg-[#0B1020] text-[#E6EDF8] ${theme === 'neon' ? 'neon-theme' : ''}`}>
+      <div className="flex min-h-screen">
+        <aside className="hidden w-64 flex-col border-r border-white/10 bg-[#0B1020]/80 p-6 md:flex">
+          <div className="flex items-center gap-3">
+            <Flame className="text-milestone" />
+            <div>
+              <p className="text-sm text-accent/80">ストリーク</p>
+              <p className="text-2xl font-bold text-milestone">{streak.currentDays}日</p>
+            </div>
+          </div>
+          <nav className="mt-10 space-y-2">
+            {navItems.map((item) => {
+              const Icon = item.icon;
+              return (
+                <NavLink
+                  key={item.to}
+                  to={item.to}
+                  className={({ isActive }) =>
+                    `focus-ring flex items-center gap-3 rounded-xl px-4 py-3 text-sm font-semibold transition hover:bg-accent/10 ${
+                      isActive ? 'bg-accent/15 text-accent' : 'text-white/70'
+                    }`
+                  }
+                  aria-label={item.label}
+                >
+                  <Icon size={18} />
+                  {item.label}
+                </NavLink>
+              );
+            })}
+          </nav>
+          <button
+            className="focus-ring mt-auto flex items-center gap-3 rounded-xl px-4 py-3 text-sm text-white/60 transition hover:bg-red-500/10 hover:text-red-300"
+            aria-label="ログアウト"
+            onClick={() => navigate('/login')}
+          >
+            <LogOut size={18} />ログアウト
+          </button>
+        </aside>
+        <main className="flex-1">
+          <header className="sticky top-0 z-20 flex items-center justify-between border-b border-white/10 bg-[#0B1020]/80 px-6 py-4 backdrop-blur">
+            <div>
+              <p className="text-xs uppercase tracking-widest text-accent/70">Neo Skill Planner</p>
+              <h1 className="text-2xl font-bold">{currentNav?.label ?? 'ダッシュボード'}</h1>
+            </div>
+            <div className="flex items-center gap-3 text-sm text-white/60">
+              <span>テーマ: {theme === 'neon' ? 'ネオン' : 'ダーク'}</span>
+            </div>
+          </header>
+          <div className="px-4 pb-12 pt-6">
+            <Outlet />
+          </div>
+        </main>
+      </div>
+      {pendingUnlock && <RewardModal unlock={pendingUnlock} onClose={closeUnlockModal} />}
+    </div>
+  );
+};
+
+export default AppLayout;

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,0 +1,16 @@
+import { HTMLAttributes } from 'react';
+import { clsx } from 'clsx';
+
+interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  variant?: 'pending' | 'progress' | 'done' | 'milestone';
+}
+
+export const Badge = ({ variant = 'pending', className, ...props }: BadgeProps) => {
+  const styles = {
+    pending: 'badge-pending',
+    progress: 'badge-progress',
+    done: 'badge-done',
+    milestone: 'badge-milestone'
+  };
+  return <span className={clsx('badge', styles[variant], className)} {...props} />;
+};

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,25 @@
+import { ButtonHTMLAttributes, forwardRef } from 'react';
+import { clsx } from 'clsx';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary' | 'ghost';
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'primary', children, ...props }, ref) => {
+    const base = 'focus-ring inline-flex items-center justify-center gap-2 rounded-2xl px-5 py-2.5 text-sm font-semibold transition shadow-neon';
+    const variants = {
+      primary: 'bg-accent text-[#0B1020] hover:bg-accent/90',
+      secondary: 'bg-success/20 text-success hover:bg-success/30',
+      ghost: 'bg-transparent text-accent hover:bg-accent/10'
+    };
+
+    return (
+      <button ref={ref} className={clsx(base, variants[variant], className)} {...props}>
+        {children}
+      </button>
+    );
+  }
+);
+
+Button.displayName = 'Button';

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,0 +1,12 @@
+import { HTMLAttributes } from 'react';
+import { clsx } from 'clsx';
+
+export const Card = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={clsx(
+      'neon-card relative overflow-hidden rounded-2xl border border-white/10 bg-surface/80 p-6 text-[#E6EDF8] shadow-neon',
+      className
+    )}
+    {...props}
+  />
+);

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -1,0 +1,43 @@
+import { ReactNode } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { X } from 'lucide-react';
+
+interface DrawerProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: ReactNode;
+}
+
+export const Drawer = ({ open, onClose, title, children }: DrawerProps) => {
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          className="fixed inset-0 z-40 flex justify-end bg-black/40"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          aria-modal="true"
+          role="dialog"
+        >
+          <motion.div
+            className="h-full w-full max-w-md overflow-y-auto border-l border-white/10 bg-[#10152B] p-6 shadow-neon"
+            initial={{ x: 400 }}
+            animate={{ x: 0 }}
+            exit={{ x: 400 }}
+            transition={{ type: 'spring', stiffness: 120, damping: 18 }}
+          >
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="text-xl font-bold text-accent">{title}</h2>
+              <button className="focus-ring rounded-full p-2 hover:bg-accent/10" onClick={onClose} aria-label="閉じる">
+                <X size={18} />
+              </button>
+            </div>
+            <div className="space-y-4 text-sm text-white/70">{children}</div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,0 +1,17 @@
+import { ButtonHTMLAttributes } from 'react';
+import { clsx } from 'clsx';
+
+interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  active?: boolean;
+}
+
+export const IconButton = ({ className, active = false, ...props }: IconButtonProps) => (
+  <button
+    className={clsx(
+      'focus-ring rounded-xl border border-white/10 bg-white/5 p-2 text-white/70 transition hover:text-accent',
+      active && 'border-accent/60 text-accent shadow-neon',
+      className
+    )}
+    {...props}
+  />
+);

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,42 @@
+import { ReactNode } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: ReactNode;
+  footer?: ReactNode;
+}
+
+export const Modal = ({ open, onClose, title, children, footer }: ModalProps) => {
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          role="dialog"
+          aria-modal="true"
+        >
+          <motion.div
+            className="w-full max-w-lg rounded-2xl border border-accent/40 bg-[#10152B] p-6 shadow-neon"
+            initial={{ scale: 0.9, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.9, opacity: 0 }}
+            transition={{ duration: 0.2, ease: 'easeOut' }}
+          >
+            <div className="mb-4">
+              <h2 className="text-xl font-bold text-accent">{title}</h2>
+            </div>
+            <div className="space-y-4 text-sm text-white/70">{children}</div>
+            {footer && <div className="mt-6 flex justify-end gap-3">{footer}</div>}
+            <button className="sr-only" aria-label="閉じる" onClick={onClose} />
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/src/components/Progress.tsx
+++ b/src/components/Progress.tsx
@@ -1,0 +1,21 @@
+import { HTMLAttributes } from 'react';
+import { clsx } from 'clsx';
+
+interface ProgressProps extends HTMLAttributes<HTMLDivElement> {
+  value: number;
+}
+
+export const Progress = ({ value, className, ...props }: ProgressProps) => {
+  return (
+    <div className={clsx('w-full rounded-full bg-white/10 p-1', className)} {...props}>
+      <div
+        className="h-2 w-full rounded-full bg-accent"
+        style={{ width: `${Math.min(100, Math.max(0, value))}%` }}
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={Math.round(value)}
+      />
+    </div>
+  );
+};

--- a/src/components/RewardChestAnimation.tsx
+++ b/src/components/RewardChestAnimation.tsx
@@ -1,0 +1,47 @@
+import { motion } from 'framer-motion';
+import { Sparkles } from 'lucide-react';
+
+interface RewardChestAnimationProps {
+  title: string;
+  description: string;
+}
+
+export const RewardChestAnimation = ({ title, description }: RewardChestAnimationProps) => {
+  return (
+    <div className="relative flex flex-col items-center gap-4">
+      <motion.div
+        className="relative flex h-32 w-40 items-center justify-center rounded-2xl border border-milestone/50 bg-gradient-to-br from-milestone/40 to-transparent"
+        initial={{ scale: 0.95 }}
+        animate={{ scale: [1, 1.1, 1] }}
+        transition={{ duration: 0.6, ease: 'easeInOut', repeat: Infinity, repeatDelay: 3 }}
+      >
+        <motion.div
+          className="absolute inset-1 rounded-2xl border border-white/20 bg-[#0B1020]/90"
+          initial={{ boxShadow: '0 0 0px rgba(241,196,15,0.3)' }}
+          animate={{ boxShadow: ['0 0 20px rgba(241,196,15,0.3)', '0 0 35px rgba(241,196,15,0.6)', '0 0 20px rgba(241,196,15,0.3)'] }}
+          transition={{ duration: 1.2, repeat: Infinity }}
+        />
+        <motion.div
+          className="relative z-10 flex flex-col items-center"
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.1 }}
+        >
+          <Sparkles className="mb-2 text-milestone" size={32} />
+          <p className="text-sm font-semibold text-milestone">{title}</p>
+          <p className="text-xs text-white/60">{description}</p>
+        </motion.div>
+      </motion.div>
+      <motion.div
+        className="absolute -top-6 flex gap-2"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: [0, 1, 0] }}
+        transition={{ duration: 1.5, repeat: Infinity }}
+      >
+        {[...Array(3)].map((_, index) => (
+          <Sparkles key={index} className="text-accent" size={18} />
+        ))}
+      </motion.div>
+    </div>
+  );
+};

--- a/src/components/RewardModal.tsx
+++ b/src/components/RewardModal.tsx
@@ -1,0 +1,49 @@
+import { Modal } from './Modal';
+import { RewardChestAnimation } from './RewardChestAnimation';
+import { Button } from './Button';
+import { useRewardsStore } from '../stores/rewards';
+import { formatRange } from '../utils/date';
+import { RewardRule } from '../types';
+
+interface RewardModalProps {
+  unlock: ReturnType<typeof useRewardsStore.getState>['pendingUnlock'];
+  onClose: () => void;
+}
+
+const rewardTypeLabel: Record<RewardRule['rewardType'], string> = {
+  food: 'フード',
+  goods: 'アイテム',
+  device_right: 'デバイス権利',
+  other: 'その他'
+};
+
+export const RewardModal = ({ unlock, onClose }: RewardModalProps) => {
+  const claimUnlock = useRewardsStore((state) => state.claimUnlock);
+  const rule = useRewardsStore((state) => state.rules.find((r) => r.id === unlock?.ruleId));
+
+  if (!unlock || !rule) return null;
+
+  return (
+    <Modal
+      open={Boolean(unlock)}
+      onClose={onClose}
+      title={`報酬解放: ${rewardTypeLabel[rule.rewardType]}`}
+      footer={
+        <Button
+          onClick={() => {
+            claimUnlock(unlock.id);
+            onClose();
+          }}
+        >
+          受け取る
+        </Button>
+      }
+    >
+      <RewardChestAnimation title={rule.rewardDesc} description={rewardTypeLabel[rule.rewardType]} />
+      <p>
+        期間: {formatRange(unlock.periodStart, unlock.periodEnd)} / 達成数: {unlock.completedCount} / 目標:
+        {rule.targetCount}
+      </p>
+    </Modal>
+  );
+};

--- a/src/components/StreakMeter.tsx
+++ b/src/components/StreakMeter.tsx
@@ -1,0 +1,25 @@
+import { Flame } from 'lucide-react';
+import { useTasksStore } from '../stores/tasks';
+
+export const StreakMeter = () => {
+  const streak = useTasksStore((state) => state.streak);
+  const intensity = Math.min(1, streak.currentDays / 7);
+
+  return (
+    <div className="flex items-center gap-4 rounded-2xl border border-accent/30 bg-[#111936]/80 px-6 py-4 shadow-neon">
+      <div
+        className="rounded-full p-3"
+        style={{
+          background: `radial-gradient(circle, rgba(241,196,15,${0.4 + intensity * 0.4}), rgba(241,196,15,0.1))`
+        }}
+      >
+        <Flame className="text-milestone" size={32} />
+      </div>
+      <div>
+        <p className="text-sm text-accent/80">連続達成日数</p>
+        <p className="text-2xl font-bold text-milestone">{streak.currentDays}日</p>
+        <p className="text-xs text-white/50">最長 {streak.longestDays} 日</p>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -1,0 +1,30 @@
+import { ButtonHTMLAttributes } from 'react';
+import { clsx } from 'clsx';
+
+interface SwitchProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'> {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}
+
+export const Switch = ({ checked, onCheckedChange, className, ...props }: SwitchProps) => {
+  return (
+    <button
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onCheckedChange(!checked)}
+      className={clsx(
+        'focus-ring relative h-8 w-14 rounded-full border border-white/10 px-1 transition',
+        checked ? 'bg-accent/80' : 'bg-white/10',
+        className
+      )}
+      {...props}
+    >
+      <span
+        className={clsx(
+          'absolute top-1 left-1 h-6 w-6 rounded-full bg-white transition-transform',
+          checked ? 'translate-x-6' : 'translate-x-0'
+        )}
+      />
+    </button>
+  );
+};

--- a/src/data/seed.ts
+++ b/src/data/seed.ts
@@ -1,0 +1,146 @@
+import { RewardRule, RewardUnlock, Streak, Suggestion, Task } from '../types';
+import { getPeriodWindow } from '../utils/reward';
+
+const now = new Date();
+const { start: dailyStart, end: dailyEnd } = getPeriodWindow('daily', now);
+const { start: weeklyStart, end: weeklyEnd } = getPeriodWindow('weekly', now);
+const { start: monthlyStart, end: monthlyEnd } = getPeriodWindow('monthly', now);
+
+export const seedTasks: Task[] = [
+  {
+    id: 'task-1',
+    title: '朝の瞑想10分',
+    description: '集中力を高めるための瞑想。呼吸を整える。',
+    status: 'in_progress',
+    difficulty: 2,
+    tags: ['health'],
+    dependsOn: []
+  },
+  {
+    id: 'task-2',
+    title: 'TypeScript教材を1セクション学習',
+    description: '進行中のオンライン講座を1チャンク進める。',
+    status: 'pending',
+    difficulty: 3,
+    tags: ['study'],
+    dependsOn: ['task-1']
+  },
+  {
+    id: 'task-3',
+    title: '週次の振り返りノート',
+    description: '今週の成果をまとめ、次週の優先度を決める。',
+    status: 'milestone',
+    difficulty: 4,
+    tags: ['work'],
+    dependsOn: ['task-1', 'task-2']
+  },
+  {
+    id: 'task-4',
+    title: '軽いHIITトレーニング',
+    description: '自宅で15分のHIITを行う。',
+    status: 'pending',
+    difficulty: 3,
+    tags: ['health'],
+    dependsOn: ['task-1']
+  },
+  {
+    id: 'task-5',
+    title: 'ブログ記事の下書き',
+    description: 'アウトプット用に500文字の下書きを作成。',
+    status: 'done',
+    difficulty: 3,
+    tags: ['work'],
+    dependsOn: ['task-2'],
+    completedAt: new Date(now.getTime() - 1000 * 60 * 60 * 20).toISOString()
+  }
+];
+
+export const seedRewardRules: RewardRule[] = [
+  {
+    id: 'reward-d-1',
+    period: 'daily',
+    targetCount: 3,
+    rewardType: 'food',
+    rewardDesc: 'ご褒美スムージー',
+    autoClaimDefault: true
+  },
+  {
+    id: 'reward-w-1',
+    period: 'weekly',
+    targetCount: 15,
+    rewardType: 'goods',
+    rewardDesc: '新しいノートを購入',
+    autoClaimDefault: false
+  },
+  {
+    id: 'reward-m-1',
+    period: 'monthly',
+    targetCount: 60,
+    rewardType: 'device_right',
+    rewardDesc: '週末のゲーム解禁日',
+    autoClaimDefault: false
+  }
+];
+
+export const seedRewardUnlocks: RewardUnlock[] = [
+  {
+    id: 'unlock-d-1',
+    ruleId: 'reward-d-1',
+    period: 'daily',
+    periodStart: dailyStart.toISOString(),
+    periodEnd: dailyEnd.toISOString(),
+    completedCount: 2
+  },
+  {
+    id: 'unlock-w-1',
+    ruleId: 'reward-w-1',
+    period: 'weekly',
+    periodStart: weeklyStart.toISOString(),
+    periodEnd: weeklyEnd.toISOString(),
+    completedCount: 8
+  },
+  {
+    id: 'unlock-m-1',
+    ruleId: 'reward-m-1',
+    period: 'monthly',
+    periodStart: monthlyStart.toISOString(),
+    periodEnd: monthlyEnd.toISOString(),
+    completedCount: 22
+  }
+];
+
+export const seedStreak: Streak = {
+  currentDays: 4,
+  longestDays: 7,
+  lastIncrementDate: now.toISOString()
+};
+
+export const seedSuggestions: Suggestion[] = [
+  {
+    id: 'sug-1',
+    title: '昼休みにストレッチ5分',
+    reason: '座りっぱなし対策としてChatGPTが推奨',
+    estMinutes: 5,
+    difficulty: 1,
+    tags: ['health'],
+    decision: 'pending'
+  },
+  {
+    id: 'sug-2',
+    title: '記事のSEO改善リサーチ',
+    reason: 'ブログのパフォーマンス向上のため',
+    estMinutes: 40,
+    difficulty: 3,
+    tags: ['work'],
+    decision: 'pending'
+  },
+  {
+    id: 'sug-3',
+    title: '英語のPodcastを1本聞く',
+    reason: 'リスニング強化のための提案',
+    estMinutes: 30,
+    difficulty: 2,
+    tags: ['study'],
+    decision: 'pending'
+  }
+];

--- a/src/lib/cyto/initCytoscape.ts
+++ b/src/lib/cyto/initCytoscape.ts
@@ -1,0 +1,56 @@
+import cytoscape, { Core } from 'cytoscape';
+import cola from 'cytoscape-cola';
+import { getStyles } from './styles';
+import { getLayoutOptions } from './layouts';
+
+cytoscape.use(cola);
+
+export interface TreeCallbacks {
+  onNodeSelect?: (data: any) => void;
+  onNodeHover?: (payload: { visible: boolean; position: { x: number; y: number }; data?: any }) => void;
+  onContextMenu?: (payload: { position: { x: number; y: number }; data: any }) => void;
+}
+
+export const initCytoscape = (
+  container: HTMLElement,
+  elements: { nodes: any[]; edges: any[] },
+  layout: 'cola' | 'concentric',
+  callbacks?: TreeCallbacks
+): Core => {
+  const cy = cytoscape({
+    container,
+    elements: [...elements.nodes, ...elements.edges],
+    style: getStyles(),
+    layout: getLayoutOptions(layout),
+    wheelSensitivity: 0.2,
+    minZoom: 0.3,
+    maxZoom: 2.5
+  });
+
+  if (callbacks?.onNodeSelect) {
+    cy.on('tap', 'node', (event) => {
+      callbacks.onNodeSelect?.(event.target.data());
+    });
+  }
+
+  if (callbacks?.onNodeHover) {
+    cy.on('mouseover', 'node', (event) => {
+      callbacks.onNodeHover?.({ visible: true, position: event.renderedPosition, data: event.target.data() });
+    });
+    cy.on('mouseout', 'node', () => {
+      callbacks.onNodeHover?.({ visible: false, position: { x: 0, y: 0 } });
+    });
+  }
+
+  if (callbacks?.onContextMenu) {
+    cy.on('cxttap', 'node', (event) => {
+      callbacks.onContextMenu?.({ position: event.renderedPosition, data: event.target.data() });
+    });
+  }
+
+  return cy;
+};
+
+export const updateCytoscape = (cy: Core, layout: 'cola' | 'concentric') => {
+  cy.layout(getLayoutOptions(layout)).run();
+};

--- a/src/lib/cyto/layouts.ts
+++ b/src/lib/cyto/layouts.ts
@@ -1,0 +1,22 @@
+import { LayoutOptions } from 'cytoscape';
+
+export const getLayoutOptions = (layout: 'cola' | 'concentric'): LayoutOptions => {
+  if (layout === 'cola') {
+    return {
+      name: 'cola',
+      animate: true,
+      nodeSpacing: 20,
+      edgeLength: 120,
+      maxSimulationTime: 1000,
+      padding: 40
+    } as LayoutOptions;
+  }
+
+  return {
+    name: 'concentric',
+    animate: true,
+    concentric: (node) => (node.data('status') === 'milestone' ? 3 : node.data('status') === 'done' ? 2 : 1),
+    levelWidth: () => 1,
+    padding: 50
+  } as LayoutOptions;
+};

--- a/src/lib/cyto/styles.ts
+++ b/src/lib/cyto/styles.ts
@@ -1,0 +1,64 @@
+import { Stylesheet } from 'cytoscape';
+
+export const getStyles = (): Stylesheet[] => [
+  {
+    selector: 'node',
+    style: {
+      width: '60px',
+      height: '60px',
+      'background-color': '#5A5F73',
+      'border-width': 2,
+      'border-color': '#0B1020',
+      label: 'data(label)',
+      color: '#E6EDF8',
+      'font-size': '12px',
+      'text-wrap': 'wrap',
+      'text-max-width': '80px',
+      'text-valign': 'center',
+      'text-halign': 'center',
+      'transition-property': 'background-color, box-shadow, border-color',
+      'transition-duration': '300ms'
+    }
+  },
+  {
+    selector: 'node[status = "in_progress"]',
+    style: {
+      'background-color': '#3DB2FF',
+      'box-shadow': '0 0 20px #3DB2FF'
+    }
+  },
+  {
+    selector: 'node[status = "done"]',
+    style: {
+      'background-color': '#2ECC71',
+      'box-shadow': '0 0 20px #2ECC71'
+    }
+  },
+  {
+    selector: 'node[status = "milestone"]',
+    style: {
+      'background-color': '#F1C40F',
+      'box-shadow': '0 0 25px #F1C40F',
+      width: '72px',
+      height: '72px',
+      'font-size': '14px'
+    }
+  },
+  {
+    selector: 'edge',
+    style: {
+      width: 3,
+      'line-color': 'rgba(61,178,255,0.4)',
+      'target-arrow-color': 'rgba(61,178,255,0.7)',
+      'target-arrow-shape': 'triangle',
+      'curve-style': 'bezier'
+    }
+  },
+  {
+    selector: ':selected',
+    style: {
+      'border-width': 4,
+      'border-color': '#F1C40F'
+    }
+  }
+];

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { RouterProvider } from 'react-router-dom';
+import './styles/index.css';
+import { router } from './routes';
+import { UIProvider } from './providers/UIProvider';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <UIProvider>
+      <RouterProvider router={router} />
+    </UIProvider>
+  </React.StrictMode>
+);

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,84 @@
+import { Card } from '../components/Card';
+import { Progress } from '../components/Progress';
+import { StreakMeter } from '../components/StreakMeter';
+import { useTasksStore } from '../stores/tasks';
+import { useRewardsStore } from '../stores/rewards';
+import { formatDate } from '../utils/date';
+import { RewardRule } from '../types';
+
+const periodLabels: Record<'daily' | 'weekly' | 'monthly', string> = {
+  daily: '今日',
+  weekly: '今週',
+  monthly: '今月'
+};
+
+const rewardTypeLabel: Record<RewardRule['rewardType'], string> = {
+  food: 'フード',
+  goods: 'アイテム',
+  device_right: 'デバイス権利',
+  other: 'その他'
+};
+
+export const DashboardPage = () => {
+  const completion = useTasksStore((state) => state.getPeriodStats());
+  const recent = useRewardsStore((state) =>
+    [...state.unlocks]
+      .filter((unlock) => unlock.unlockedAt)
+      .sort((a, b) => (b.unlockedAt ?? '').localeCompare(a.unlockedAt ?? ''))
+      .slice(0, 5)
+  );
+
+  return (
+    <div className="space-y-8">
+      <div className="card-grid">
+        {(Object.keys(periodLabels) as Array<'daily' | 'weekly' | 'monthly'>).map((period) => (
+          <Card key={period}>
+            <p className="text-sm text-accent/80">{periodLabels[period]}の達成率</p>
+            <h2 className="mt-2 text-3xl font-bold">
+              {completion[period].count}/{completion[period].target}
+            </h2>
+            <Progress value={completion[period].rate * 100} className="mt-4" />
+            <p className="mt-2 text-xs text-white/50">目標: {completion[period].target} タスク</p>
+          </Card>
+        ))}
+      </div>
+      <StreakMeter />
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <h3 className="text-lg font-semibold text-accent">直近の報酬解放</h3>
+          <div className="mt-4 space-y-3">
+            {recent.length === 0 && <p className="text-sm text-white/50">まだ報酬は解放されていません。</p>}
+            {recent.map((unlock) => {
+              const rule = useRewardsStore.getState().rules.find((r) => r.id === unlock.ruleId);
+              if (!rule) return null;
+              return (
+                <div key={unlock.id} className="flex items-center justify-between rounded-xl bg-white/5 px-4 py-3">
+                  <div>
+                    <p className="text-sm font-semibold text-milestone">{rule.rewardDesc}</p>
+                    <p className="text-xs text-white/50">{formatDate(unlock.unlockedAt ?? unlock.periodEnd)}</p>
+                  </div>
+                  <span className="text-xs text-accent/80">{rewardTypeLabel[rule.rewardType]}</span>
+                </div>
+              );
+            })}
+          </div>
+        </Card>
+        <Card>
+          <h3 className="text-lg font-semibold text-accent">フォーカスタグ</h3>
+          <div className="mt-4 grid grid-cols-3 gap-4 text-center text-sm">
+            {['health', 'study', 'work'].map((tag) => {
+              const count = useTasksStore.getState().tasks.filter((task) => task.tags.includes(tag)).length;
+              return (
+                <div key={tag} className="rounded-2xl border border-white/10 bg-white/5 px-3 py-6">
+                  <p className="text-accent/80">{tag.toUpperCase()}</p>
+                  <p className="mt-2 text-2xl font-bold">{count}</p>
+                  <p className="text-xs text-white/50">登録タスク</p>
+                </div>
+              );
+            })}
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,29 @@
+import { Button } from '../components/Button';
+
+export const LoginPage = () => {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[#0B1020]">
+      <div className="w-full max-w-md rounded-3xl border border-white/10 bg-[#121833]/90 p-10 text-center shadow-neon">
+        <h1 className="mb-6 text-3xl font-bold text-accent">Neo Skill Planner</h1>
+        <p className="mb-10 text-sm text-white/70">ゲーム感覚でスキルを育てるタスク管理。ログインはダミーです。</p>
+        <form className="space-y-4" aria-label="ログインフォーム">
+          <input
+            className="focus-ring w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-sm"
+            placeholder="メールアドレス"
+            type="email"
+            aria-label="メールアドレス"
+          />
+          <input
+            className="focus-ring w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-sm"
+            placeholder="パスワード"
+            type="password"
+            aria-label="パスワード"
+          />
+          <Button type="submit" className="w-full">
+            ログイン（ダミー）
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/Rewards.tsx
+++ b/src/pages/Rewards.tsx
@@ -1,0 +1,92 @@
+import { useMemo, useState } from 'react';
+import { Card } from '../components/Card';
+import { Button } from '../components/Button';
+import { Progress } from '../components/Progress';
+import { useRewardsStore } from '../stores/rewards';
+import { useTasksStore } from '../stores/tasks';
+import { formatRange } from '../utils/date';
+import { RewardRule } from '../types';
+
+const periods: Array<'daily' | 'weekly' | 'monthly'> = ['daily', 'weekly', 'monthly'];
+
+const periodLabel: Record<'daily' | 'weekly' | 'monthly', string> = {
+  daily: '日次',
+  weekly: '週次',
+  monthly: '月次'
+};
+
+const rewardTypeLabel: Record<RewardRule['rewardType'], string> = {
+  food: 'フード',
+  goods: 'アイテム',
+  device_right: 'デバイス権利',
+  other: 'その他'
+};
+
+export const RewardsPage = () => {
+  const [selected, setSelected] = useState<'daily' | 'weekly' | 'monthly'>('daily');
+  const rules = useRewardsStore((state) => state.rules.filter((rule) => rule.period === selected));
+  const unlocks = useRewardsStore((state) => state.unlocks.filter((unlock) => unlock.period === selected));
+  const claimUnlock = useRewardsStore((state) => state.claimUnlock);
+  const stats = useTasksStore((state) => state.getPeriodStats());
+
+  const currentUnlockMap = useMemo(() => {
+    const map = new Map<string, typeof unlocks[number]>();
+    unlocks.forEach((unlock) => map.set(unlock.ruleId, unlock));
+    return map;
+  }, [unlocks]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex gap-2">
+        {periods.map((period) => (
+          <button
+            key={period}
+            onClick={() => setSelected(period)}
+            className={`focus-ring rounded-full px-4 py-2 text-sm ${
+              selected === period ? 'bg-accent text-[#0B1020]' : 'bg-white/10 text-white/60'
+            }`}
+            aria-label={`${periodLabel[period]}タブ`}
+          >
+            {periodLabel[period]}
+          </button>
+        ))}
+      </div>
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {rules.map((rule) => {
+          const unlock = currentUnlockMap.get(rule.id);
+          const completion = stats[selected];
+          const achieved = completion.count >= rule.targetCount;
+          const progressValue = rule.targetCount === 0 ? 100 : Math.min(100, (completion.count / rule.targetCount) * 100);
+          return (
+            <Card key={rule.id}>
+              <p className="text-xs uppercase tracking-widest text-accent/70">{rewardTypeLabel[rule.rewardType]}</p>
+              <h3 className="mt-2 text-lg font-semibold text-milestone">{rule.rewardDesc}</h3>
+              <p className="mt-2 text-xs text-white/60">条件: {rule.targetCount}タスク達成</p>
+              <Progress value={progressValue} className="mt-4" />
+              <p className="mt-2 text-xs text-white/50">
+                {completion.count}/{rule.targetCount} 達成 ({Math.round(completion.rate * 100)}%)
+              </p>
+              {unlock && (
+                <p className="mt-3 text-xs text-white/40">期間: {formatRange(unlock.periodStart, unlock.periodEnd)}</p>
+              )}
+              <div className="mt-4 flex items-center justify-between">
+                <span className={`text-xs ${achieved ? 'text-success' : 'text-white/40'}`}>
+                  {achieved ? '解放条件クリア' : '未達'}
+                </span>
+                {unlock && !unlock.claimedAt ? (
+                  <Button onClick={() => claimUnlock(unlock.id)} aria-label="報酬を受け取る">
+                    受け取る
+                  </Button>
+                ) : (
+                  <Button variant="ghost" disabled={!achieved} aria-label="報酬未解放">
+                    {unlock?.claimedAt ? '受取済み' : '解放待ち'}
+                  </Button>
+                )}
+              </div>
+            </Card>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,50 @@
+import { Card } from '../components/Card';
+import { useUIStore } from '../stores/ui';
+import { Switch } from '../components/Switch';
+
+export const SettingsPage = () => {
+  const theme = useUIStore((state) => state.theme);
+  const animationsOn = useUIStore((state) => state.animationsOn);
+  const notificationsOn = useUIStore((state) => state.notificationsOn);
+  const toggleTheme = useUIStore((state) => state.toggleTheme);
+  const setAnimationsOn = useUIStore((state) => state.setAnimationsOn);
+  const setNotificationsOn = useUIStore((state) => state.setNotificationsOn);
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <Card className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="font-semibold text-accent">テーマ</h3>
+            <p className="text-xs text-white/50">ネオンとダークテーマを切り替え</p>
+          </div>
+          <button className="focus-ring rounded-full bg-accent/20 px-4 py-2 text-sm" onClick={toggleTheme} aria-label="テーマ切替">
+            {theme === 'neon' ? 'ネオン' : 'ダーク'}
+          </button>
+        </div>
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="font-semibold text-accent">アニメーション</h3>
+            <p className="text-xs text-white/50">演出を有効にするか選択</p>
+          </div>
+          <Switch
+            checked={animationsOn}
+            onCheckedChange={setAnimationsOn}
+            aria-label="アニメーション切替"
+          />
+        </div>
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="font-semibold text-accent">通知</h3>
+            <p className="text-xs text-white/50">完了や報酬時の通知</p>
+          </div>
+          <Switch
+            checked={notificationsOn}
+            onCheckedChange={setNotificationsOn}
+            aria-label="通知切替"
+          />
+        </div>
+      </Card>
+    </div>
+  );
+};

--- a/src/pages/SkillTree.tsx
+++ b/src/pages/SkillTree.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { Core } from 'cytoscape';
+import { initCytoscape, updateCytoscape } from '../lib/cyto/initCytoscape';
+import { useTasksStore } from '../stores/tasks';
+import { useUIStore } from '../stores/ui';
+import { Drawer } from '../components/Drawer';
+import { Button } from '../components/Button';
+import { Badge } from '../components/Badge';
+import { IconButton } from '../components/IconButton';
+import { Map as MapIcon, Orbit, Sparkles } from 'lucide-react';
+import { TaskStatus } from '../types';
+
+const statusLabel: Record<TaskStatus, string> = {
+  pending: '未着手',
+  in_progress: '進行中',
+  done: '完了',
+  milestone: 'マイルストーン'
+};
+
+export const SkillTreePage = () => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const cyRef = useRef<Core | null>(null);
+  const tasks = useTasksStore((state) => state.tasks);
+  const completeTask = useTasksStore((state) => state.completeTask);
+  const layout = useUIStore((state) => state.treeLayout);
+  const setLayout = useUIStore((state) => state.setTreeLayout);
+
+  const [selected, setSelected] = useState<string | null>(null);
+  const selectedTask = useMemo(() => tasks.find((task) => task.id === selected) ?? null, [tasks, selected]);
+  const [tooltip, setTooltip] = useState<{ visible: boolean; x: number; y: number; label?: string }>({
+    visible: false,
+    x: 0,
+    y: 0
+  });
+  const [contextMenu, setContextMenu] = useState<{ visible: boolean; x: number; y: number; taskId?: string }>({
+    visible: false,
+    x: 0,
+    y: 0
+  });
+
+  const elements = useMemo(() => {
+    const nodes = tasks.map((task) => ({
+      group: 'nodes',
+      data: {
+        id: task.id,
+        label: task.title,
+        status: task.status,
+        difficulty: task.difficulty,
+        tags: task.tags
+      }
+    }));
+
+    const edges = tasks
+      .flatMap((task) => task.dependsOn.map((dep) => ({
+        group: 'edges',
+        data: { id: `${dep}-${task.id}`, source: dep, target: task.id }
+      })))
+      .filter((edge) => tasks.some((task) => task.id === edge.data.source) && tasks.some((task) => task.id === edge.data.target));
+
+    return { nodes, edges };
+  }, [tasks]);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    if (cyRef.current) {
+      cyRef.current.destroy();
+      cyRef.current = null;
+    }
+
+    cyRef.current = initCytoscape(containerRef.current, elements, layout, {
+      onNodeSelect: (data) => {
+        setSelected(data.id);
+      },
+      onNodeHover: ({ visible, position, data }) => {
+        setTooltip({ visible, x: position.x, y: position.y, label: data?.label });
+      },
+      onContextMenu: ({ position, data }) => {
+        setContextMenu({ visible: true, x: position.x, y: position.y, taskId: data.id });
+      }
+    });
+
+    return () => {
+      cyRef.current?.destroy();
+      cyRef.current = null;
+    };
+  }, [elements, layout]);
+
+  useEffect(() => {
+    if (cyRef.current) {
+      updateCytoscape(cyRef.current, layout);
+    }
+  }, [layout]);
+
+  useEffect(() => {
+    const handler = () => setContextMenu((prev) => ({ ...prev, visible: false }));
+    window.addEventListener('click', handler);
+    return () => window.removeEventListener('click', handler);
+  }, []);
+
+  const handleComplete = (taskId: string) => {
+    completeTask(taskId);
+    const cy = cyRef.current;
+    if (!cy) return;
+    const node = cy.getElementById(taskId);
+    node.animate({ style: { 'box-shadow': '0 0 40px #2ECC71' } }, { duration: 150 });
+    setTimeout(() => {
+      node.animate({ style: { 'box-shadow': '' } }, { duration: 150 });
+    }, 200);
+  };
+
+  return (
+    <div className="relative grid gap-6 lg:grid-cols-[minmax(0,1fr)]">
+      <div className="relative h-[600px] rounded-3xl border border-white/10 bg-[#0B1020]/70">
+        <div className="absolute left-4 top-4 z-20 flex gap-2">
+          <IconButton
+            onClick={() => setLayout('cola')}
+            active={layout === 'cola'}
+            aria-label="colaレイアウトに切替"
+          >
+            <MapIcon size={18} />
+          </IconButton>
+          <IconButton
+            onClick={() => setLayout('concentric')}
+            active={layout === 'concentric'}
+            aria-label="同心円レイアウトに切替"
+          >
+            <Orbit size={18} />
+          </IconButton>
+        </div>
+        <div ref={containerRef} className="h-full w-full" aria-label="スキルツリーグラフ" />
+        {tooltip.visible && (
+          <div
+            className="pointer-events-none absolute z-30 rounded-xl border border-accent/40 bg-[#10152B]/90 px-3 py-2 text-xs shadow-neon"
+            style={{ left: tooltip.x + 10, top: tooltip.y + 10 }}
+          >
+            {tooltip.label}
+          </div>
+        )}
+        {contextMenu.visible && contextMenu.taskId && (
+          <div
+            className="absolute z-30 w-48 rounded-2xl border border-white/10 bg-[#10152B] p-3 text-xs text-white/70 shadow-neon"
+            style={{ left: contextMenu.x, top: contextMenu.y }}
+            role="menu"
+          >
+            <button className="focus-ring w-full rounded-xl px-3 py-2 text-left hover:bg-accent/10" aria-label="依存追加">
+              依存追加（仮）
+            </button>
+            <button className="focus-ring mt-2 w-full rounded-xl px-3 py-2 text-left hover:bg-accent/10" aria-label="マイルストーン化">
+              マイルストーン化（仮）
+            </button>
+          </div>
+        )}
+      </div>
+      <Drawer
+        open={Boolean(selectedTask)}
+        onClose={() => setSelected(null)}
+        title={selectedTask?.title ?? '詳細'}
+      >
+        {selectedTask && (
+          <div className="space-y-4 text-sm">
+            <Badge
+              variant={
+                selectedTask.status === 'done'
+                  ? 'done'
+                  : selectedTask.status === 'in_progress'
+                  ? 'progress'
+                  : selectedTask.status === 'milestone'
+                  ? 'milestone'
+                  : 'pending'
+              }
+            >
+              {statusLabel[selectedTask.status]}
+            </Badge>
+            <p>{selectedTask.description}</p>
+            <p>難易度: {'★'.repeat(selectedTask.difficulty)}</p>
+            <div>
+              <p className="text-xs text-white/50">タグ</p>
+              <div className="mt-2 flex flex-wrap gap-2 text-xs">
+                {selectedTask.tags.map((tag) => (
+                  <span key={tag} className="rounded-full bg-white/10 px-3 py-1">
+                    #{tag}
+                  </span>
+                ))}
+              </div>
+            </div>
+            <div>
+              <p className="text-xs text-white/50">依存タスク</p>
+              <ul className="mt-2 space-y-1">
+                {selectedTask.dependsOn.length === 0 && <li className="text-white/40">なし</li>}
+                {selectedTask.dependsOn.map((dep) => {
+                  const task = tasks.find((t) => t.id === dep);
+                  return <li key={dep}>{task?.title ?? dep}</li>;
+                })}
+              </ul>
+            </div>
+            {selectedTask.status !== 'done' && (
+              <Button onClick={() => handleComplete(selectedTask.id)} aria-label="タスク完了">
+                <Sparkles size={18} /> 完了する
+              </Button>
+            )}
+          </div>
+        )}
+      </Drawer>
+    </div>
+  );
+};

--- a/src/pages/Suggestions.tsx
+++ b/src/pages/Suggestions.tsx
@@ -1,0 +1,65 @@
+import { Card } from '../components/Card';
+import { Button } from '../components/Button';
+import { Badge } from '../components/Badge';
+import { useSuggestionsStore } from '../stores/suggestions';
+
+export const SuggestionsPage = () => {
+  const suggestions = useSuggestionsStore((state) => state.suggestions);
+  const approve = useSuggestionsStore((state) => state.approve);
+  const reject = useSuggestionsStore((state) => state.reject);
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      {suggestions.map((suggestion) => (
+        <Card key={suggestion.id} className="flex flex-col gap-4">
+          <div>
+            <h3 className="text-lg font-semibold text-accent">{suggestion.title}</h3>
+            <p className="mt-1 text-xs text-white/60">提案理由: {suggestion.reason}</p>
+          </div>
+          <div className="flex flex-wrap gap-2 text-xs text-white/60">
+            <span>想定時間: {suggestion.estMinutes}分</span>
+            <span>難易度: {'★'.repeat(suggestion.difficulty)}</span>
+            {suggestion.tags.map((tag) => (
+              <span key={tag} className="rounded-full bg-white/10 px-2 py-1">
+                #{tag}
+              </span>
+            ))}
+          </div>
+          <Badge
+            variant={
+              suggestion.decision === 'approved'
+                ? 'done'
+                : suggestion.decision === 'rejected'
+                ? 'pending'
+                : 'progress'
+            }
+          >
+            {suggestion.decision === 'pending'
+              ? '保留中'
+              : suggestion.decision === 'approved'
+              ? '採用'
+              : '却下'}
+          </Badge>
+          <div className="mt-auto flex gap-2">
+            <Button
+              variant="secondary"
+              onClick={() => approve(suggestion.id)}
+              disabled={suggestion.decision === 'approved'}
+              aria-label={`${suggestion.title}を承認`}
+            >
+              承認
+            </Button>
+            <Button
+              variant="ghost"
+              onClick={() => reject(suggestion.id)}
+              disabled={suggestion.decision === 'rejected'}
+              aria-label={`${suggestion.title}を拒否`}
+            >
+              拒否
+            </Button>
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+};

--- a/src/pages/Tasks.tsx
+++ b/src/pages/Tasks.tsx
@@ -1,0 +1,229 @@
+import { useMemo, useState } from 'react';
+import { Card } from '../components/Card';
+import { Button } from '../components/Button';
+import { Modal } from '../components/Modal';
+import { Badge } from '../components/Badge';
+import { useTasksStore } from '../stores/tasks';
+import { TaskStatus } from '../types';
+
+const tags = ['all', 'health', 'study', 'work'] as const;
+
+const statusLabel: Record<TaskStatus, string> = {
+  pending: '未着手',
+  in_progress: '進行中',
+  done: '完了',
+  milestone: 'マイルストーン'
+};
+
+type TagFilter = (typeof tags)[number];
+
+type TaskFormState = {
+  title: string;
+  description: string;
+  difficulty: number;
+  tags: string[];
+};
+
+const emptyForm: TaskFormState = {
+  title: '',
+  description: '',
+  difficulty: 2,
+  tags: []
+};
+
+export const TasksPage = () => {
+  const [search, setSearch] = useState('');
+  const [tag, setTag] = useState<TagFilter>('all');
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState<TaskFormState>(emptyForm);
+  const tasks = useTasksStore((state) => state.tasks);
+  const completeTask = useTasksStore((state) => state.completeTask);
+  const addTask = useTasksStore((state) => state.addTask);
+
+  const filtered = useMemo(() => {
+    return tasks.filter((task) => {
+      const matchesTag = tag === 'all' || task.tags.includes(tag);
+      const matchesSearch = task.title.toLowerCase().includes(search.toLowerCase());
+      return matchesTag && matchesSearch;
+    });
+  }, [tasks, tag, search]);
+
+  const handleSubmit = () => {
+    addTask({
+      title: form.title,
+      description: form.description,
+      difficulty: form.difficulty,
+      tags: form.tags,
+      status: 'in_progress',
+      dependsOn: []
+    });
+    setForm(emptyForm);
+    setOpen(false);
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card className="flex flex-wrap items-center gap-4">
+        <input
+          type="search"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="タスク検索"
+          aria-label="タスク検索"
+          className="focus-ring w-full max-w-xs rounded-2xl border border-white/10 bg-black/30 px-4 py-2 text-sm"
+        />
+        <div className="flex gap-2 text-xs">
+          {tags.map((value) => (
+            <button
+              key={value}
+              onClick={() => setTag(value)}
+              className={`focus-ring rounded-full px-4 py-1 transition ${
+                tag === value ? 'bg-accent text-[#0B1020]' : 'bg-white/10 text-white/60 hover:bg-white/20'
+              }`}
+              aria-label={`${value}タグでフィルタ`}
+            >
+              #{value}
+            </button>
+          ))}
+        </div>
+        <Button onClick={() => setOpen(true)} aria-label="新規タスク登録">
+          新規登録
+        </Button>
+      </Card>
+      <div className="overflow-x-auto rounded-3xl border border-white/10">
+        <table className="min-w-full divide-y divide-white/5 text-sm">
+          <thead>
+            <tr className="bg-white/5">
+              <th className="table-header px-4 py-3">タスク</th>
+              <th className="table-header px-4 py-3">タグ</th>
+              <th className="table-header px-4 py-3">難易度</th>
+              <th className="table-header px-4 py-3">状態</th>
+              <th className="table-header px-4 py-3 text-right">操作</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-white/5">
+            {filtered.map((task) => (
+              <tr key={task.id} className="hover:bg-white/5">
+                <td className="px-4 py-4">
+                  <p className="font-semibold text-white/90">{task.title}</p>
+                  <p className="text-xs text-white/50">{task.description}</p>
+                </td>
+                <td className="px-4 py-4">
+                  <div className="flex flex-wrap gap-2 text-xs">
+                    {task.tags.map((tagName) => (
+                      <span key={tagName} className="rounded-full bg-white/10 px-3 py-1">
+                        #{tagName}
+                      </span>
+                    ))}
+                  </div>
+                </td>
+                <td className="px-4 py-4">{'★'.repeat(task.difficulty)}</td>
+                <td className="px-4 py-4">
+                  <Badge
+                    variant={
+                      task.status === 'done'
+                        ? 'done'
+                        : task.status === 'in_progress'
+                        ? 'progress'
+                        : task.status === 'milestone'
+                        ? 'milestone'
+                        : 'pending'
+                    }
+                  >
+                    {statusLabel[task.status]}
+                  </Badge>
+                </td>
+                <td className="px-4 py-4 text-right">
+                  {task.status !== 'done' ? (
+                    <Button
+                      variant="secondary"
+                      onClick={() => completeTask(task.id)}
+                      aria-label={`${task.title}を完了`}
+                    >
+                      完了
+                    </Button>
+                  ) : (
+                    <span className="text-xs text-success">完了済み</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <Modal
+        open={open}
+        onClose={() => setOpen(false)}
+        title="新規タスク"
+        footer={
+          <>
+            <Button variant="ghost" onClick={() => setOpen(false)}>
+              キャンセル
+            </Button>
+            <Button onClick={handleSubmit} disabled={!form.title}>
+              追加
+            </Button>
+          </>
+        }
+      >
+        <div className="space-y-4">
+          <label className="block text-xs text-white/60">
+            タイトル
+            <input
+              value={form.title}
+              onChange={(event) => setForm((prev) => ({ ...prev, title: event.target.value }))}
+              className="focus-ring mt-1 w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-2 text-sm"
+              aria-label="タスクタイトル"
+            />
+          </label>
+          <label className="block text-xs text-white/60">
+            詳細
+            <textarea
+              value={form.description}
+              onChange={(event) => setForm((prev) => ({ ...prev, description: event.target.value }))}
+              className="focus-ring mt-1 w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-2 text-sm"
+              rows={3}
+              aria-label="タスク詳細"
+            />
+          </label>
+          <label className="block text-xs text-white/60">
+            難易度
+            <input
+              type="range"
+              min={1}
+              max={5}
+              value={form.difficulty}
+              onChange={(event) => setForm((prev) => ({ ...prev, difficulty: Number(event.target.value) }))}
+              className="mt-2 w-full"
+              aria-label="難易度"
+            />
+          </label>
+          <div>
+            <p className="text-xs text-white/60">タグ</p>
+            <div className="mt-2 flex flex-wrap gap-2 text-xs">
+              {tags.filter((tagValue) => tagValue !== 'all').map((tagValue) => (
+                <button
+                  key={tagValue}
+                  onClick={() =>
+                    setForm((prev) => ({
+                      ...prev,
+                      tags: prev.tags.includes(tagValue)
+                        ? prev.tags.filter((t) => t !== tagValue)
+                        : [...prev.tags, tagValue]
+                    }))
+                  }
+                  className={`focus-ring rounded-full px-3 py-1 ${
+                    form.tags.includes(tagValue) ? 'bg-accent text-[#0B1020]' : 'bg-white/10 text-white/60'
+                  }`}
+                  aria-label={`${tagValue}タグを切替`}
+                >
+                  #{tagValue}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+};

--- a/src/providers/UIProvider.tsx
+++ b/src/providers/UIProvider.tsx
@@ -1,0 +1,23 @@
+import { ReactNode, useEffect } from 'react';
+import { useUIStore } from '../stores/ui';
+
+interface Props {
+  children: ReactNode;
+}
+
+export const UIProvider = ({ children }: Props) => {
+  const theme = useUIStore((state) => state.theme);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.remove('neon');
+      root.classList.add('dark');
+    } else {
+      root.classList.add('neon');
+      root.classList.add('dark');
+    }
+  }, [theme]);
+
+  return <>{children}</>;
+};

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,0 +1,28 @@
+import { createBrowserRouter } from 'react-router-dom';
+import { AppLayout } from './App';
+import { LoginPage } from './pages/Login';
+import { DashboardPage } from './pages/Dashboard';
+import { SkillTreePage } from './pages/SkillTree';
+import { TasksPage } from './pages/Tasks';
+import { RewardsPage } from './pages/Rewards';
+import { SuggestionsPage } from './pages/Suggestions';
+import { SettingsPage } from './pages/Settings';
+
+export const router = createBrowserRouter([
+  {
+    path: '/login',
+    element: <LoginPage />
+  },
+  {
+    path: '/',
+    element: <AppLayout />,
+    children: [
+      { index: true, element: <DashboardPage /> },
+      { path: 'tree', element: <SkillTreePage /> },
+      { path: 'tasks', element: <TasksPage /> },
+      { path: 'rewards', element: <RewardsPage /> },
+      { path: 'suggestions', element: <SuggestionsPage /> },
+      { path: 'settings', element: <SettingsPage /> }
+    ]
+  }
+]);

--- a/src/stores/rewards.ts
+++ b/src/stores/rewards.ts
@@ -1,0 +1,70 @@
+import { create } from 'zustand';
+import { seedRewardRules, seedRewardUnlocks } from '../data/seed';
+import { RewardRule, RewardUnlock } from '../types';
+
+type Period = 'daily' | 'weekly' | 'monthly';
+
+interface RewardsState {
+  rules: RewardRule[];
+  unlocks: RewardUnlock[];
+  pendingUnlock: RewardUnlock | null;
+  evaluateRewards: (period: Period, completedCount: number, startIso: string, endIso: string) => void;
+  claimUnlock: (unlockId: string) => void;
+  dismissPending: () => void;
+}
+
+export const useRewardsStore = create<RewardsState>((set, get) => ({
+  rules: seedRewardRules,
+  unlocks: seedRewardUnlocks,
+  pendingUnlock: null,
+  evaluateRewards: (period, completedCount, startIso, endIso) => {
+    const now = new Date().toISOString();
+    const state = get();
+    const rules = state.rules.filter((rule) => rule.period === period);
+
+    set((current) => {
+      let pendingUnlock: RewardUnlock | null = current.pendingUnlock;
+      const updatedUnlocks = current.unlocks.map((unlock) => {
+        if (unlock.period === period && unlock.periodStart === startIso && unlock.periodEnd === endIso) {
+          return { ...unlock, completedCount };
+        }
+        return unlock;
+      });
+
+      const ensureUnlock = (rule: RewardRule) => {
+        let unlock = updatedUnlocks.find((item) => item.ruleId === rule.id && item.periodStart === startIso);
+        if (!unlock) {
+          unlock = {
+            id: `${rule.id}-${startIso}`,
+            ruleId: rule.id,
+            period,
+            periodStart: startIso,
+            periodEnd: endIso,
+            completedCount
+          };
+          updatedUnlocks.push(unlock);
+        } else if (unlock.completedCount !== completedCount) {
+          unlock.completedCount = completedCount;
+        }
+
+        if (completedCount >= rule.targetCount && !unlock.unlockedAt) {
+          unlock.unlockedAt = now;
+          pendingUnlock = unlock;
+        }
+      };
+
+      rules.forEach(ensureUnlock);
+
+      return { unlocks: updatedUnlocks, pendingUnlock };
+    });
+  },
+  claimUnlock: (unlockId) => {
+    set((state) => ({
+      unlocks: state.unlocks.map((unlock) =>
+        unlock.id === unlockId ? { ...unlock, claimedAt: new Date().toISOString() } : unlock
+      ),
+      pendingUnlock: state.pendingUnlock?.id === unlockId ? null : state.pendingUnlock
+    }));
+  },
+  dismissPending: () => set({ pendingUnlock: null })
+}));

--- a/src/stores/suggestions.ts
+++ b/src/stores/suggestions.ts
@@ -1,0 +1,51 @@
+import { create } from 'zustand';
+import { seedSuggestions } from '../data/seed';
+import { Suggestion } from '../types';
+import { useTasksStore, NewTaskInput } from './tasks';
+
+interface SuggestionsState {
+  suggestions: Suggestion[];
+  approve: (id: string) => void;
+  reject: (id: string) => void;
+}
+
+export const useSuggestionsStore = create<SuggestionsState>((set) => ({
+  suggestions: seedSuggestions,
+  approve: (id) => {
+    set((state) => {
+      const suggestion = state.suggestions.find((item) => item.id === id);
+      if (!suggestion || suggestion.decision === 'approved') return state;
+
+      const tasksState = useTasksStore.getState();
+      const dependsOn = tasksState.tasks
+        .filter((task) => suggestion.tags.some((tag) => task.tags.includes(tag)))
+        .slice(0, 2)
+        .map((task) => task.id);
+
+      const newTask: NewTaskInput = {
+        id: `task-from-${id}`,
+        title: suggestion.title,
+        description: suggestion.reason,
+        difficulty: suggestion.difficulty,
+        tags: suggestion.tags,
+        dependsOn,
+        status: dependsOn.length === 0 ? 'in_progress' : 'pending'
+      };
+
+      tasksState.addTask(newTask);
+
+      return {
+        suggestions: state.suggestions.map((item) =>
+          item.id === id ? { ...item, decision: 'approved' } : item
+        )
+      };
+    });
+  },
+  reject: (id) => {
+    set((state) => ({
+      suggestions: state.suggestions.map((item) =>
+        item.id === id ? { ...item, decision: 'rejected' } : item
+      )
+    }));
+  }
+}));

--- a/src/stores/tasks.ts
+++ b/src/stores/tasks.ts
@@ -1,0 +1,166 @@
+import { create } from 'zustand';
+import { seedStreak, seedTasks } from '../data/seed';
+import { Streak, Task, TaskStatus } from '../types';
+import { startOfDay } from '../utils/date';
+import { getPeriodWindow } from '../utils/reward';
+import { useRewardsStore } from './rewards';
+
+interface CompletionLog {
+  taskId: string;
+  completedAt: string;
+}
+
+type Period = 'daily' | 'weekly' | 'monthly';
+
+export interface NewTaskInput {
+  id?: string;
+  title: string;
+  description: string;
+  status: TaskStatus;
+  difficulty: number;
+  tags: string[];
+  dependsOn?: string[];
+  completedAt?: string;
+}
+
+interface TasksState {
+  tasks: Task[];
+  streak: Streak;
+  completionLog: CompletionLog[];
+  completeTask: (taskId: string) => void;
+  addTask: (task: NewTaskInput) => void;
+  getCompletionCounts: () => Record<Period, { count: number; start: string; end: string }>;
+  getPeriodStats: () => Record<Period, { count: number; target: number; rate: number }>;
+}
+
+const ensureDependenciesReady = (tasks: Task[], target: Task) => {
+  return target.dependsOn.every((id) => {
+    const task = tasks.find((t) => t.id === id);
+    return task && (task.status === 'done' || task.status === 'milestone');
+  });
+};
+
+const updateStreak = (streak: Streak): Streak => {
+  const today = startOfDay(new Date());
+  if (!streak.lastIncrementDate) {
+    return { currentDays: 1, longestDays: 1, lastIncrementDate: today.toISOString() };
+  }
+  const last = startOfDay(new Date(streak.lastIncrementDate));
+  const diff = Math.floor((today.getTime() - last.getTime()) / (1000 * 60 * 60 * 24));
+  if (diff === 0) {
+    return streak;
+  }
+  if (diff === 1) {
+    const currentDays = streak.currentDays + 1;
+    return {
+      currentDays,
+      longestDays: Math.max(streak.longestDays, currentDays),
+      lastIncrementDate: today.toISOString()
+    };
+  }
+  return {
+    currentDays: 1,
+    longestDays: Math.max(streak.longestDays, 1),
+    lastIncrementDate: today.toISOString()
+  };
+};
+
+export const useTasksStore = create<TasksState>((set, get) => ({
+  tasks: seedTasks,
+  streak: seedStreak,
+  completionLog: [],
+  completeTask: (taskId) => {
+    const state = get();
+    const task = state.tasks.find((t) => t.id === taskId);
+    if (!task || task.status === 'done') return;
+    if (!ensureDependenciesReady(state.tasks, task)) return;
+
+    const now = new Date().toISOString();
+
+    const updatedTasks = state.tasks.map((t) =>
+      t.id === taskId
+        ? { ...t, status: 'done', completedAt: now }
+        : t
+    );
+
+    const streak = updateStreak(state.streak);
+
+    set({
+      tasks: updatedTasks.map((t) => {
+        if (t.status === 'pending' && ensureDependenciesReady(updatedTasks, t)) {
+          return { ...t, status: 'in_progress' };
+        }
+        return t;
+      }),
+      streak,
+      completionLog: [...state.completionLog, { taskId, completedAt: now }]
+    });
+
+    const counts = get().getCompletionCounts();
+    const rewardStore = useRewardsStore.getState();
+    (['daily', 'weekly', 'monthly'] as Period[]).forEach((period) => {
+      rewardStore.evaluateRewards(period, counts[period].count, counts[period].start, counts[period].end);
+    });
+  },
+  addTask: (taskInput) => {
+    const id = taskInput.id ?? crypto.randomUUID();
+    const dependencies = taskInput.dependsOn ?? [];
+    const initialStatus = dependencies.length === 0 && taskInput.status === 'pending' ? 'in_progress' : taskInput.status;
+    const newTask: Task = {
+      id,
+      title: taskInput.title,
+      description: taskInput.description,
+      difficulty: taskInput.difficulty,
+      tags: taskInput.tags,
+      dependsOn: dependencies,
+      status: initialStatus,
+      completedAt: taskInput.completedAt
+    };
+
+    set((state) => {
+      const base = [...state.tasks, newTask];
+      const nextTasks = base.map((task) => {
+        if (task.status === 'pending' && ensureDependenciesReady(base, task)) {
+          return { ...task, status: 'in_progress' };
+        }
+        return task;
+      });
+      return { tasks: nextTasks };
+    });
+  },
+  getCompletionCounts: () => {
+    const result: Record<Period, { count: number; start: string; end: string }> = {
+      daily: { count: 0, start: '', end: '' },
+      weekly: { count: 0, start: '', end: '' },
+      monthly: { count: 0, start: '', end: '' }
+    };
+
+    const now = new Date();
+    (['daily', 'weekly', 'monthly'] as Period[]).forEach((period) => {
+      const { start, end } = getPeriodWindow(period, now);
+      const count = get().tasks.filter((task) => {
+        if (!task.completedAt) return false;
+        const completed = new Date(task.completedAt);
+        return completed >= start && completed <= end;
+      }).length;
+      result[period] = { count, start: start.toISOString(), end: end.toISOString() };
+    });
+
+    return result;
+  },
+  getPeriodStats: () => {
+    const counts = get().getCompletionCounts();
+    const rules = useRewardsStore.getState().rules;
+    const stats = {} as Record<Period, { count: number; target: number; rate: number }>;
+    (['daily', 'weekly', 'monthly'] as Period[]).forEach((period) => {
+      const target = rules.filter((rule) => rule.period === period).map((rule) => rule.targetCount)[0] ?? 5;
+      const count = counts[period].count;
+      stats[period] = {
+        count,
+        target,
+        rate: target === 0 ? 0 : Math.min(1, count / target)
+      };
+    });
+    return stats;
+  }
+}));

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand';
+
+type Theme = 'dark' | 'neon';
+
+type TreeLayout = 'cola' | 'concentric';
+
+interface UIState {
+  theme: Theme;
+  animationsOn: boolean;
+  notificationsOn: boolean;
+  treeLayout: TreeLayout;
+  toggleTheme: () => void;
+  setAnimationsOn: (value: boolean) => void;
+  setNotificationsOn: (value: boolean) => void;
+  setTreeLayout: (layout: TreeLayout) => void;
+}
+
+export const useUIStore = create<UIState>((set) => ({
+  theme: 'neon',
+  animationsOn: true,
+  notificationsOn: true,
+  treeLayout: 'cola',
+  toggleTheme: () =>
+    set((state) => ({
+      theme: state.theme === 'dark' ? 'neon' : 'dark'
+    })),
+  setAnimationsOn: (value) => set({ animationsOn: value }),
+  setNotificationsOn: (value) => set({ notificationsOn: value }),
+  setTreeLayout: (layout) => set({ treeLayout: layout })
+}));

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,0 +1,77 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  @apply bg-[#0B1020] text-[#E6EDF8] font-sans;
+}
+
+a {
+  @apply text-accent;
+}
+
+.neon-theme {
+  background: radial-gradient(circle at top, rgba(61, 178, 255, 0.08), transparent 60%), #0B1020;
+}
+
+.focus-ring {
+  @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background;
+}
+
+.neon-card {
+  @apply bg-surface/90 border border-white/10 rounded-2xl shadow-lg shadow-accent/30 backdrop-blur;
+}
+
+.neon-border {
+  box-shadow: 0 0 0 1px rgba(61, 178, 255, 0.35);
+}
+
+.scrollbar-thin {
+  scrollbar-width: thin;
+}
+
+.scrollbar-thin::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+.scrollbar-thin::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.scrollbar-thin::-webkit-scrollbar-thumb {
+  background: rgba(61, 178, 255, 0.65);
+  border-radius: 999px;
+}
+
+.card-grid {
+  @apply grid gap-6 md:grid-cols-3;
+}
+
+.table-header {
+  @apply text-left text-xs uppercase tracking-wider text-accent/80;
+}
+
+.badge {
+  @apply inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide;
+}
+
+.badge-pending {
+  @apply badge bg-slate/30 text-slate;
+}
+
+.badge-progress {
+  @apply badge bg-accent/20 text-accent;
+}
+
+.badge-done {
+  @apply badge bg-success/20 text-success;
+}
+
+.badge-milestone {
+  @apply badge bg-milestone/20 text-milestone;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,48 @@
+export type TaskStatus = 'pending' | 'in_progress' | 'done' | 'milestone';
+
+export interface Task {
+  id: string;
+  title: string;
+  description: string;
+  status: TaskStatus;
+  difficulty: number;
+  tags: string[];
+  dependsOn: string[];
+  completedAt?: string;
+}
+
+export interface RewardRule {
+  id: string;
+  period: 'daily' | 'weekly' | 'monthly';
+  targetCount: number;
+  rewardType: 'food' | 'goods' | 'device_right' | 'other';
+  rewardDesc: string;
+  autoClaimDefault: boolean;
+}
+
+export interface RewardUnlock {
+  id: string;
+  ruleId: string;
+  period: 'daily' | 'weekly' | 'monthly';
+  periodStart: string;
+  periodEnd: string;
+  unlockedAt?: string;
+  completedCount: number;
+  claimedAt?: string;
+}
+
+export interface Streak {
+  currentDays: number;
+  longestDays: number;
+  lastIncrementDate?: string;
+}
+
+export interface Suggestion {
+  id: string;
+  title: string;
+  reason: string;
+  estMinutes: number;
+  difficulty: number;
+  tags: string[];
+  decision: 'pending' | 'approved' | 'rejected';
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,59 @@
+const formatter = new Intl.DateTimeFormat('ja-JP', {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit'
+});
+
+export const startOfDay = (date: Date) => {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d;
+};
+
+export const endOfDay = (date: Date) => {
+  const d = new Date(date);
+  d.setHours(23, 59, 59, 999);
+  return d;
+};
+
+export const startOfWeek = (date: Date) => {
+  const d = startOfDay(date);
+  const day = d.getDay();
+  const diff = (day + 6) % 7;
+  d.setDate(d.getDate() - diff);
+  return d;
+};
+
+export const endOfWeek = (date: Date) => {
+  const d = startOfWeek(date);
+  d.setDate(d.getDate() + 6);
+  d.setHours(23, 59, 59, 999);
+  return d;
+};
+
+export const startOfMonth = (date: Date) => {
+  const d = startOfDay(date);
+  d.setDate(1);
+  return d;
+};
+
+export const endOfMonth = (date: Date) => {
+  const d = startOfMonth(date);
+  d.setMonth(d.getMonth() + 1);
+  d.setDate(0);
+  d.setHours(23, 59, 59, 999);
+  return d;
+};
+
+export const isWithinRange = (date: Date, start: Date, end: Date) => {
+  return date >= start && date <= end;
+};
+
+export const formatDate = (value?: string) => {
+  if (!value) return '-';
+  return formatter.format(new Date(value));
+};
+
+export const formatRange = (start: string, end: string) => {
+  return `${formatter.format(new Date(start))} - ${formatter.format(new Date(end))}`;
+};

--- a/src/utils/reward.ts
+++ b/src/utils/reward.ts
@@ -1,0 +1,19 @@
+import { endOfDay, endOfMonth, endOfWeek, startOfDay, startOfMonth, startOfWeek } from './date';
+
+export const getPeriodWindow = (
+  period: 'daily' | 'weekly' | 'monthly',
+  baseDate: Date
+): { start: Date; end: Date } => {
+  if (period === 'daily') {
+    return { start: startOfDay(baseDate), end: endOfDay(baseDate) };
+  }
+  if (period === 'weekly') {
+    return { start: startOfWeek(baseDate), end: endOfWeek(baseDate) };
+  }
+  return { start: startOfMonth(baseDate), end: endOfMonth(baseDate) };
+};
+
+export const periodKey = (period: 'daily' | 'weekly' | 'monthly', date: Date) => {
+  const window = getPeriodWindow(period, date);
+  return `${period}-${window.start.toISOString().split('T')[0]}`;
+};

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,22 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{ts,tsx,jsx,js}'],
+  theme: {
+    extend: {
+      colors: {
+        background: '#0B1020',
+        accent: '#3DB2FF',
+        success: '#2ECC71',
+        milestone: '#F1C40F',
+        surface: '#121833',
+        slate: '#5A5F73'
+      },
+      boxShadow: {
+        neon: '0 0 20px rgba(61, 178, 255, 0.45)',
+        inset: 'inset 0 0 20px rgba(11, 16, 32, 0.95)'
+      }
+    }
+  },
+  plugins: []
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: true
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React + Tailwind application with neon styling, routing, and reusable UI primitives
- implement Zustand stores with seeded data to drive tasks, rewards, suggestions, and UI preferences alongside utility helpers
- build dashboard, skill tree, tasks, rewards, suggestions, and settings pages including Cytoscape visualization, modals, and animations

## Testing
- npm install *(fails: registry returned 403 for scoped packages)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd88156108329bedb0683823a744f