### PR TITLE
Add FireTaste cooking simulator MVP

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FireTaste - 焚き火グルメ・シミュレータ</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "firetaste",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "README": "npm install && npm run dev"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.3.3",
+    "vite": "^5.0.0"
+  }
+}

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#1b1b1b" />
+  <path d="M32 10c8 8 10 14 6 20s-2 10 2 14c-8 0-14-4-16-10-2 4-2 8 0 12-6-4-10-10-10-16 0-8 6-16 18-20z" fill="#ff7043"/>
+  <circle cx="32" cy="46" r="6" fill="#ffd27f"/>
+</svg>

--- a/src/audio.ts
+++ b/src/audio.ts
@@ -1,0 +1,112 @@
+// src/audio.ts
+// 簡易的なWebAudioサウンドの生成。
+
+interface FireLoop {
+  source: AudioBufferSourceNode;
+  gain: GainNode;
+}
+
+export interface AudioSystem {
+  context: AudioContext | null;
+  fireLoop: FireLoop | null;
+}
+
+export const audioSystem: AudioSystem = {
+  context: null,
+  fireLoop: null
+};
+
+async function ensureContext(): Promise<AudioContext> {
+  if (!audioSystem.context) {
+    audioSystem.context = new AudioContext();
+  }
+  if (audioSystem.context.state === 'suspended') {
+    await audioSystem.context.resume();
+  }
+  return audioSystem.context;
+}
+
+function createNoiseBuffer(context: AudioContext): AudioBuffer {
+  const length = context.sampleRate * 2;
+  const buffer = context.createBuffer(1, length, context.sampleRate);
+  const data = buffer.getChannelData(0);
+  for (let i = 0; i < length; i++) {
+    data[i] = (Math.random() * 2 - 1) * 0.3;
+  }
+  return buffer;
+}
+
+export async function startFireLoop(): Promise<void> {
+  const context = await ensureContext();
+  stopFireLoop();
+  const buffer = createNoiseBuffer(context);
+  const source = context.createBufferSource();
+  source.buffer = buffer;
+  source.loop = true;
+
+  const gain = context.createGain();
+  gain.gain.value = 0.15;
+
+  const filter = context.createBiquadFilter();
+  filter.type = 'bandpass';
+  filter.frequency.value = 800;
+  filter.Q.value = 0.7;
+
+  source.connect(filter);
+  filter.connect(gain);
+  gain.connect(context.destination);
+  source.start();
+
+  audioSystem.fireLoop = { source, gain };
+}
+
+export function stopFireLoop(): void {
+  if (audioSystem.fireLoop) {
+    try {
+      audioSystem.fireLoop.source.stop();
+    } catch (error) {
+      // noop
+    }
+    audioSystem.fireLoop.gain.disconnect();
+    audioSystem.fireLoop = null;
+  }
+}
+
+export async function playSizzle(): Promise<void> {
+  const context = await ensureContext();
+  const buffer = context.createBuffer(1, context.sampleRate * 0.25, context.sampleRate);
+  const data = buffer.getChannelData(0);
+  for (let i = 0; i < data.length; i++) {
+    const t = i / data.length;
+    data[i] = (Math.random() * 2 - 1) * (1 - t) * 0.6;
+  }
+  const source = context.createBufferSource();
+  source.buffer = buffer;
+  const gain = context.createGain();
+  gain.gain.value = 0.4;
+  source.connect(gain).connect(context.destination);
+  source.start();
+}
+
+export async function playDrink(): Promise<void> {
+  const context = await ensureContext();
+  const osc = context.createOscillator();
+  osc.type = 'sine';
+  osc.frequency.value = 520;
+  const gain = context.createGain();
+  gain.gain.setValueAtTime(0.0, context.currentTime);
+  gain.gain.linearRampToValueAtTime(0.3, context.currentTime + 0.05);
+  gain.gain.exponentialRampToValueAtTime(0.001, context.currentTime + 0.4);
+  osc.connect(gain).connect(context.destination);
+  osc.start();
+  osc.stop(context.currentTime + 0.4);
+}
+
+export async function setFireVolume(amount: number): Promise<void> {
+  if (!audioSystem.fireLoop) {
+    await startFireLoop();
+  }
+  if (audioSystem.fireLoop) {
+    audioSystem.fireLoop.gain.gain.value = amount * 0.18;
+  }
+}

--- a/src/fire.ts
+++ b/src/fire.ts
@@ -1,0 +1,80 @@
+// src/fire.ts
+// 焚き火のパーティクルと熱揺らぎシミュレーション。
+
+import { CONFIG } from './state';
+import { randRange } from './utils';
+
+export interface FireParticle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+  maxLife: number;
+  size: number;
+}
+
+export interface FireSimulation {
+  particles: FireParticle[];
+  flicker: number;
+  time: number;
+}
+
+export function createFireSimulation(): FireSimulation {
+  return {
+    particles: [],
+    flicker: 1,
+    time: 0
+  };
+}
+
+export function updateFire(sim: FireSimulation, dt: number): void {
+  sim.time += dt;
+  const target = 1 + Math.sin(sim.time * 1.7) * 0.2 + (Math.random() - 0.5) * CONFIG.fire.flickerStrength;
+  sim.flicker = sim.flicker * 0.85 + target * 0.15;
+
+  const spawnCount = CONFIG.fire.particleRate * dt * sim.flicker;
+  for (let i = 0; i < spawnCount; i++) {
+    sim.particles.push(createParticle());
+  }
+
+  const gravity = -20;
+  for (let i = sim.particles.length - 1; i >= 0; i--) {
+    const p = sim.particles[i];
+    p.life += dt;
+    if (p.life >= p.maxLife) {
+      sim.particles.splice(i, 1);
+      continue;
+    }
+    const t = p.life / p.maxLife;
+    p.vx *= 0.98;
+    p.vy += gravity * dt * (0.3 + Math.random() * 0.2);
+    p.x += p.vx * dt * 60;
+    p.y += p.vy * dt * 60;
+    p.size *= 0.995 - t * 0.05;
+    if (p.size < 2) {
+      sim.particles.splice(i, 1);
+    }
+  }
+}
+
+function createParticle(): FireParticle {
+  return {
+    x: randRange(-30, 30),
+    y: randRange(-10, 10),
+    vx: randRange(-5, 5),
+    vy: randRange(35, 55),
+    life: 0,
+    maxLife: randRange(CONFIG.fire.particleLifetime[0], CONFIG.fire.particleLifetime[1]),
+    size: randRange(10, 22)
+  };
+}
+
+export function getFireHeatFactor(sim: FireSimulation): number {
+  return 0.6 + sim.flicker * 0.5;
+}
+
+export function getHeatAtHeight(height: number): number {
+  const normalized = Math.max(0, 1 - Math.abs(height) / CONFIG.fire.radius);
+  return CONFIG.fire.ambientHeat * normalized;
+}

