### PR TITLE
Add master maintenance mock app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,76 @@
-# mock-private
-private mockup
+# マスタメンテ Web アプリ (モック実装)
+
+本リポジトリは Vanilla JS + Express で構成したマスタメンテ Web アプリのモック実装です。`npm install` → `npm run dev` でフロントエンドとモック API を同時起動し、ブラウザから CRUD を確認できます。
+
+## 🏗 プロジェクト構成
+
+```
+project-root/
+  README.md
+  package.json
+  frontend/
+    index.html
+    style.css
+    app.js
+    config.js
+  mock-api/
+    package.json
+    server.js
+    schema.md
+    seed.js
+    utils/
+      paging.js
+      errors.js
+```
+
+* フロントエンド: `frontend/` 配下の静的ファイル（ES Modules）。
+* モック API: `mock-api/server.js` が Express ベースで起動します。
+* ルート `package.json` は `concurrently` を使用してフロントと API を同時起動します。
+
+## 🚀 起動方法
+
+```bash
+npm install
+npm run dev
+```
+
+- フロント: http://127.0.0.1:3000
+- API: http://127.0.0.1:3001
+
+起動後、ブラウザで http://127.0.0.1:3000 を開くと一覧と編集フォームが表示されます。
+
+## 🔌 API ベース URL
+
+`frontend/config.js` の `window.APP_CONFIG.apiBase` を書き換えることで、API Gateway など任意のエンドポイントへ差し替え可能です。認証を追加する場合は `frontend/app.js` の `apiFetch` 関数でヘッダを拡張してください。
+
+## 📜 モック API 仕様
+
+詳細は `mock-api/schema.md` を参照してください。エンドポイントは本番 API を想定した DynamoDB 互換のスキーマ・レスポンス形に沿っています。
+
+## 🔄 データ初期化
+
+`mock-api/seed.js` で 10 件以上のマスタデータを定義しており、モック API 起動時に読み込まれます。永続化は行われません。
+
+## ✅ 動作確認チェックリスト
+
+- [ ] `npm install` → `npm run dev` でフロント(3000)と API(3001) が起動する
+- [ ] 初期表示でデータが表に表示され、ページングが動作する
+- [ ] 検索が `name`/`code` の部分一致でフィルタされる
+- [ ] 新規作成で `version = 1` のレコードが作成されフォームに反映される
+- [ ] 既存レコード更新で `version` が +1 される
+- [ ] 競合（409）時にトーストで警告が表示される
+- [ ] 削除で一覧から対象が消える
+- [ ] ネットワーク/サーバエラー時に赤トーストが表示される
+
+## 🔄 将来の AWS 差し替え
+
+- `frontend/config.js` の `apiBase` を API Gateway の URL に変更するだけで接続先を切り替えられます。
+- DynamoDB の `LastEvaluatedKey` は `mock-api/utils/paging.js` と同等の `nextToken` 形式に変換してください。
+- 認証が必要な場合は `apiFetch` で `x-api-key` や `Authorization` ヘッダを追加して対応可能です。
+
+## 🧹 開発メモ
+
+- すべて UTF-8。日本語コメント可。
+- フロントはビルド不要の Vanilla JS、CSS でシンプルな UI を実装しています。
+- API は CORS 対応かつ 150–400ms の人工レイテンシを入れて動作検証しやすくしています。
+

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,356 @@
+const { apiBase } = window.APP_CONFIG || {};
+
+const state = {
+  query: "",
+  limit: 20,
+  currentToken: null,
+  nextToken: null,
+  prevTokens: [],
+  items: [],
+  selectedId: null
+};
+
+const elements = {
+  searchForm: document.getElementById("search-form"),
+  searchInput: document.getElementById("search-input"),
+  clearSearch: document.getElementById("clear-search"),
+  itemsBody: document.getElementById("items-body"),
+  prevPage: document.getElementById("prev-page"),
+  nextPage: document.getElementById("next-page"),
+  itemForm: document.getElementById("item-form"),
+  itemId: document.getElementById("item-id"),
+  itemVersion: document.getElementById("item-version"),
+  itemCode: document.getElementById("item-code"),
+  itemName: document.getElementById("item-name"),
+  itemDescription: document.getElementById("item-description"),
+  itemEnabled: document.getElementById("item-enabled"),
+  resetButton: document.getElementById("reset-button"),
+  deleteButton: document.getElementById("delete-button"),
+  toastContainer: document.getElementById("toast-container"),
+  saveButton: document.getElementById("save-button")
+};
+
+function showToast(message, type = "info") {
+  const toast = document.createElement("div");
+  toast.className = `toast ${type}`;
+  toast.setAttribute("role", "status");
+  toast.textContent = message;
+  elements.toastContainer.appendChild(toast);
+  setTimeout(() => {
+    toast.remove();
+  }, 4200);
+}
+
+async function apiFetch(path, options = {}) {
+  const url = new URL(path, apiBase);
+  const opts = { ...options };
+  opts.headers = {
+    "Accept": "application/json",
+    ...(options.body ? { "Content-Type": "application/json" } : {}),
+    ...(options.headers || {})
+  };
+  const response = await fetch(url, opts);
+  if (!response.ok) {
+    let errorPayload;
+    try {
+      errorPayload = await response.json();
+    } catch (err) {
+      errorPayload = { message: response.statusText };
+    }
+    const error = new Error(errorPayload.message || "Request failed");
+    error.status = response.status;
+    error.payload = errorPayload;
+    throw error;
+  }
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    return text;
+  }
+}
+
+function formatDate(value) {
+  if (!value) return "-";
+  try {
+    const date = new Date(value);
+    return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+  } catch (err) {
+    return value;
+  }
+}
+
+function renderItems(items) {
+  elements.itemsBody.innerHTML = "";
+  if (!items.length) {
+    const row = document.createElement("tr");
+    const cell = document.createElement("td");
+    cell.colSpan = 6;
+    cell.textContent = "該当するデータがありません";
+    cell.style.textAlign = "center";
+    row.appendChild(cell);
+    elements.itemsBody.appendChild(row);
+    return;
+  }
+
+  for (const item of items) {
+    const row = document.createElement("tr");
+    if (item.id === state.selectedId) {
+      row.classList.add("selected");
+    }
+
+    const idCell = document.createElement("td");
+    idCell.className = "cell-id";
+    idCell.title = item.id;
+    idCell.textContent = item.id;
+
+    const codeCell = document.createElement("td");
+    codeCell.textContent = item.code || "-";
+
+    const nameCell = document.createElement("td");
+    nameCell.textContent = item.name || "-";
+
+    const enabledCell = document.createElement("td");
+    enabledCell.appendChild(createEnabledBadge(item.enabled));
+
+    const updatedCell = document.createElement("td");
+    updatedCell.textContent = formatDate(item.updatedAt);
+
+    const actionsCell = document.createElement("td");
+    actionsCell.className = "actions";
+    const editBtn = document.createElement("button");
+    editBtn.type = "button";
+    editBtn.textContent = "編集";
+    editBtn.addEventListener("click", () => {
+      loadItemDetail(item.id);
+    });
+    actionsCell.appendChild(editBtn);
+
+    row.append(idCell, codeCell, nameCell, enabledCell, updatedCell, actionsCell);
+    elements.itemsBody.appendChild(row);
+  }
+}
+
+function createEnabledBadge(enabled) {
+  const span = document.createElement("span");
+  span.className = enabled ? "badge" : "badge disabled";
+  span.textContent = enabled ? "有効" : "無効";
+  return span;
+}
+
+function updatePagingControls() {
+  elements.prevPage.disabled = state.prevTokens.length === 0;
+  elements.nextPage.disabled = !state.nextToken;
+}
+
+async function loadItems({ action = "reset" } = {}) {
+  let nextTokenParam = null;
+  let newCurrentToken = state.currentToken;
+  let newPrevTokens = [...state.prevTokens];
+
+  if (action === "reset") {
+    newPrevTokens = [];
+    newCurrentToken = null;
+    nextTokenParam = null;
+  } else if (action === "next") {
+    if (!state.nextToken) {
+      return;
+    }
+    newPrevTokens.push(state.currentToken);
+    newCurrentToken = state.nextToken;
+    nextTokenParam = state.nextToken;
+  } else if (action === "prev") {
+    if (state.prevTokens.length === 0) {
+      return;
+    }
+    const targetToken = newPrevTokens.pop();
+    newCurrentToken = targetToken ?? null;
+    nextTokenParam = newCurrentToken;
+  } else if (action === "refresh") {
+    nextTokenParam = state.currentToken;
+  }
+
+  try {
+    const params = new URLSearchParams();
+    if (state.query) params.set("q", state.query);
+    if (state.limit) params.set("limit", state.limit);
+    if (nextTokenParam) params.set("nextToken", nextTokenParam);
+
+    const data = await apiFetch(`/items?${params.toString()}`);
+    state.items = data.items || [];
+    state.nextToken = data.nextToken || null;
+    state.currentToken = newCurrentToken;
+    state.prevTokens = newPrevTokens;
+    renderItems(state.items);
+    updatePagingControls();
+  } catch (error) {
+    console.error(error);
+    showToast(error.message || "一覧の取得に失敗しました", "error");
+  }
+}
+
+async function loadItemDetail(id) {
+  try {
+    const item = await apiFetch(`/items/${id}`);
+    populateForm(item);
+    state.selectedId = item.id;
+    renderItems(state.items);
+  } catch (error) {
+    if (error.status === 404) {
+      showToast("対象のデータが見つかりません", "error");
+    } else {
+      showToast("詳細の取得に失敗しました", "error");
+    }
+  }
+}
+
+function populateForm(item) {
+  if (!item) {
+    elements.itemId.value = "";
+    elements.itemVersion.value = "";
+    elements.itemCode.value = "";
+    elements.itemName.value = "";
+    elements.itemDescription.value = "";
+    elements.itemEnabled.checked = true;
+    state.selectedId = null;
+    renderItems(state.items);
+    return;
+  }
+  elements.itemId.value = item.id || "";
+  elements.itemVersion.value = item.version ?? "";
+  elements.itemCode.value = item.code || "";
+  elements.itemName.value = item.name || "";
+  elements.itemDescription.value = item.description || "";
+  elements.itemEnabled.checked = Boolean(item.enabled);
+  state.selectedId = item.id;
+}
+
+function validateForm(payload) {
+  const errors = [];
+  if (!payload.code) {
+    errors.push("コードは必須です");
+  } else if (payload.code.length > 64) {
+    errors.push("コードは64文字以内で入力してください");
+  }
+  if (!payload.name) {
+    errors.push("名前は必須です");
+  } else if (payload.name.length > 128) {
+    errors.push("名前は128文字以内で入力してください");
+  }
+  if (payload.description && payload.description.length > 512) {
+    errors.push("説明は512文字以内で入力してください");
+  }
+  return errors;
+}
+
+elements.searchForm.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const query = elements.searchInput.value.trim();
+  state.query = query;
+  loadItems({ action: "reset" });
+});
+
+elements.clearSearch.addEventListener("click", () => {
+  elements.searchInput.value = "";
+  state.query = "";
+  loadItems({ action: "reset" });
+});
+
+elements.prevPage.addEventListener("click", () => {
+  if (!elements.prevPage.disabled) {
+    loadItems({ action: "prev" });
+  }
+});
+
+elements.nextPage.addEventListener("click", () => {
+  if (!elements.nextPage.disabled) {
+    loadItems({ action: "next" });
+  }
+});
+
+elements.resetButton.addEventListener("click", () => {
+  populateForm(null);
+});
+
+elements.deleteButton.addEventListener("click", async () => {
+  const id = elements.itemId.value;
+  if (!id) {
+    showToast("削除対象を選択してください", "info");
+    return;
+  }
+  if (!confirm("このレコードを削除しますか？")) {
+    return;
+  }
+  const version = elements.itemVersion.value;
+  try {
+    const query = version ? `?version=${encodeURIComponent(version)}` : "";
+    await apiFetch(`/items/${id}${query}`, { method: "DELETE" });
+    showToast("削除しました", "success");
+    populateForm(null);
+    await loadItems({ action: "refresh" });
+  } catch (error) {
+    if (error.status === 409) {
+      showToast("他のユーザーにより更新されました。最新を読み込んでください", "error");
+    } else if (error.status === 404) {
+      showToast("対象が見つかりません", "error");
+    } else {
+      showToast("削除に失敗しました", "error");
+    }
+  }
+});
+
+elements.itemForm.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const formData = new FormData(elements.itemForm);
+  const payload = {
+    code: (formData.get("code") || "").trim(),
+    name: (formData.get("name") || "").trim(),
+    description: (formData.get("description") || "").trim(),
+    enabled: formData.get("enabled") !== null
+  };
+  const id = formData.get("id");
+  const version = formData.get("version");
+
+  const errors = validateForm(payload);
+  if (errors.length) {
+    showToast(errors[0], "error");
+    return;
+  }
+
+  const body = JSON.stringify(
+    id
+      ? { ...payload, version: version ? Number(version) : undefined }
+      : payload
+  );
+
+  elements.saveButton.disabled = true;
+  try {
+    let result;
+    if (id) {
+      result = await apiFetch(`/items/${id}`, { method: "PUT", body });
+      showToast("更新しました", "success");
+    } else {
+      result = await apiFetch(`/items`, { method: "POST", body });
+      showToast("作成しました", "success");
+    }
+    populateForm(result);
+    await loadItems({ action: "refresh" });
+  } catch (error) {
+    if (error.status === 409) {
+      showToast("他のユーザーにより更新されました。最新を読み込んでください", "error");
+    } else if (error.status === 400) {
+      showToast(error.message || "入力エラーです", "error");
+    } else {
+      showToast("保存に失敗しました", "error");
+    }
+  } finally {
+    elements.saveButton.disabled = false;
+  }
+});
+
+function init() {
+  loadItems({ action: "reset" });
+}
+
+document.addEventListener("DOMContentLoaded", init);

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -1,0 +1,3 @@
+window.APP_CONFIG = {
+  apiBase: "http://127.0.0.1:3001"
+};

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>マスタメンテ</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>マスタメンテ</h1>
+      <p class="app-subtitle">検索・編集が1画面で完結するシンプルなマスタ管理ツール</p>
+    </header>
+
+    <main class="app-main">
+      <section class="panel search-panel" aria-label="検索と一覧">
+        <form id="search-form" class="search-form" novalidate>
+          <label for="search-input">キーワード検索</label>
+          <div class="search-input-group">
+            <input id="search-input" name="q" type="search" placeholder="コード / 名前" />
+            <div class="search-buttons">
+              <button type="submit">検索</button>
+              <button type="button" id="clear-search">クリア</button>
+            </div>
+          </div>
+        </form>
+
+        <div class="table-wrapper" aria-live="polite">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">ID</th>
+                <th scope="col">コード</th>
+                <th scope="col">名前</th>
+                <th scope="col">有効</th>
+                <th scope="col">更新日時</th>
+                <th scope="col">編集</th>
+              </tr>
+            </thead>
+            <tbody id="items-body"></tbody>
+          </table>
+        </div>
+
+        <div class="paging-controls">
+          <button type="button" id="prev-page" disabled>前へ</button>
+          <button type="button" id="next-page" disabled>次へ</button>
+        </div>
+      </section>
+
+      <section class="panel form-panel" aria-label="編集フォーム">
+        <form id="item-form" novalidate>
+          <input type="hidden" name="id" id="item-id" />
+          <input type="hidden" name="version" id="item-version" />
+
+          <fieldset>
+            <legend>基本情報</legend>
+            <div class="form-group">
+              <label for="item-code">コード <span aria-hidden="true" class="required">*</span></label>
+              <input id="item-code" name="code" type="text" maxlength="64" required />
+            </div>
+            <div class="form-group">
+              <label for="item-name">名前 <span aria-hidden="true" class="required">*</span></label>
+              <input id="item-name" name="name" type="text" maxlength="128" required />
+            </div>
+            <div class="form-group">
+              <label for="item-description">説明</label>
+              <textarea id="item-description" name="description" rows="4" maxlength="512"></textarea>
+            </div>
+            <div class="form-group checkbox">
+              <input id="item-enabled" name="enabled" type="checkbox" />
+              <label for="item-enabled">有効</label>
+            </div>
+          </fieldset>
+
+          <div class="form-actions">
+            <button type="submit" id="save-button">保存</button>
+            <button type="button" id="reset-button">リセット</button>
+            <button type="button" id="delete-button" class="danger">削除</button>
+          </div>
+        </form>
+      </section>
+    </main>
+
+    <div id="toast-container" aria-live="assertive" role="status"></div>
+
+    <script type="module" src="config.js"></script>
+    <script type="module" src="app.js"></script>
+  </body>
+</html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,275 @@
+:root {
+  color-scheme: light;
+  font-family: "Segoe UI", "Hiragino Kaku Gothic ProN", "BIZ UDPGothic", sans-serif;
+  background-color: #f5f6fa;
+  color: #1f2933;
+  line-height: 1.5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.app-header {
+  background: linear-gradient(135deg, #4c6ef5, #228be6);
+  color: #fff;
+  padding: 1.5rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+
+.app-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.8rem;
+}
+
+.app-subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  opacity: 0.9;
+}
+
+.app-main {
+  display: flex;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  align-items: flex-start;
+}
+
+.panel {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  padding: 1.5rem;
+}
+
+.search-panel {
+  flex: 1 1 55%;
+}
+
+.form-panel {
+  flex: 1 1 45%;
+  position: sticky;
+  top: 1.5rem;
+}
+
+.search-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.search-input-group {
+  display: flex;
+  gap: 0.5rem;
+  align-items: stretch;
+}
+
+.search-input-group input[type="search"] {
+  flex: 1;
+  padding: 0.6rem 0.8rem;
+  border: 1px solid #d0d7e2;
+  border-radius: 8px;
+  font-size: 1rem;
+}
+
+.search-buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+button {
+  cursor: pointer;
+  border: none;
+  border-radius: 8px;
+  padding: 0.6rem 1.1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  background: #4263eb;
+  color: #fff;
+  transition: background-color 0.2s, transform 0.2s;
+}
+
+button:disabled {
+  background: #c5cee0;
+  color: #fff;
+  cursor: not-allowed;
+  transform: none;
+}
+
+button:not(:disabled):hover,
+button:not(:disabled):focus-visible {
+  background: #364fc7;
+}
+
+button:not(:disabled):active {
+  transform: translateY(1px);
+}
+
+button.danger {
+  background: #f03e3e;
+}
+
+button.danger:hover,
+button.danger:focus-visible {
+  background: #c92a2a;
+}
+
+.table-wrapper {
+  max-height: 60vh;
+  overflow: auto;
+  border: 1px solid #e1e7f0;
+  border-radius: 8px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+thead {
+  background: #f1f4ff;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+th,
+td {
+  padding: 0.6rem 0.8rem;
+  border-bottom: 1px solid #eef1f7;
+  text-align: left;
+  vertical-align: middle;
+}
+
+tbody tr:hover {
+  background: #f8f9ff;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  background: #e7f5ff;
+  color: #1c7ed6;
+}
+
+.badge.disabled {
+  background: #fff5f5;
+  color: #c92a2a;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+}
+
+.form-group input,
+.form-group textarea {
+  padding: 0.65rem 0.8rem;
+  border-radius: 8px;
+  border: 1px solid #d5ddea;
+  font-size: 1rem;
+}
+
+.form-group.checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.form-group.checkbox input[type="checkbox"] {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.required {
+  color: #f03e3e;
+  font-weight: bold;
+}
+
+#toast-container {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 999;
+}
+
+.toast {
+  padding: 0.9rem 1.1rem;
+  border-radius: 10px;
+  color: #fff;
+  min-width: 240px;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.35);
+  opacity: 0;
+  transform: translateY(10px);
+  animation: toast-in 200ms ease forwards, toast-out 400ms ease forwards 3600ms;
+}
+
+.toast.success {
+  background: #37b24d;
+}
+
+.toast.error {
+  background: #fa5252;
+}
+
+.toast.info {
+  background: #4263eb;
+}
+
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes toast-out {
+  to {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+}
+
+@media (max-width: 960px) {
+  .app-main {
+    flex-direction: column;
+  }
+
+  .form-panel {
+    position: static;
+    width: 100%;
+  }
+
+  .table-wrapper {
+    max-height: none;
+  }
+}
+
+tbody tr.selected {
+  background: #e7f5ff !important;
+}

--- a/mock-api/package.json
+++ b/mock-api/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "master-maint-mock-api",
+  "version": "1.0.0",
+  "private": true,
+  "type": "commonjs",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "uuid": "^9.0.1"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.2"
+  },
+  "scripts": {
+    "dev": "nodemon server.js"
+  }
+}

--- a/mock-api/schema.md
+++ b/mock-api/schema.md
@@ -1,0 +1,103 @@
+# モック API スキーマ
+
+モック API は Express で実装された DynamoDB 想定のエンティティを返却します。ベース URL は `http://127.0.0.1:3001` です。
+
+## 共通仕様
+
+- `Content-Type: application/json`
+- CORS 許可 (`Access-Control-Allow-Origin: *`)
+- レイテンシ: 150–400ms の人工遅延
+- エンティティ構造:
+
+```json
+{
+  "id": "string-uuid",
+  "code": "string",          // <= 64
+  "name": "string",          // <= 128
+  "description": "string",   // 任意
+  "enabled": true,
+  "version": 1,
+  "createdAt": "ISO-8601",
+  "updatedAt": "ISO-8601"
+}
+```
+
+## エンドポイント
+
+### `GET /items`
+
+クエリパラメータ:
+
+- `q` (任意): `code` / `name` に対する部分一致検索（小文字比較）
+- `limit` (任意): 1–100。既定値 20。
+- `nextToken` (任意): `mock-api/utils/paging.js` の base64 トークン。
+
+レスポンス:
+
+```json
+{
+  "items": [Item...],
+  "nextToken": "base64-token" | null
+}
+```
+
+### `GET /items/:id`
+
+指定 ID のアイテムを返却します。存在しない場合は `404`。
+
+### `POST /items`
+
+リクエストボディ:
+
+```json
+{
+  "code": "string",          // 必須、<=64
+  "name": "string",          // 必須、<=128
+  "description": "string",   // 任意
+  "enabled": true             // 任意、省略時 true
+}
+```
+
+レスポンス: `201 Created` + 作成されたアイテム。
+
+### `PUT /items/:id`
+
+リクエストボディ:
+
+```json
+{
+  "code": "string",          // 任意
+  "name": "string",          // 任意
+  "description": "string",   // 任意
+  "enabled": true,            // 任意
+  "version": 1                // 必須、楽観ロック
+}
+```
+
+- `version` が一致しない場合は `409 { "message": "ConditionalCheckFailed" }`
+- 更新後は `version` が +1 され `updatedAt` が更新されます。
+
+### `DELETE /items/:id`
+
+クエリパラメータ:
+
+- `version` (任意): 指定時は一致必須。不一致で `409`。
+
+レスポンス:
+
+```json
+{ "ok": true, "deletedId": "..." }
+```
+
+## ページング
+
+`utils/paging.js` で `LastEvaluatedKey` 風トークンを base64 文字列として生成・復元しています。`nextToken` を `GET /items` の `nextToken` クエリに渡すことで次ページを取得できます。
+
+## エラー
+
+- `400 Bad Request`: バリデーションエラー
+- `404 Not Found`: 対象が存在しない
+- `409 Conflict`: 楽観ロック競合 (`ConditionalCheckFailed`)
+- `500 Internal Server Error`: 上記以外の予期しないエラー
+
+`mock-api/utils/errors.js` に例外クラスとエラーハンドラを定義しています。

--- a/mock-api/seed.js
+++ b/mock-api/seed.js
@@ -1,0 +1,35 @@
+const { v4: uuid } = require("uuid");
+
+const templates = [
+  { code: "BASE-001", name: "基本設定", description: "システム全体の既定値" },
+  { code: "BASE-002", name: "画面テーマ", description: "UI テーマの割り当て" },
+  { code: "DEPT-ENG", name: "開発部", description: "エンジニアリング部門", enabled: true },
+  { code: "DEPT-HR", name: "人事部", description: "人材・労務管理" },
+  { code: "DEPT-SLS", name: "営業部", description: "国内営業", enabled: true },
+  { code: "DEPT-MKT", name: "マーケティング", description: "ブランド戦略" },
+  { code: "FLAG-JP", name: "国内向け", description: "日本市場向け設定", enabled: true },
+  { code: "FLAG-GLOBAL", name: "グローバル", description: "海外向け設定" },
+  { code: "WF-APPROVAL", name: "承認フロー標準", description: "標準的な承認フロー" },
+  { code: "WF-SHORT", name: "簡易承認", description: "小規模プロジェクト向け" },
+  { code: "CAT-OPS", name: "運用", description: "運用カテゴリ" },
+  { code: "CAT-RISK", name: "リスク管理", description: "リスク評価カテゴリ" },
+  { code: "CAT-QUALITY", name: "品質", description: "品質保証カテゴリ", enabled: true }
+];
+
+function createItem(template, index) {
+  const now = new Date(Date.now() - index * 86400000).toISOString();
+  return {
+    id: uuid(),
+    code: template.code,
+    name: template.name,
+    description: template.description || "",
+    enabled: template.enabled !== undefined ? template.enabled : true,
+    version: 1,
+    createdAt: now,
+    updatedAt: now
+  };
+}
+
+module.exports = function seed() {
+  return templates.map(createItem);
+};

--- a/mock-api/server.js
+++ b/mock-api/server.js
@@ -1,0 +1,195 @@
+const express = require("express");
+const cors = require("cors");
+const { v4: uuid } = require("uuid");
+const seed = require("./seed");
+const { toNextToken, fromNextToken, sliceWithToken } = require("./utils/paging");
+const {
+  BadRequestError,
+  NotFoundError,
+  ConflictError,
+  errorHandler,
+  withLatency
+} = require("./utils/errors");
+
+const PORT = process.env.PORT || 3001;
+
+const app = express();
+app.use(cors());
+app.options("*", cors());
+app.use(express.json());
+app.use(withLatency());
+
+let items = seed();
+
+function normalizeString(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function validateRequiredString(value, field, maxLength) {
+  const trimmed = normalizeString(value);
+  if (!trimmed) {
+    throw new BadRequestError(`${field} is required`);
+  }
+  if (trimmed.length > maxLength) {
+    throw new BadRequestError(`${field} must be <= ${maxLength} characters`);
+  }
+  return trimmed;
+}
+
+function validateOptionalString(value, field, maxLength) {
+  const trimmed = normalizeString(value);
+  if (!trimmed) return "";
+  if (trimmed.length > maxLength) {
+    throw new BadRequestError(`${field} must be <= ${maxLength} characters`);
+  }
+  return trimmed;
+}
+
+function parseEnabled(value, fallback = true) {
+  if (value === undefined || value === null) return fallback;
+  return Boolean(value);
+}
+
+app.get("/health", (req, res) => {
+  res.json({ ok: true });
+});
+
+app.get("/items", (req, res) => {
+  const q = normalizeString(req.query.q).toLowerCase();
+  const limitParam = Number.parseInt(req.query.limit, 10);
+  const limit = Number.isInteger(limitParam)
+    ? Math.min(Math.max(limitParam, 1), 100)
+    : 20;
+  const token = fromNextToken(req.query.nextToken);
+
+  let rows = [...items];
+  if (q) {
+    rows = rows.filter((item) => {
+      const code = (item.code || "").toLowerCase();
+      const name = (item.name || "").toLowerCase();
+      return code.includes(q) || name.includes(q);
+    });
+  }
+
+  const { slice, nextKey } = sliceWithToken(rows, token, limit);
+  res.json({ items: slice, nextToken: toNextToken(nextKey) });
+});
+
+app.get("/items/:id", (req, res, next) => {
+  const found = items.find((item) => item.id === req.params.id);
+  if (!found) {
+    return next(new NotFoundError());
+  }
+  res.json(found);
+});
+
+app.post("/items", (req, res, next) => {
+  try {
+    const code = validateRequiredString(req.body.code, "code", 64);
+    const name = validateRequiredString(req.body.name, "name", 128);
+    const description = validateOptionalString(req.body.description, "description", 512);
+    const enabled = parseEnabled(req.body.enabled, true);
+
+    const now = new Date().toISOString();
+    const item = {
+      id: uuid(),
+      code,
+      name,
+      description,
+      enabled,
+      version: 1,
+      createdAt: now,
+      updatedAt: now
+    };
+    items = [item, ...items];
+    res.status(201).json(item);
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.put("/items/:id", (req, res, next) => {
+  try {
+    const existingIndex = items.findIndex((item) => item.id === req.params.id);
+    if (existingIndex === -1) {
+      throw new NotFoundError();
+    }
+    const existing = items[existingIndex];
+
+    if (req.body.version === undefined || req.body.version === null) {
+      throw new BadRequestError("version is required");
+    }
+    const incomingVersion = Number(req.body.version);
+    if (!Number.isInteger(incomingVersion)) {
+      throw new BadRequestError("version must be an integer");
+    }
+    if (existing.version !== incomingVersion) {
+      throw new ConflictError();
+    }
+
+    const now = new Date().toISOString();
+    const patch = {};
+    if (req.body.code !== undefined) {
+      patch.code = validateRequiredString(req.body.code, "code", 64);
+    }
+    if (req.body.name !== undefined) {
+      patch.name = validateRequiredString(req.body.name, "name", 128);
+    }
+    if (req.body.description !== undefined) {
+      patch.description = validateOptionalString(
+        req.body.description,
+        "description",
+        512
+      );
+    }
+    if (req.body.enabled !== undefined) {
+      patch.enabled = parseEnabled(req.body.enabled, existing.enabled);
+    }
+
+    const updated = {
+      ...existing,
+      ...patch,
+      version: existing.version + 1,
+      updatedAt: now
+    };
+    items[existingIndex] = updated;
+    res.json(updated);
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.delete("/items/:id", (req, res, next) => {
+  try {
+    const existingIndex = items.findIndex((item) => item.id === req.params.id);
+    if (existingIndex === -1) {
+      throw new NotFoundError();
+    }
+    const existing = items[existingIndex];
+
+    if (req.query.version !== undefined) {
+      const incomingVersion = Number(req.query.version);
+      if (!Number.isInteger(incomingVersion)) {
+        throw new BadRequestError("version must be an integer");
+      }
+      if (existing.version !== incomingVersion) {
+        throw new ConflictError();
+      }
+    }
+
+    items.splice(existingIndex, 1);
+    res.json({ ok: true, deletedId: existing.id });
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.use((req, res, next) => {
+  next(new NotFoundError());
+});
+
+app.use(errorHandler);
+
+app.listen(PORT, () => {
+  console.log(`Mock API running at http://127.0.0.1:${PORT}`);
+});

--- a/mock-api/utils/errors.js
+++ b/mock-api/utils/errors.js
@@ -1,0 +1,53 @@
+class ApiError extends Error {
+  constructor(message, status = 500, payload = {}) {
+    super(message);
+    this.name = this.constructor.name;
+    this.status = status;
+    this.payload = payload;
+    Error.captureStackTrace?.(this, this.constructor);
+  }
+}
+
+class NotFoundError extends ApiError {
+  constructor(message = "Not Found", payload = {}) {
+    super(message, 404, payload);
+  }
+}
+
+class ConflictError extends ApiError {
+  constructor(message = "ConditionalCheckFailed", payload = {}) {
+    super(message, 409, payload);
+  }
+}
+
+class BadRequestError extends ApiError {
+  constructor(message = "Bad Request", payload = {}) {
+    super(message, 400, payload);
+  }
+}
+
+function errorHandler(err, req, res, next) {
+  if (res.headersSent) {
+    return next(err);
+  }
+  const status = err.status || 500;
+  const message = err.message || "Internal Server Error";
+  const payload = err.payload || {};
+  res.status(status).json({ message, ...payload });
+}
+
+function withLatency(min = 150, max = 400) {
+  return function latencyMiddleware(req, res, next) {
+    const delay = Math.floor(Math.random() * (max - min + 1)) + min;
+    setTimeout(next, delay);
+  };
+}
+
+module.exports = {
+  ApiError,
+  NotFoundError,
+  ConflictError,
+  BadRequestError,
+  errorHandler,
+  withLatency
+};

--- a/mock-api/utils/paging.js
+++ b/mock-api/utils/paging.js
@@ -1,0 +1,37 @@
+const TOKEN_PREFIX = "MMTK";
+
+function toNextToken(key) {
+  if (!key || typeof key.index !== "number") {
+    return null;
+  }
+  const payload = JSON.stringify({ index: key.index, prefix: TOKEN_PREFIX });
+  return Buffer.from(payload).toString("base64");
+}
+
+function fromNextToken(token) {
+  if (!token) return null;
+  try {
+    const decoded = Buffer.from(token, "base64").toString("utf8");
+    const parsed = JSON.parse(decoded);
+    if (parsed.prefix !== TOKEN_PREFIX) return null;
+    if (typeof parsed.index !== "number" || parsed.index < 0) return null;
+    return { index: parsed.index };
+  } catch (error) {
+    return null;
+  }
+}
+
+function sliceWithToken(array, token, limit) {
+  const startIndex = token?.index ?? 0;
+  const safeStart = Number.isFinite(startIndex) && startIndex >= 0 ? startIndex : 0;
+  const slice = array.slice(safeStart, safeStart + limit);
+  const nextIndex = safeStart + slice.length;
+  const nextKey = nextIndex < array.length ? { index: nextIndex } : null;
+  return { slice, nextKey };
+}
+
+module.exports = {
+  toNextToken,
+  fromNextToken,
+  sliceWithToken
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "master-maint-web",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "concurrently \"npm:dev:api\" \"npm:dev:fe\"",
+    "dev:api": "npm --prefix mock-api run dev",
+    "dev:fe": "npx http-server ./frontend -p 3000 -c-1",
+    "postinstall": "npm --prefix mock-api install"
+  },
+  "devDependencies": {
+    "concurrently": "^8.2.2",
+    "http-server": "^14.1.1"
+  }
+}


### PR DESCRIPTION
## Summary
- implement a vanilla JS master maintenance UI with search, paging, CRUD form, and toast feedback
- add an Express-based mock API with DynamoDB-style schema, optimistic locking, seed data, and token paging utilities
- document project layout and configure monorepo scripts for running the frontend and API together

## Testing
- not run (environment lacks npm registry access)


------
https://chatgpt.com/codex/tasks/task_e_68e4541dfb7c83298e6a1d5056257f30