### PR TITLE
Add mock master maintenance web app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>マスタメンテ Web アプリ (Mock)</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>マスタメンテ Web アプリ</h1>
+      <p class="subtitle">DynamoDB マスタデータ管理のモックツール</p>
+    </header>
+
+    <main class="app-main">
+      <section class="panel" aria-labelledby="table-controls-title">
+        <div class="panel-header">
+          <h2 id="table-controls-title">テーブル選択と検索条件</h2>
+        </div>
+        <form id="table-form" class="form-grid">
+          <label class="form-field">
+            <span class="form-label">テーブル</span>
+            <select id="table-select" name="table" aria-label="対象テーブル">
+              <!-- オプションは JavaScript で挿入 -->
+            </select>
+          </label>
+
+          <fieldset class="conditions" aria-label="検索条件">
+            <legend>検索条件</legend>
+            <div id="condition-list" class="condition-list" role="list">
+              <!-- 条件行を挿入 -->
+            </div>
+            <div class="condition-actions">
+              <button type="button" id="add-condition" class="btn ghost">条件を追加</button>
+            </div>
+          </fieldset>
+
+          <div class="form-actions">
+            <button type="submit" class="btn primary">検索</button>
+            <button type="button" id="reset-conditions" class="btn ghost">条件クリア</button>
+          </div>
+        </form>
+      </section>
+
+      <section class="panel" aria-labelledby="json-input-title">
+        <div class="panel-header">
+          <h2 id="json-input-title">JSON データ入力</h2>
+          <p class="panel-subtitle">DynamoDB 形式の JSON をペーストし、読み込みボタンで反映します。</p>
+        </div>
+        <div class="json-input">
+          <textarea id="json-source" spellcheck="false" aria-label="JSON データ入力"></textarea>
+          <div class="json-actions">
+            <button type="button" id="load-json" class="btn secondary">JSON 読み込み</button>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel" aria-labelledby="result-title">
+        <div class="panel-header">
+          <h2 id="result-title">検索結果</h2>
+          <div class="panel-actions">
+            <button type="button" id="add-row" class="btn secondary">行を追加</button>
+            <button type="button" id="update-data" class="btn primary">更新</button>
+          </div>
+        </div>
+        <div id="feedback" role="status" aria-live="polite" class="feedback"></div>
+        <div class="table-wrapper">
+          <table id="result-table">
+            <thead></thead>
+            <tbody></tbody>
+          </table>
+          <div id="empty-state" class="empty-state" hidden>
+            <p>条件に一致するレコードがありません。</p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="app-footer">
+      <small>このアプリは DynamoDB マスタメンテナンスのモック実装です。</small>
+    </footer>
+
+    <script type="module" src="js/app.js"></script>
+  </body>
+</html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,419 @@
+const DEFAULT_DATA = {
+  Users: [
+    {
+      id: "0de76988-26ab-4a63-9e0b-8f0a36f3a807",
+      version: 3,
+      userName: "田中 太郎",
+      email: "taro.tanaka@example.com",
+      departmentId: "dep-001",
+      role: "admin",
+      isActive: true,
+      updatedAt: "2024-03-01T08:14:22Z",
+    },
+    {
+      id: "4c3f7d1b-cd06-4b42-8da0-350950e64564",
+      version: 1,
+      userName: "山田 花子",
+      email: "hanako.yamada@example.com",
+      departmentId: "dep-002",
+      role: "editor",
+      isActive: true,
+      updatedAt: "2024-04-12T10:03:45Z",
+    },
+    {
+      id: "851f64b9-3731-4e3c-9061-efbcb7dfaa43",
+      version: 5,
+      userName: "鈴木 次郎",
+      email: "jiro.suzuki@example.com",
+      departmentId: "dep-001",
+      role: "viewer",
+      isActive: false,
+      updatedAt: "2024-02-08T15:43:11Z",
+    },
+  ],
+  Departments: [
+    {
+      id: "dep-001",
+      version: 2,
+      name: "営業部",
+      manager: "田中 太郎",
+      updatedAt: "2024-03-31T00:00:00Z",
+    },
+    {
+      id: "dep-002",
+      version: 4,
+      name: "開発部",
+      manager: "山田 花子",
+      updatedAt: "2024-02-01T00:00:00Z",
+    },
+  ],
+};
+
+const KEYS = new Set(["id"]);
+
+const tableSelect = document.querySelector("#table-select");
+const conditionList = document.querySelector("#condition-list");
+const addConditionButton = document.querySelector("#add-condition");
+const resetConditionsButton = document.querySelector("#reset-conditions");
+const tableForm = document.querySelector("#table-form");
+const jsonSource = document.querySelector("#json-source");
+const loadJsonButton = document.querySelector("#load-json");
+const resultTable = document.querySelector("#result-table");
+const tableHead = resultTable.querySelector("thead");
+const tableBody = resultTable.querySelector("tbody");
+const emptyState = document.querySelector("#empty-state");
+const addRowButton = document.querySelector("#add-row");
+const updateButton = document.querySelector("#update-data");
+const feedback = document.querySelector("#feedback");
+
+let database = deepClone(DEFAULT_DATA);
+let activeTableName = Object.keys(database)[0] ?? "";
+let filteredRows = [];
+
+function init() {
+  jsonSource.value = JSON.stringify(database, null, 2);
+  populateTableOptions();
+  ensureAtLeastOneCondition();
+  renderTable();
+}
+
+function deepClone(source) {
+  if (typeof structuredClone === "function") {
+    return structuredClone(source);
+  }
+  return JSON.parse(JSON.stringify(source));
+}
+
+function generateId() {
+  const cryptoObj = globalThis.crypto;
+  if (cryptoObj && typeof cryptoObj.randomUUID === "function") {
+    return cryptoObj.randomUUID();
+  }
+  if (cryptoObj && typeof cryptoObj.getRandomValues === "function") {
+    const buffer = new Uint8Array(16);
+    cryptoObj.getRandomValues(buffer);
+    buffer[6] = (buffer[6] & 0x0f) | 0x40;
+    buffer[8] = (buffer[8] & 0x3f) | 0x80;
+    const hex = Array.from(buffer, (b) => b.toString(16).padStart(2, "0"));
+    return `${hex.slice(0, 4).join("")}-${hex.slice(4, 6).join("")}-${hex
+      .slice(6, 8)
+      .join("")}-${hex.slice(8, 10).join("")}-${hex.slice(10).join("")}`;
+  }
+  return `id-${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
+}
+
+function populateTableOptions() {
+  tableSelect.innerHTML = "";
+  const tableNames = Object.keys(database);
+
+  if (tableNames.length === 0) {
+    const option = document.createElement("option");
+    option.value = "";
+    option.textContent = "テーブルがありません";
+    tableSelect.append(option);
+    tableSelect.disabled = true;
+    return;
+  }
+
+  tableSelect.disabled = false;
+
+  for (const tableName of tableNames) {
+    const option = document.createElement("option");
+    option.value = tableName;
+    option.textContent = tableName;
+    option.selected = tableName === activeTableName;
+    tableSelect.append(option);
+  }
+
+  if (!tableNames.includes(activeTableName)) {
+    activeTableName = tableNames[0];
+    tableSelect.value = activeTableName;
+  }
+}
+
+function ensureAtLeastOneCondition() {
+  if (conditionList.children.length === 0) {
+    addConditionRow();
+  }
+}
+
+function addConditionRow(initial = { attribute: "", value: "" }) {
+  const row = document.createElement("div");
+  row.className = "condition-row";
+  row.setAttribute("role", "listitem");
+
+  const attributeInput = document.createElement("input");
+  attributeInput.type = "text";
+  attributeInput.placeholder = "属性名";
+  attributeInput.value = initial.attribute;
+  attributeInput.setAttribute("aria-label", "属性名");
+
+  const valueInput = document.createElement("input");
+  valueInput.type = "text";
+  valueInput.placeholder = "値";
+  valueInput.value = initial.value;
+  valueInput.setAttribute("aria-label", "値");
+
+  const removeButton = document.createElement("button");
+  removeButton.type = "button";
+  removeButton.className = "btn ghost";
+  removeButton.textContent = "削除";
+  removeButton.addEventListener("click", () => {
+    row.remove();
+    if (conditionList.children.length === 0) {
+      ensureAtLeastOneCondition();
+    }
+  });
+
+  row.append(attributeInput, valueInput, removeButton);
+  conditionList.append(row);
+}
+
+function readConditions() {
+  const rows = Array.from(conditionList.children);
+  return rows
+    .map((row) => {
+      const [attributeInput, valueInput] = row.querySelectorAll("input");
+      const attribute = attributeInput.value.trim();
+      const value = valueInput.value.trim();
+      if (!attribute || !value) {
+        return null;
+      }
+      return { attribute, value };
+    })
+    .filter(Boolean);
+}
+
+function parseJsonSource() {
+  try {
+    const parsed = JSON.parse(jsonSource.value);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("ルートはオブジェクトである必要があります");
+    }
+    const normalized = {};
+    for (const [tableName, rows] of Object.entries(parsed)) {
+      if (!Array.isArray(rows)) {
+        throw new Error(`${tableName} は配列である必要があります`);
+      }
+      normalized[tableName] = rows.map((row) => ({ ...row }));
+    }
+    return normalized;
+  } catch (error) {
+    showFeedback(error.message, "error");
+    return null;
+  }
+}
+
+function renderTable() {
+  const rows = database[activeTableName] ?? [];
+  const columns = new Set();
+  rows.forEach((row) => {
+    Object.keys(row).forEach((key) => columns.add(key));
+  });
+  columns.add("id");
+  columns.add("version");
+
+  const columnList = Array.from(columns).sort((a, b) => {
+    const aIsKey = KEYS.has(a);
+    const bIsKey = KEYS.has(b);
+    if (aIsKey && !bIsKey) return -1;
+    if (!aIsKey && bIsKey) return 1;
+    return a.localeCompare(b);
+  });
+
+  tableHead.innerHTML = "";
+  const headerRow = document.createElement("tr");
+  for (const column of columnList) {
+    const th = document.createElement("th");
+    th.textContent = column;
+    headerRow.append(th);
+  }
+  tableHead.append(headerRow);
+
+  tableBody.innerHTML = "";
+  filteredRows = [];
+
+  if (rows.length === 0) {
+    emptyState.hidden = false;
+    return;
+  }
+
+  filteredRows = applyFilters(rows, readConditions());
+  emptyState.hidden = filteredRows.length > 0;
+
+  for (const rowData of filteredRows) {
+    const tr = document.createElement("tr");
+    for (const column of columnList) {
+      const td = document.createElement("td");
+      if (KEYS.has(column)) {
+        td.textContent = rowData[column] ?? "";
+      } else {
+        const input = document.createElement("input");
+        input.value = valueToString(rowData[column]);
+        input.dataset.column = column;
+        input.dataset.id = rowData.id;
+        input.addEventListener("change", handleCellChange);
+        td.append(input);
+      }
+      tr.append(td);
+    }
+    tableBody.append(tr);
+  }
+
+  if (filteredRows.length === 0) {
+    emptyState.hidden = false;
+  }
+}
+
+function valueToString(value) {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+function handleCellChange(event) {
+  const input = event.target;
+  const { id, column } = input.dataset;
+  const tableRows = database[activeTableName];
+  const target = tableRows.find((row) => row.id === id);
+  if (!target) return;
+
+  target[column] = parseInputValue(input.value, target[column]);
+  showFeedback(`id: ${id} の ${column} を更新しました`, "success");
+  jsonSource.value = JSON.stringify(database, null, 2);
+}
+
+function parseInputValue(rawValue, previousValue) {
+  const trimmed = rawValue.trim();
+  if (trimmed === "") {
+    return "";
+  }
+
+  if (typeof previousValue === "number") {
+    const num = Number(trimmed);
+    if (!Number.isNaN(num)) {
+      return num;
+    }
+  }
+
+  if (typeof previousValue === "boolean") {
+    if (["true", "false"].includes(trimmed.toLowerCase())) {
+      return trimmed.toLowerCase() === "true";
+    }
+  }
+
+  if (isIsoDate(previousValue) && !Number.isNaN(Date.parse(trimmed))) {
+    return new Date(trimmed).toISOString();
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (typeof parsed === "object") {
+      return parsed;
+    }
+  } catch (error) {
+    // 無効な JSON は無視
+  }
+
+  return trimmed;
+}
+
+function isIsoDate(value) {
+  return typeof value === "string" && /\d{4}-\d{2}-\d{2}T/.test(value);
+}
+
+function applyFilters(rows, conditions) {
+  if (conditions.length === 0) return [...rows];
+
+  return rows.filter((row) =>
+    conditions.every(({ attribute, value }) => {
+      if (!(attribute in row)) return false;
+      const rowValue = row[attribute];
+      if (typeof rowValue === "object") {
+        return JSON.stringify(rowValue) === value;
+      }
+      return String(rowValue) === value;
+    })
+  );
+}
+
+function addRow() {
+  const templateRow = database[activeTableName]?.[0] ?? {};
+  const newRow = {};
+
+  const columns = new Set(Object.keys(templateRow));
+  columns.add("id");
+  columns.add("version");
+
+  for (const column of columns) {
+    if (column === "id") {
+      newRow.id = generateId();
+    } else if (column === "version") {
+      newRow.version = 1;
+    } else {
+      newRow[column] = "";
+    }
+  }
+
+  if (!database[activeTableName]) {
+    database[activeTableName] = [];
+  }
+
+  database[activeTableName].unshift(newRow);
+  jsonSource.value = JSON.stringify(database, null, 2);
+  renderTable();
+  showFeedback(`新しいレコード (id: ${newRow.id}) を追加しました`, "success");
+}
+
+function updateData() {
+  const rowsAffected = filteredRows.length;
+  const timestamp = new Date().toLocaleString("ja-JP", {
+    hour12: false,
+  });
+  showFeedback(
+    `${activeTableName} テーブルを更新リクエストしました (対象件数: ${rowsAffected}) - ${timestamp}`,
+    "success"
+  );
+}
+
+function showFeedback(message, variant = "") {
+  feedback.textContent = message;
+  feedback.className = `feedback ${variant}`.trim();
+}
+
+function handleSearch(event) {
+  event.preventDefault();
+  renderTable();
+  showFeedback("検索条件を適用しました", "success");
+}
+
+function handleTableChange(event) {
+  activeTableName = event.target.value;
+  renderTable();
+  showFeedback(`${activeTableName} を選択しました`, "success");
+}
+
+function handleJsonLoad() {
+  const parsed = parseJsonSource();
+  if (!parsed) return;
+  database = parsed;
+  activeTableName = Object.keys(database)[0] ?? "";
+  populateTableOptions();
+  renderTable();
+  showFeedback("JSON データを読み込みました", "success");
+}
+
+addConditionButton.addEventListener("click", () => addConditionRow());
+resetConditionsButton.addEventListener("click", () => {
+  conditionList.innerHTML = "";
+  ensureAtLeastOneCondition();
+});
+tableForm.addEventListener("submit", handleSearch);
+tableSelect.addEventListener("change", handleTableChange);
+loadJsonButton.addEventListener("click", handleJsonLoad);
+addRowButton.addEventListener("click", addRow);
+updateButton.addEventListener("click", updateData);
+
+document.addEventListener("DOMContentLoaded", init);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,334 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Segoe UI", "Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN", Meiryo, sans-serif;
+  --surface: #ffffff;
+  --surface-alt: #f7f7f9;
+  --border: #d9dce3;
+  --border-strong: #8b90a0;
+  --primary: #2962ff;
+  --primary-dark: #1742a1;
+  --primary-contrast: #ffffff;
+  --text-main: #1d2433;
+  --text-subtle: #4a5162;
+  --shadow: 0 12px 32px rgba(15, 23, 42, 0.12);
+  --radius: 12px;
+  background-color: #eef1f6;
+  color: var(--text-main);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  padding: 32px clamp(16px, 5vw, 48px) 16px;
+  background: linear-gradient(120deg, #2f5ef7, #1bb7f0);
+  color: white;
+  text-align: center;
+  box-shadow: var(--shadow);
+}
+
+.app-header h1 {
+  margin: 0 0 8px;
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  letter-spacing: 0.05em;
+}
+
+.subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  opacity: 0.85;
+}
+
+.app-main {
+  flex: 1;
+  width: min(1200px, 94vw);
+  margin: -48px auto 32px;
+  display: grid;
+  gap: 24px;
+}
+
+.panel {
+  background: var(--surface);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: clamp(16px, 3vw, 24px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.panel-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: var(--text-main);
+}
+
+.panel-subtitle {
+  margin: 0;
+  color: var(--text-subtle);
+  font-size: 0.9rem;
+}
+
+.panel-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.form-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.form-label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+select,
+input,
+textarea {
+  font: inherit;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface-alt);
+  color: inherit;
+}
+
+textarea {
+  min-height: 180px;
+  resize: vertical;
+  line-height: 1.5;
+}
+
+.btn {
+  font: inherit;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  padding: 10px 18px;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.btn:focus-visible {
+  outline: 3px solid rgba(41, 98, 255, 0.45);
+  outline-offset: 2px;
+}
+
+.btn.primary {
+  background: var(--primary);
+  color: var(--primary-contrast);
+  box-shadow: 0 6px 18px rgba(41, 98, 255, 0.25);
+}
+
+.btn.primary:hover {
+  background: var(--primary-dark);
+  transform: translateY(-1px);
+}
+
+.btn.secondary {
+  background: var(--surface-alt);
+  border-color: var(--border);
+}
+
+.btn.ghost {
+  background: transparent;
+  border-color: var(--border);
+}
+
+.btn.secondary:hover,
+.btn.ghost:hover {
+  border-color: var(--primary);
+  color: var(--primary);
+}
+
+.conditions {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 16px;
+  background: var(--surface-alt);
+  display: grid;
+  gap: 12px;
+}
+
+.conditions legend {
+  font-weight: 600;
+  padding: 0 4px;
+}
+
+.condition-list {
+  display: grid;
+  gap: 12px;
+}
+
+.condition-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)) auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.condition-row input {
+  width: 100%;
+}
+
+.condition-row button {
+  white-space: nowrap;
+}
+
+.condition-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.form-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.json-input {
+  display: grid;
+  gap: 12px;
+}
+
+.json-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.table-wrapper {
+  position: relative;
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 400px;
+}
+
+thead {
+  background: var(--surface-alt);
+}
+
+thead th,
+tbody td {
+  border: 1px solid var(--border);
+  padding: 10px 12px;
+  text-align: left;
+  font-size: 0.95rem;
+}
+
+thead th {
+  font-weight: 600;
+  color: var(--text-subtle);
+}
+
+tbody tr:nth-child(even) td {
+  background: rgba(41, 98, 255, 0.04);
+}
+
+tbody input {
+  width: 100%;
+  border-radius: 6px;
+  padding: 8px 10px;
+  border: 1px solid transparent;
+  background: transparent;
+}
+
+tbody input:focus {
+  border-color: var(--primary);
+  background: var(--surface);
+}
+
+.empty-state {
+  text-align: center;
+  padding: 24px;
+  color: var(--text-subtle);
+}
+
+.feedback {
+  min-height: 1.5em;
+  font-size: 0.95rem;
+  color: var(--text-subtle);
+}
+
+.feedback.success {
+  color: #0f9d58;
+}
+
+.feedback.error {
+  color: #d93025;
+}
+
+.app-footer {
+  padding: 24px 16px;
+  text-align: center;
+  color: var(--text-subtle);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 768px) {
+  .app-main {
+    margin-top: -32px;
+  }
+
+  .panel {
+    padding: 16px;
+  }
+
+  table {
+    font-size: 0.9rem;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --surface: #111827;
+    --surface-alt: #1f2937;
+    --border: #334155;
+    --border-strong: #475569;
+    --primary: #4f83ff;
+    --primary-dark: #345ad6;
+    --text-main: #e5e7eb;
+    --text-subtle: #9ca3af;
+    background-color: #0f172a;
+  }
+
+  .app-header {
+    background: linear-gradient(120deg, #1e3a8a, #0ea5e9);
+  }
+
+  textarea,
+  select,
+  input {
+    background: rgba(15, 23, 42, 0.6);
+  }
+
+  tbody tr:nth-child(even) td {
+    background: rgba(79, 131, 255, 0.08);
+  }
+}


### PR DESCRIPTION
## Summary
- build a vanilla HTML/CSS/JS mock interface for maintaining DynamoDB-style master data tables
- implement table selection, filtering, row editing, and mock update workflow
- support JSON data input to reload tables plus responsive layout and dark mode styling

## Testing
- Manual UI verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e5b73da6588329806aa8bf5e10a1ed