--- a/src/heatModel.ts
+++ b/src/heatModel.ts
@@ -1,0 +1,39 @@
+// src/heatModel.ts
+// 焼成シミュレーションを担当する。
+
+import type { CookState } from './state';
+import { CONFIG } from './state';
+import { clamp } from './utils';
+
+export function computeHeatPower(distance: number): number {
+  const minDistance = 20;
+  const d = Math.max(minDistance, distance);
+  const heat = CONFIG.heat.maxPower / Math.pow(d / 80, CONFIG.heat.exponent);
+  return heat;
+}
+
+export function applyCookingStep(cook: CookState, dt: number, heatPower: number): void {
+  const ambient = 20;
+  const heatGain = heatPower * CONFIG.heat.surfaceGain * dt;
+  const cooling = (cook.surfaceTemp - ambient) * CONFIG.heat.cooling * dt * 0.01;
+  cook.surfaceTemp += heatGain - cooling;
+  cook.surfaceTemp = Math.max(cook.surfaceTemp, ambient);
+
+  const coreExchange = (cook.surfaceTemp - cook.coreTemp) * CONFIG.heat.coreGain * dt * 0.01;
+  cook.coreTemp += coreExchange;
+  cook.coreTemp = Math.max(cook.coreTemp, ambient);
+
+  if (cook.surfaceTemp >= CONFIG.heat.charThreshold) {
+    cook.char += (cook.surfaceTemp - CONFIG.heat.charThreshold) / 400 * CONFIG.heat.charRate * dt;
+  }
+  cook.char = clamp(cook.char, 0, 1);
+}
+
+export function coolDown(cook: CookState, dt: number): void {
+  const ambient = 20;
+  const cooling = (cook.surfaceTemp - ambient) * CONFIG.heat.cooling * 0.5 * dt * 0.01;
+  cook.surfaceTemp -= cooling;
+  cook.coreTemp -= cooling * 0.6;
+  cook.surfaceTemp = Math.max(cook.surfaceTemp, ambient);
+  cook.coreTemp = Math.max(cook.coreTemp, ambient);
+}

--- a/src/ingredients.ts
+++ b/src/ingredients.ts
@@ -1,0 +1,163 @@
+// src/ingredients.ts
+// 食材・調味料・飲み物のデータと相性ロジック。
+
+import type { Config, EvaluationResult } from './state';
+import { clamp, mapRange } from './utils';
+
+export interface Ingredient {
+  id: string;
+  name: string;
+  size: number;
+  colorStops: string[];
+}
+
+export interface Seasoning {
+  id: string;
+  name: string;
+  accentColor: string;
+}
+
+export interface Drink {
+  id: string;
+  name: string;
+  accentColor: string;
+}
+
+export const INGREDIENTS: Ingredient[] = [
+  { id: 'marshmallow', name: 'マシュマロ', size: 42, colorStops: ['#ffffff', '#ffd9b3', '#d98c4c'] },
+  { id: 'sausage', name: 'ソーセージ', size: 54, colorStops: ['#ff9a63', '#cc4d1f', '#802711'] },
+  { id: 'cheese', name: 'チーズ', size: 50, colorStops: ['#ffe27a', '#ffc947', '#d69c1e'] },
+  { id: 'mushroom', name: 'マッシュルーム', size: 48, colorStops: ['#f8f1e7', '#d3c2ae', '#9a8164'] },
+  { id: 'apple', name: 'りんご', size: 46, colorStops: ['#ff7373', '#c62828', '#7a1a1a'] }
+];
+
+export const SEASONINGS: Seasoning[] = [
+  { id: 'butter', name: 'バター', accentColor: '#ffd54f' },
+  { id: 'salt', name: '岩塩', accentColor: '#b0bec5' },
+  { id: 'pepper', name: 'ペッパー', accentColor: '#8d6e63' },
+  { id: 'cinnamon', name: 'シナモン', accentColor: '#a1887f' },
+  { id: 'honey', name: 'ハニー', accentColor: '#ffb74d' },
+  { id: 'soy', name: '醤油', accentColor: '#6d4c41' }
+];
+
+export const DRINKS: Drink[] = [
+  { id: 'whisky', name: 'ウィスキー', accentColor: '#f57c00' },
+  { id: 'redwine', name: '赤ワイン', accentColor: '#ad1457' },
+  { id: 'whitewine', name: '白ワイン', accentColor: '#fdd835' },
+  { id: 'sake', name: '日本酒', accentColor: '#90caf9' },
+  { id: 'coffee', name: 'コーヒー', accentColor: '#4e342e' },
+  { id: 'tea', name: 'お茶', accentColor: '#7cb342' }
+];
+
+const DRINK_PAIRINGS = new Map<string, number>([
+  [['marshmallow', 'whisky'].join(':'), 15],
+  [['marshmallow', 'coffee'].join(':'), 6],
+  [['sausage', 'redwine'].join(':'), 6],
+  [['cheese', 'redwine'].join(':'), 18],
+  [['cheese', 'whisky'].join(':'), 4],
+  [['mushroom', 'sake'].join(':'), 16],
+  [['mushroom', 'whitewine'].join(':'), 10],
+  [['apple', 'tea'].join(':'), 5]
+]);
+
+const SEASONING_PAIRINGS = new Map<string, number>([
+  [['marshmallow', 'honey'].join(':'), 6],
+  [['marshmallow', 'soy'].join(':'), -2],
+  [['sausage', 'pepper'].join(':'), 5],
+  [['sausage', 'butter'].join(':'), 3],
+  [['cheese', 'pepper'].join(':'), 3],
+  [['cheese', 'soy'].join(':'), 2],
+  [['mushroom', 'butter'].join(':'), 6],
+  [['mushroom', 'salt'].join(':'), 3],
+  [['apple', 'cinnamon'].join(':'), 8],
+  [['apple', 'honey'].join(':'), 4]
+]);
+
+function pairingKey(a: string, b: string): string {
+  return `${a}:${b}`;
+}
+
+export interface CookingSnapshot {
+  surface: number;
+  core: number;
+  char: number;
+}
+
+export function getIngredientById(id: string): Ingredient | undefined {
+  return INGREDIENTS.find((item) => item.id === id);
+}
+
+export function getSeasoningById(id: string): Seasoning | undefined {
+  return SEASONINGS.find((item) => item.id === id);
+}
+
+export function getDrinkById(id: string): Drink | undefined {
+  return DRINKS.find((item) => item.id === id);
+}
+
+function rangeScore(value: number, min: number, max: number): number {
+  const center = (min + max) / 2;
+  const span = (max - min) / 2;
+  const diff = Math.abs(value - center);
+  return clamp(1 - diff / (span * 1.6), 0, 1);
+}
+
+function charScore(char: number, ideal: number): number {
+  if (char <= ideal) {
+    const t = clamp(char / ideal, 0, 1);
+    return clamp(0.7 + 0.3 * t, 0, 1);
+  }
+  return clamp(1 - (char - ideal) / (1 - ideal) * 1.2, 0, 1);
+}
+
+function labelFromScore(total: number): string {
+  if (total >= 32) return 'Perfect';
+  if (total >= 24) return 'Great';
+  if (total >= 16) return 'Good';
+  if (total >= 8) return 'Under';
+  return 'Over';
+}
+
+function computeTimingMultiplier(sinceServe: number, config: Config): number {
+  if (sinceServe < 0) return 1;
+  if (sinceServe >= config.drinkWindow.total) {
+    return 0.8;
+  }
+  if (sinceServe >= config.drinkWindow.perfectStart && sinceServe <= config.drinkWindow.perfectEnd) {
+    return config.drinkWindow.multiplier;
+  }
+  const t = mapRange(sinceServe, 0, config.drinkWindow.perfectStart, 0.9, 1.0);
+  return clamp(t, 0.85, config.drinkWindow.multiplier);
+}
+
+export function evaluateCooking(
+  ingredient: Ingredient,
+  seasoning: Seasoning | null,
+  drink: Drink | null,
+  cooking: CookingSnapshot,
+  sinceServe: number,
+  config: Config
+): EvaluationResult {
+  const surfaceScore = rangeScore(cooking.surface, config.scoring.idealSurface[0], config.scoring.idealSurface[1]);
+  const coreScore = rangeScore(cooking.core, config.scoring.idealCore[0], config.scoring.idealCore[1]);
+  const charMultiplier = charScore(cooking.char, config.scoring.idealChar);
+  const baseScore = Math.round(config.scoring.maxBase * ((surfaceScore + coreScore) / 2) * charMultiplier);
+
+  const seasoningBonus = seasoning ? (SEASONING_PAIRINGS.get(pairingKey(ingredient.id, seasoning.id)) ?? 0) : 0;
+  const drinkBonus = drink ? (DRINK_PAIRINGS.get(pairingKey(ingredient.id, drink.id)) ?? 0) : 0;
+  const timingMultiplier = drink ? computeTimingMultiplier(sinceServe, config) : 1;
+
+  const total = Math.round((baseScore + seasoningBonus + drinkBonus) * timingMultiplier);
+
+  return {
+    ingredient,
+    seasoning,
+    drink,
+    baseScore,
+    seasoningBonus,
+    drinkBonus,
+    timingMultiplier,
+    total,
+    label: labelFromScore(total)
+  };
+}

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,0 +1,59 @@
+// src/input.ts
+// Pointerイベントから串の操作とUIクリックを抽象化する。
+
+interface PointerState {
+  active: boolean;
+  id: number | null;
+  lastX: number;
+  lastY: number;
+  totalDistance: number;
+}
+
+export interface PointerCallbacks {
+  onSkewerMove: (deltaAngle: number, deltaHeight: number) => void;
+  onTap: (x: number, y: number) => void;
+}
+
+const pointerState: PointerState = {
+  active: false,
+  id: null,
+  lastX: 0,
+  lastY: 0,
+  totalDistance: 0
+};
+
+export function setupInput(canvas: HTMLCanvasElement, callbacks: PointerCallbacks): void {
+  canvas.addEventListener('pointerdown', (event) => {
+    pointerState.active = true;
+    pointerState.id = event.pointerId;
+    pointerState.lastX = event.clientX;
+    pointerState.lastY = event.clientY;
+    pointerState.totalDistance = 0;
+    canvas.setPointerCapture(event.pointerId);
+  });
+
+  canvas.addEventListener('pointermove', (event) => {
+    if (!pointerState.active || pointerState.id !== event.pointerId) return;
+    const dx = event.clientX - pointerState.lastX;
+    const dy = event.clientY - pointerState.lastY;
+    pointerState.lastX = event.clientX;
+    pointerState.lastY = event.clientY;
+    pointerState.totalDistance += Math.sqrt(dx * dx + dy * dy);
+
+    const deltaAngle = dx;
+    const deltaHeight = dy;
+    callbacks.onSkewerMove(deltaAngle, deltaHeight);
+  });
+
+  function endPointer(event: PointerEvent): void {
+    if (!pointerState.active || pointerState.id !== event.pointerId) return;
+    canvas.releasePointerCapture(event.pointerId);
+    pointerState.active = false;
+    if (pointerState.totalDistance < 10) {
+      callbacks.onTap(event.offsetX, event.offsetY);
+    }
+  }
+
+  canvas.addEventListener('pointerup', endPointer);
+  canvas.addEventListener('pointercancel', endPointer);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,190 @@
+// src/main.ts
+// エントリポイント。ゲームループと状態管理を司る。
+
+import { setupInput } from './input';
+import { createRenderer, render } from './renderer';
+import { createFireSimulation, updateFire, getFireHeatFactor } from './fire';
+import { applyCookingStep, computeHeatPower, coolDown } from './heatModel';
+import { CONFIG, GamePhase, createInitialState } from './state';
+import { evaluateCooking, getDrinkById, getIngredientById, getSeasoningById } from './ingredients';
+import { findButtonAt, type UIButton } from './ui';
+import { playDrink, playSizzle, setFireVolume } from './audio';
+import { clamp } from './utils';
+
+const app = document.getElementById('app');
+if (!app) {
+  throw new Error('#app not found');
+}
+
+const canvas = document.createElement('canvas');
+app.appendChild(canvas);
+
+const renderer = createRenderer(canvas);
+const fire = createFireSimulation();
+const state = createInitialState(fire);
+state.phase = GamePhase.Playing;
+
+let lastTime = performance.now();
+let sizzleCheck = CONFIG.heat.charThreshold - 1;
+let audioInitialized = false;
+
+setupInput(canvas, {
+  onSkewerMove: (deltaAngle, deltaHeight) => {
+    const cook = state.cook;
+    if (!cook || cook.done) return;
+    cook.angle = clamp(cook.angle + deltaAngle * CONFIG.skewer.rotationSpeed, -0.7, 0.7);
+    cook.rotation += deltaAngle * CONFIG.skewer.rotationSpeed * 1.4;
+    cook.height = clamp(cook.height + deltaHeight * CONFIG.skewer.heightSensitivity, CONFIG.skewer.minHeight, CONFIG.skewer.maxHeight);
+  },
+  onTap: (x, y) => {
+    if (!audioInitialized) {
+      audioInitialized = true;
+      void setFireVolume(0.6);
+    }
+    if (!renderer.layout) return;
+    const button = findButtonAt(renderer.layout, x, y);
+    if (button) {
+      handleButton(button);
+    }
+  }
+});
+
+function handleButton(button: UIButton): void {
+  switch (button.kind) {
+    case 'ingredient':
+      if (state.drinkWindowActive) return;
+      startCooking(button.id);
+      break;
+    case 'seasoning':
+      applySeasoning(button.id);
+      break;
+    case 'drink':
+      state.selection.drinkId = button.id;
+      if (state.drinkWindowActive) {
+        const drink = getDrinkById(button.id);
+        if (drink) {
+          finalizeServe(drink);
+          void playDrink();
+        }
+      }
+      break;
+    case 'serve':
+      serveIngredient();
+      break;
+  }
+}
+
+function startCooking(ingredientId: string): void {
+  const ingredient = getIngredientById(ingredientId);
+  if (!ingredient) return;
+  state.cook = {
+    ingredient,
+    seasoning: null,
+    surfaceTemp: 20,
+    coreTemp: 20,
+    char: 0,
+    angle: 0,
+    height: -40,
+    rotation: 0,
+    done: false,
+    doneTimer: 0,
+    evaluation: null
+  };
+  state.selection.ingredientId = ingredientId;
+  state.selection.seasoningId = null;
+  state.selection.drinkId = null;
+  sizzleCheck = CONFIG.heat.charThreshold - 1;
+}
+
+function applySeasoning(seasoningId: string): void {
+  const cook = state.cook;
+  if (!cook || cook.done) return;
+  const seasoning = getSeasoningById(seasoningId);
+  if (!seasoning) return;
+  cook.seasoning = seasoning;
+  state.selection.seasoningId = seasoningId;
+}
+
+function serveIngredient(): void {
+  const cook = state.cook;
+  if (!cook || cook.done) return;
+  cook.done = true;
+  cook.doneTimer = 0;
+  cook.evaluation = evaluateCooking(
+    cook.ingredient,
+    cook.seasoning,
+    null,
+    { surface: cook.surfaceTemp, core: cook.coreTemp, char: cook.char },
+    0,
+    CONFIG
+  );
+  state.lastEvaluation = cook.evaluation;
+  state.drinkWindowActive = true;
+  state.drinkWindowTimer = 0;
+}
+
+function finalizeServe(drink: ReturnType<typeof getDrinkById> | null): void {
+  const cook = state.cook;
+  if (!cook) return;
+  const sinceServe = state.drinkWindowTimer;
+  const evaluation = evaluateCooking(
+    cook.ingredient,
+    cook.seasoning,
+    drink ?? null,
+    { surface: cook.surfaceTemp, core: cook.coreTemp, char: cook.char },
+    sinceServe,
+    CONFIG
+  );
+  state.score += evaluation.total;
+  state.lastEvaluation = evaluation;
+  state.drinkWindowActive = false;
+  state.drinkWindowTimer = 0;
+  state.cook = null;
+  state.selection.ingredientId = null;
+  state.selection.seasoningId = null;
+  state.selection.drinkId = drink?.id ?? null;
+}
+
+function update(dt: number): void {
+  state.timeRemaining = Math.max(0, state.timeRemaining - dt);
+  updateFire(state.fire, dt);
+
+  const cook = state.cook;
+  if (cook) {
+    if (!cook.done) {
+      const distance = clamp(CONFIG.fire.radius + cook.height, 40, 280);
+      const heat = computeHeatPower(distance) * getFireHeatFactor(state.fire);
+      state.heatLevel = heat;
+      applyCookingStep(cook, dt, heat);
+      cook.rotation += dt * 1.2;
+      if (cook.surfaceTemp >= CONFIG.heat.charThreshold && sizzleCheck < CONFIG.heat.charThreshold) {
+        void playSizzle();
+      }
+      sizzleCheck = cook.surfaceTemp;
+    } else {
+      coolDown(cook, dt);
+      state.heatLevel = 40;
+      state.drinkWindowTimer += dt;
+      if (state.drinkWindowTimer > CONFIG.drinkWindow.total) {
+        finalizeServe(null);
+      }
+    }
+  } else {
+    state.heatLevel = 30;
+  }
+
+  if (audioInitialized) {
+    const volume = clamp(state.heatLevel / 260, 0.2, 1);
+    void setFireVolume(volume);
+  }
+}
+
+function gameLoop(time: number): void {
+  const dt = Math.min((time - lastTime) / 1000, 0.05);
+  lastTime = time;
+  update(dt);
+  render(state, renderer);
+  requestAnimationFrame(gameLoop);
+}
+
+requestAnimationFrame(gameLoop);

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,0 +1,257 @@
+// src/renderer.ts
+// Canvas2D を用いてゲームシーン全体を描画する。
+
+import { CONFIG, type GameState } from './state';
+import type { CookState } from './state';
+import { buildUILayout, drawUI, type UILayout } from './ui';
+import type { FireParticle } from './fire';
+import { clamp, lerp } from './utils';
+
+export interface Renderer {
+  canvas: HTMLCanvasElement;
+  ctx: CanvasRenderingContext2D;
+  width: number;
+  height: number;
+  layout: UILayout | null;
+}
+
+export function createRenderer(canvas: HTMLCanvasElement): Renderer {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    throw new Error('Canvas 2D context is not available');
+  }
+  canvas.style.width = '100vw';
+  canvas.style.height = '100vh';
+  canvas.style.touchAction = 'none';
+  return {
+    canvas,
+    ctx,
+    width: CONFIG.canvas.baseWidth,
+    height: CONFIG.canvas.baseHeight,
+    layout: null
+  };
+}
+
+export function resizeRenderer(renderer: Renderer): void {
+  const aspect = CONFIG.canvas.baseWidth / CONFIG.canvas.baseHeight;
+  const availableWidth = window.innerWidth;
+  const availableHeight = window.innerHeight;
+  let width = availableWidth;
+  let height = width / aspect;
+  if (height > availableHeight) {
+    height = availableHeight;
+    width = height * aspect;
+  }
+  renderer.canvas.style.width = `${width}px`;
+  renderer.canvas.style.height = `${height}px`;
+
+  const dpr = window.devicePixelRatio || 1;
+  renderer.canvas.width = width * dpr;
+  renderer.canvas.height = height * dpr;
+  renderer.ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  renderer.width = width;
+  renderer.height = height;
+}
+
+export function render(state: GameState, renderer: Renderer): void {
+  resizeRenderer(renderer);
+  const ctx = renderer.ctx;
+  const width = renderer.width;
+  const height = renderer.height;
+
+  ctx.clearRect(0, 0, width, height);
+  drawBackground(ctx, width, height);
+
+  const layout = buildUILayout(width, height, state);
+  renderer.layout = layout;
+
+  drawTable(ctx, width, height);
+  drawFire(ctx, state, width, height);
+  if (state.cook) {
+    drawSkewer(ctx, state.cook, width, height);
+    drawIngredient(ctx, state.cook, width, height);
+  }
+
+  drawUI(ctx, state, layout);
+
+  if (state.drinkWindowActive) {
+    drawDrinkRipple(ctx, width, height, state.drinkWindowTimer / CONFIG.drinkWindow.total);
+  }
+}
+
+function drawBackground(ctx: CanvasRenderingContext2D, width: number, height: number): void {
+  const gradient = ctx.createLinearGradient(0, 0, 0, height);
+  gradient.addColorStop(0, '#0f1115');
+  gradient.addColorStop(1, '#1f1308');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+}
+
+function drawTable(ctx: CanvasRenderingContext2D, width: number, height: number): void {
+  ctx.save();
+  const panelWidth = width * CONFIG.ui.panelWidthRatio;
+  const tableWidth = width - panelWidth;
+  const tableHeight = height * 0.3;
+  const y = height - tableHeight;
+  const gradient = ctx.createLinearGradient(0, y, 0, height);
+  gradient.addColorStop(0, '#4e342e');
+  gradient.addColorStop(1, '#2d1f19');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, y, tableWidth, tableHeight + 20);
+  ctx.restore();
+}
+
+function drawFire(ctx: CanvasRenderingContext2D, state: GameState, width: number, height: number): void {
+  const panelWidth = width * CONFIG.ui.panelWidthRatio;
+  const centerX = (width - panelWidth) / 2;
+  const baseY = height * 0.72;
+  const fireRadius = CONFIG.fire.radius * (width / CONFIG.canvas.baseWidth);
+
+  // 焚き火の光のにじみ
+  const radial = ctx.createRadialGradient(centerX, baseY, 10, centerX, baseY, fireRadius * 1.4);
+  radial.addColorStop(0, 'rgba(255, 160, 64, 0.6)');
+  radial.addColorStop(1, 'rgba(0,0,0,0)');
+  ctx.fillStyle = radial;
+  ctx.fillRect(centerX - fireRadius * 1.4, baseY - fireRadius * 1.4, fireRadius * 2.8, fireRadius * 2.8);
+
+  ctx.save();
+  ctx.translate(centerX, baseY);
+  ctx.globalCompositeOperation = 'lighter';
+  state.fire.particles.forEach((particle: FireParticle) => {
+    const alpha = 1 - particle.life / particle.maxLife;
+    ctx.fillStyle = `rgba(255, ${Math.round(120 + alpha * 80)}, ${Math.round(40 + alpha * 40)}, ${alpha})`;
+    ctx.beginPath();
+    ctx.ellipse(particle.x, -particle.y, particle.size * 0.4, particle.size, 0, 0, Math.PI * 2);
+    ctx.fill();
+  });
+  ctx.restore();
+
+  // 焚き火本体
+  ctx.save();
+  ctx.translate(centerX, baseY);
+  const flameGradient = ctx.createRadialGradient(0, 0, 10, 0, 0, fireRadius * 0.7);
+  flameGradient.addColorStop(0, 'rgba(255, 200, 120, 0.9)');
+  flameGradient.addColorStop(0.5, 'rgba(255, 120, 60, 0.8)');
+  flameGradient.addColorStop(1, 'rgba(200, 60, 20, 0)');
+  ctx.fillStyle = flameGradient;
+  ctx.beginPath();
+  ctx.ellipse(0, -fireRadius * 0.1, fireRadius * 0.5, fireRadius * 0.7, 0, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.restore();
+}
+
+function drawSkewer(ctx: CanvasRenderingContext2D, cook: CookState, width: number, height: number): void {
+  ctx.save();
+  const panelWidth = width * CONFIG.ui.panelWidthRatio;
+  const originX = (width - panelWidth) / 2;
+  const baseY = height * 0.55 + cook.height;
+  const length = CONFIG.skewer.baseLength;
+  const angle = cook.angle;
+  const cos = Math.cos(angle);
+  const sin = Math.sin(angle);
+
+  const startX = originX - cos * length;
+  const startY = baseY - sin * length;
+  const endX = originX + cos * length;
+  const endY = baseY + sin * length;
+
+  ctx.lineWidth = 6;
+  ctx.strokeStyle = '#c0a080';
+  ctx.beginPath();
+  ctx.moveTo(startX, startY);
+  ctx.lineTo(endX, endY);
+  ctx.stroke();
+
+  ctx.fillStyle = '#d7ccc8';
+  ctx.beginPath();
+  ctx.arc(startX, startY, 9, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.restore();
+}
+
+function drawIngredient(ctx: CanvasRenderingContext2D, cook: CookState, width: number, height: number): void {
+  const panelWidth = width * CONFIG.ui.panelWidthRatio;
+  const centerX = (width - panelWidth) / 2;
+  const centerY = height * 0.55 + cook.height;
+  const radius = cook.ingredient.size * (width / CONFIG.canvas.baseWidth);
+
+  ctx.save();
+  ctx.translate(centerX, centerY);
+  ctx.rotate(cook.rotation);
+
+  const [base, mid, dark] = cook.ingredient.colorStops;
+  const burn = clamp(cook.char, 0, 1);
+  const charMix = lerp(0, 0.8, burn);
+
+  const gradient = ctx.createRadialGradient(0, 0, radius * 0.2, 0, 0, radius);
+  gradient.addColorStop(0, lightenColor(base, 0.2 - charMix * 0.2));
+  gradient.addColorStop(0.6, lerpColor(mid ?? base, dark ?? base, burn * 0.5));
+  gradient.addColorStop(1, lerpColor(dark ?? mid ?? base, '#1b1b1b', burn));
+
+  ctx.fillStyle = gradient;
+  ctx.beginPath();
+  ctx.ellipse(0, 0, radius * 1.6, radius, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  const highlight = ctx.createLinearGradient(-radius, -radius, radius, radius);
+  highlight.addColorStop(0, 'rgba(255,255,255,0.1)');
+  highlight.addColorStop(0.5, 'rgba(255,255,255,0.3)');
+  highlight.addColorStop(1, 'rgba(0,0,0,0)');
+  ctx.globalCompositeOperation = 'lighter';
+  ctx.fillStyle = highlight;
+  ctx.beginPath();
+  ctx.ellipse(-radius * 0.2, -radius * 0.2, radius, radius * 0.6, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.restore();
+}
+
+function drawDrinkRipple(ctx: CanvasRenderingContext2D, width: number, height: number, t: number): void {
+  const maxRadius = Math.min(width, height) * 0.25;
+  const centerX = width * 0.85;
+  const centerY = height * 0.15;
+  const alpha = clamp(1 - t, 0, 1) * 0.5;
+
+  ctx.save();
+  ctx.strokeStyle = `rgba(200, 220, 255, ${alpha})`;
+  ctx.lineWidth = 4;
+  ctx.beginPath();
+  ctx.arc(centerX, centerY, maxRadius * t, 0, Math.PI * 2);
+  ctx.stroke();
+  ctx.restore();
+}
+
+function lightenColor(color: string, amount: number): string {
+  const c = parseColor(color);
+  return `rgb(${clamp(Math.round(c[0] + 255 * amount), 0, 255)}, ${clamp(Math.round(c[1] + 255 * amount), 0, 255)}, ${clamp(Math.round(c[2] + 255 * amount), 0, 255)})`;
+}
+
+function lerpColor(a: string, b: string, t: number): string {
+  const ca = parseColor(a);
+  const cb = parseColor(b);
+  const color = [
+    Math.round(lerp(ca[0], cb[0], t)),
+    Math.round(lerp(ca[1], cb[1], t)),
+    Math.round(lerp(ca[2], cb[2], t))
+  ];
+  return `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
+}
+
+function parseColor(hex: string): [number, number, number] {
+  if (hex.startsWith('#')) {
+    const normalized = hex.replace('#', '');
+    const size = normalized.length === 3 ? 1 : 2;
+    const r = parseInt(normalized.slice(0, size), 16);
+    const g = parseInt(normalized.slice(size, size * 2), 16);
+    const b = parseInt(normalized.slice(size * 2), 16);
+    if (size === 1) {
+      return [r * 17, g * 17, b * 17];
+    }
+    return [r, g, b];
+  }
+  const match = hex.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
+  if (match) {
+    return [Number(match[1]), Number(match[2]), Number(match[3])];
+  }
+  return [255, 255, 255];
+}

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,0 +1,139 @@
+// src/state.ts
+// ゲーム全体の共有状態と列挙体を定義する。
+
+import type { Drink, Ingredient, Seasoning } from './ingredients';
+import type { FireSimulation } from './fire';
+
+export enum GamePhase {
+  Intro = 'intro',
+  Playing = 'playing',
+  Result = 'result'
+}
+
+export interface EvaluationResult {
+  ingredient: Ingredient;
+  seasoning: Seasoning | null;
+  drink: Drink | null;
+  baseScore: number;
+  seasoningBonus: number;
+  drinkBonus: number;
+  timingMultiplier: number;
+  total: number;
+  label: string;
+}
+
+export interface CookState {
+  ingredient: Ingredient;
+  seasoning: Seasoning | null;
+  surfaceTemp: number;
+  coreTemp: number;
+  char: number;
+  angle: number;
+  height: number;
+  rotation: number;
+  done: boolean;
+  doneTimer: number;
+  evaluation: EvaluationResult | null;
+}
+
+export interface SelectionState {
+  ingredientId: string | null;
+  seasoningId: string | null;
+  drinkId: string | null;
+}
+
+export interface FloatingText {
+  text: string;
+  timer: number;
+  duration: number;
+}
+
+export interface GameState {
+  phase: GamePhase;
+  timeRemaining: number;
+  score: number;
+  cook: CookState | null;
+  selection: SelectionState;
+  fire: FireSimulation;
+  heatLevel: number;
+  floatingTexts: FloatingText[];
+  lastEvaluation: EvaluationResult | null;
+  drinkWindowTimer: number;
+  drinkWindowActive: boolean;
+}
+
+export const CONFIG = {
+  canvas: {
+    baseWidth: 960,
+    baseHeight: 540
+  },
+  round: {
+    duration: 60
+  },
+  skewer: {
+    minHeight: -120,
+    maxHeight: 80,
+    rotationSpeed: 0.003,
+    heightSensitivity: 0.5,
+    baseLength: 320
+  },
+  heat: {
+    exponent: 1.6,
+    maxPower: 220,
+    surfaceGain: 55,
+    coreGain: 12,
+    cooling: 8,
+    charThreshold: 200,
+    charRate: 0.12
+  },
+  scoring: {
+    idealSurface: [160, 190] as [number, number],
+    idealCore: [60, 75] as [number, number],
+    idealChar: 0.15,
+    maxBase: 20
+  },
+  drinkWindow: {
+    perfectStart: 0.5,
+    perfectEnd: 3,
+    total: 4,
+    multiplier: 1.25
+  },
+  fire: {
+    radius: 140,
+    particleRate: 48,
+    particleLifetime: [1.2, 2.4] as [number, number],
+    flickerStrength: 0.4,
+    ambientHeat: 32
+  },
+  ui: {
+    panelWidthRatio: 0.28,
+    padding: 16,
+    gaugeHeight: 72
+  }
+} as const;
+
+export type Config = typeof CONFIG;
+
+export function createInitialSelection(): SelectionState {
+  return {
+    ingredientId: null,
+    seasoningId: null,
+    drinkId: null
+  };
+}
+
+export function createInitialState(fire: FireSimulation): GameState {
+  return {
+    phase: GamePhase.Intro,
+    timeRemaining: CONFIG.round.duration,
+    score: 0,
+    cook: null,
+    selection: createInitialSelection(),
+    fire,
+    heatLevel: 0,
+    floatingTexts: [],
+    lastEvaluation: null,
+    drinkWindowTimer: 0,
+    drinkWindowActive: false
+  };
+}

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,0 +1,310 @@
+// src/ui.ts
+// HUDとUIパネルのレイアウト／描画を担当する。
+
+import type { GameState } from './state';
+import { CONFIG } from './state';
+import { DRINKS, INGREDIENTS, SEASONINGS } from './ingredients';
+import type { Rectangle } from './utils';
+import { clamp, easeOutCubic } from './utils';
+
+export type UIButtonKind = 'ingredient' | 'seasoning' | 'drink' | 'serve';
+
+export interface UIButton {
+  id: string;
+  kind: UIButtonKind;
+  rect: Rectangle;
+  label: string;
+  accent: string;
+  active: boolean;
+}
+
+export interface UILayout {
+  panelRect: Rectangle;
+  gaugeRect: Rectangle;
+  heatRect: Rectangle;
+  buttons: UIButton[];
+}
+
+export function buildUILayout(width: number, height: number, state: GameState): UILayout {
+  const panelWidth = width * CONFIG.ui.panelWidthRatio;
+  const panelRect: Rectangle = {
+    x: width - panelWidth,
+    y: 0,
+    width: panelWidth,
+    height
+  };
+
+  const padding = CONFIG.ui.padding;
+  const buttonWidth = panelRect.width - padding * 2;
+  const buttonHeight = 44;
+
+  const buttons: UIButton[] = [];
+  let cursorY = panelRect.y + 120;
+
+  const addButton = (id: string, kind: UIButtonKind, label: string, accent: string, active: boolean, col?: number, cols?: number, rowIndex?: number): void => {
+    if (cols && cols > 1 && rowIndex !== undefined && col !== undefined) {
+      const spacing = 12;
+      const cellWidth = (buttonWidth - spacing * (cols - 1)) / cols;
+      const x = panelRect.x + padding + col * (cellWidth + spacing);
+      const y = cursorY + rowIndex * (buttonHeight + 10);
+      buttons.push({
+        id,
+        kind,
+        label,
+        accent,
+        active,
+        rect: { x, y, width: cellWidth, height: buttonHeight }
+      });
+    } else {
+      buttons.push({
+        id,
+        kind,
+        label,
+        accent,
+        active,
+        rect: { x: panelRect.x + padding, y: cursorY, width: buttonWidth, height: buttonHeight }
+      });
+      cursorY += buttonHeight + 10;
+    }
+  };
+
+  INGREDIENTS.forEach((ingredient) => {
+    const active = state.cook?.ingredient.id === ingredient.id;
+    addButton(ingredient.id, 'ingredient', ingredient.name, ingredient.colorStops[1] ?? '#fff', active);
+  });
+
+  cursorY += 10;
+  const seasoningRows = Math.ceil(SEASONINGS.length / 2);
+  for (let row = 0; row < seasoningRows; row++) {
+    for (let col = 0; col < 2; col++) {
+      const index = row * 2 + col;
+      if (index >= SEASONINGS.length) continue;
+      const item = SEASONINGS[index];
+      const active = state.cook?.seasoning?.id === item.id;
+      addButton(item.id, 'seasoning', item.name, item.accentColor, active, col, 2, row);
+    }
+  }
+  cursorY += seasoningRows * (buttonHeight + 10) + 20;
+
+  const drinkRows = Math.ceil(DRINKS.length / 2);
+  for (let row = 0; row < drinkRows; row++) {
+    for (let col = 0; col < 2; col++) {
+      const index = row * 2 + col;
+      if (index >= DRINKS.length) continue;
+      const item = DRINKS[index];
+      const active = state.selection.drinkId === item.id;
+      addButton(item.id, 'drink', item.name, item.accentColor, active, col, 2, row);
+    }
+  }
+
+  const serveRect: Rectangle = {
+    x: panelRect.x + padding,
+    y: height - padding - buttonHeight,
+    width: buttonWidth,
+    height: buttonHeight
+  };
+  buttons.push({
+    id: 'serve',
+    kind: 'serve',
+    label: state.cook?.done ? '評価待ち' : 'サーブする',
+    accent: '#ff8f00',
+    active: state.cook !== null && !state.cook.done,
+    rect: serveRect
+  });
+
+  const gaugeRect: Rectangle = {
+    x: padding,
+    y: height - CONFIG.ui.gaugeHeight - padding,
+    width: width - panelRect.width - padding * 2,
+    height: CONFIG.ui.gaugeHeight
+  };
+
+  const heatRect: Rectangle = {
+    x: gaugeRect.x,
+    y: gaugeRect.y - 40,
+    width: gaugeRect.width,
+    height: 24
+  };
+
+  return {
+    panelRect,
+    gaugeRect,
+    heatRect,
+    buttons
+  };
+}
+
+export function drawUI(ctx: CanvasRenderingContext2D, state: GameState, layout: UILayout): void {
+  drawPanel(ctx, layout.panelRect);
+  drawHeader(ctx, state, layout.panelRect);
+  drawButtons(ctx, layout.buttons);
+  drawGauge(ctx, state, layout.gaugeRect);
+  drawHeatBar(ctx, state, layout.heatRect);
+  drawFloatingText(ctx, state, layout.panelRect);
+}
+
+function drawPanel(ctx: CanvasRenderingContext2D, rect: Rectangle): void {
+  ctx.save();
+  ctx.fillStyle = 'rgba(24, 18, 12, 0.8)';
+  ctx.fillRect(rect.x, rect.y, rect.width, rect.height);
+  ctx.restore();
+}
+
+function drawHeader(ctx: CanvasRenderingContext2D, state: GameState, rect: Rectangle): void {
+  ctx.save();
+  ctx.fillStyle = '#ffe0b2';
+  ctx.font = 'bold 28px "Noto Sans JP", sans-serif';
+  ctx.textAlign = 'center';
+  ctx.fillText('FireTaste', rect.x + rect.width / 2, rect.y + 40);
+
+  ctx.font = '20px "Noto Sans JP", sans-serif';
+  ctx.textAlign = 'left';
+  ctx.fillText(`残り時間: ${state.timeRemaining.toFixed(0)}s`, rect.x + 20, rect.y + 80);
+  ctx.fillText(`総スコア: ${state.score}`, rect.x + 20, rect.y + 110);
+  ctx.restore();
+}
+
+function drawButtons(ctx: CanvasRenderingContext2D, buttons: UIButton[]): void {
+  buttons.forEach((button) => {
+    ctx.save();
+    ctx.fillStyle = button.active ? `${button.accent}cc` : 'rgba(255, 255, 255, 0.08)';
+    ctx.strokeStyle = button.active ? '#fff' : 'rgba(255,255,255,0.2)';
+    roundRect(ctx, button.rect.x, button.rect.y, button.rect.width, button.rect.height, 10);
+    ctx.fill();
+    ctx.lineWidth = 2;
+    ctx.stroke();
+    ctx.fillStyle = button.active ? '#1b1b1b' : '#fff';
+    ctx.font = '16px "Noto Sans JP", sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(button.label, button.rect.x + button.rect.width / 2, button.rect.y + button.rect.height / 2 + 1);
+    ctx.restore();
+  });
+}
+
+function drawGauge(ctx: CanvasRenderingContext2D, state: GameState, rect: Rectangle): void {
+  ctx.save();
+  ctx.fillStyle = 'rgba(15, 10, 6, 0.6)';
+  roundRect(ctx, rect.x, rect.y, rect.width, rect.height, 12);
+  ctx.fill();
+
+  const cook = state.cook;
+  if (cook) {
+    const ratioSurface = clamp((cook.surfaceTemp - 50) / 200, 0, 1);
+    const ratioCore = clamp((cook.coreTemp - 30) / 120, 0, 1);
+    const ratioChar = cook.char;
+
+    const barHeight = rect.height / 3 - 4;
+    drawGaugeBar(ctx, rect.x + 16, rect.y + 12, rect.width - 32, barHeight, ratioSurface, '#ffb74d', '表面温度');
+    drawGaugeBar(ctx, rect.x + 16, rect.y + 12 + barHeight + 6, rect.width - 32, barHeight, ratioCore, '#81d4fa', '中心温度');
+    drawGaugeBar(ctx, rect.x + 16, rect.y + 12 + (barHeight + 6) * 2, rect.width - 32, barHeight, ratioChar, '#8d6e63', '焦げ');
+  } else {
+    ctx.fillStyle = 'rgba(255,255,255,0.4)';
+    ctx.font = '18px "Noto Sans JP", sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('食材を選んで開始', rect.x + rect.width / 2, rect.y + rect.height / 2);
+  }
+  ctx.restore();
+}
+
+function drawHeatBar(ctx: CanvasRenderingContext2D, state: GameState, rect: Rectangle): void {
+  ctx.save();
+  ctx.fillStyle = 'rgba(15,10,6,0.6)';
+  roundRect(ctx, rect.x, rect.y, rect.width, rect.height, 12);
+  ctx.fill();
+
+  const heat = clamp(state.heatLevel / 260, 0, 1);
+  const barWidth = rect.width - 32;
+  const x = rect.x + 16;
+  const y = rect.y + rect.height / 2 - 10;
+  ctx.fillStyle = '#ff7043';
+  roundRect(ctx, x, y, barWidth * heat, 20, 10);
+  ctx.fill();
+
+  ctx.strokeStyle = 'rgba(255,255,255,0.3)';
+  roundRect(ctx, x, y, barWidth, 20, 10);
+  ctx.stroke();
+
+  ctx.fillStyle = '#fff';
+  ctx.font = '16px "Noto Sans JP", sans-serif';
+  ctx.textAlign = 'left';
+  ctx.fillText('火力', rect.x + 16, rect.y + 18);
+  ctx.restore();
+}
+
+function drawFloatingText(ctx: CanvasRenderingContext2D, state: GameState, panelRect: Rectangle): void {
+  if (!state.lastEvaluation) return;
+  const evalResult = state.lastEvaluation;
+  const baseY = panelRect.y + 150;
+  const t = clamp(evalResult.total / 40, 0, 1);
+  const color = `rgba(${Math.round(255 - 80 * t)}, ${Math.round(180 * t + 40)}, 120, 0.9)`;
+  ctx.save();
+  ctx.fillStyle = color;
+  ctx.font = '24px "Noto Sans JP", sans-serif';
+  ctx.textAlign = 'center';
+  ctx.fillText(`${evalResult.label} +${evalResult.total}`, panelRect.x + panelRect.width / 2, baseY);
+
+  ctx.fillStyle = 'rgba(255,255,255,0.6)';
+  ctx.font = '16px "Noto Sans JP", sans-serif';
+  ctx.textAlign = 'left';
+  const lines = [
+    `ベース: ${evalResult.baseScore}`,
+    `調味料: ${evalResult.seasoningBonus}`,
+    `飲み物: ${evalResult.drinkBonus}`
+  ];
+  lines.forEach((line, index) => {
+    ctx.fillText(line, panelRect.x + 24, baseY + 26 + index * 20);
+  });
+  if (evalResult.drink) {
+    ctx.fillText(`タイミング倍率: x${evalResult.timingMultiplier.toFixed(2)}`, panelRect.x + 24, baseY + 26 + lines.length * 20);
+  }
+  ctx.restore();
+}
+
+function drawGaugeBar(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  ratio: number,
+  color: string,
+  label: string
+): void {
+  ctx.save();
+  ctx.fillStyle = 'rgba(255,255,255,0.1)';
+  roundRect(ctx, x, y, width, height, 8);
+  ctx.fill();
+
+  const eased = easeOutCubic(ratio);
+  ctx.fillStyle = color;
+  roundRect(ctx, x, y, width * eased, height, 8);
+  ctx.fill();
+
+  ctx.fillStyle = '#fff';
+  ctx.font = '14px "Noto Sans JP", sans-serif';
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(label, x + 8, y + height / 2);
+  ctx.restore();
+}
+
+function roundRect(ctx: CanvasRenderingContext2D, x: number, y: number, width: number, height: number, radius: number): void {
+  ctx.beginPath();
+  ctx.moveTo(x + radius, y);
+  ctx.arcTo(x + width, y, x + width, y + height, radius);
+  ctx.arcTo(x + width, y + height, x, y + height, radius);
+  ctx.arcTo(x, y + height, x, y, radius);
+  ctx.arcTo(x, y, x + width, y, radius);
+  ctx.closePath();
+}
+
+export function findButtonAt(layout: UILayout, x: number, y: number): UIButton | null {
+  for (const button of layout.buttons) {
+    if (x >= button.rect.x && x <= button.rect.x + button.rect.width && y >= button.rect.y && y <= button.rect.y + button.rect.height) {
+      return button;
+    }
+  }
+  return null;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,40 @@
+// src/utils.ts
+// 汎用的なユーティリティ関数群。
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+export function smoothstep(edge0: number, edge1: number, x: number): number {
+  const t = clamp((x - edge0) / (edge1 - edge0), 0, 1);
+  return t * t * (3 - 2 * t);
+}
+
+export function randRange(min: number, max: number): number {
+  return Math.random() * (max - min) + min;
+}
+
+export function easeOutCubic(t: number): number {
+  const x = clamp(t, 0, 1);
+  return 1 - Math.pow(1 - x, 3);
+}
+
+export function mapRange(value: number, inMin: number, inMax: number, outMin: number, outMax: number): number {
+  const t = (value - inMin) / (inMax - inMin);
+  return lerp(outMin, outMax, clamp(t, 0, 1));
+}
+
+export interface Rectangle {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export function isPointInRect(px: number, py: number, rect: Rectangle): boolean {
+  return px >= rect.x && px <= rect.x + rect.width && py >= rect.y && py <= rect.y + rect.height;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "lib": ["ES2020", "DOM"],
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": []
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  server: {
+    host: true
+  }
+});


### PR DESCRIPTION
## Summary
- implement FireTaste canvas-based cooking mini-game with heat simulation, scoring, and UI panels
- add TypeScript modules for ingredients, heat modeling, fire particles, audio, and input handling
- render responsive 16:9 scene with HUD, gauges, and interactive buttons for serving, seasoning, and drinks

## Testing
- npm install *(fails: 403 Forbidden from registry in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d982cc148329a2cc867c63477d23