### PR TITLE
Add daily menu management dashboard mock

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,587 @@
+const TOTAL_SLOTS = 10;
+const STORAGE_PREFIX = 'daily:';
+const DESCRIPTION_LIMIT = 1000;
+
+// TODO: replace with real API
+const api = {
+  loadByDate(date) {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        const raw = localStorage.getItem(`${STORAGE_PREFIX}${date}`);
+        resolve(raw ? JSON.parse(raw) : null);
+      }, 320);
+    });
+  },
+  saveDraft(date, payload) {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        localStorage.setItem(`${STORAGE_PREFIX}${date}`, JSON.stringify(payload));
+        resolve(payload);
+      }, 420);
+    });
+  },
+  publish(date, payload) {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        localStorage.setItem(`${STORAGE_PREFIX}${date}`, JSON.stringify(payload));
+        resolve(payload);
+      }, 420);
+    });
+  },
+  copyFromDate(date) {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        const raw = localStorage.getItem(`${STORAGE_PREFIX}${date}`);
+        resolve(raw ? JSON.parse(raw) : null);
+      }, 320);
+    });
+  }
+};
+
+const state = {
+  date: '',
+  status: 'draft',
+  lastUpdated: null,
+  items: new Map(),
+  previews: new Map(),
+  activeCard: null
+};
+
+const elements = {};
+
+document.addEventListener('DOMContentLoaded', () => {
+  cacheElements();
+  renderCards();
+  bindEvents();
+  initializeDate();
+});
+
+function cacheElements() {
+  elements.app = document.getElementById('app');
+  elements.dateInput = document.getElementById('menu-date');
+  elements.themeSwitch = document.getElementById('theme-switch');
+  elements.cardGrid = document.querySelector('.card-grid');
+  elements.statusBadge = document.getElementById('status-badge');
+  elements.lastUpdated = document.getElementById('last-updated');
+  elements.toastContainer = document.querySelector('.toast-container');
+  elements.progressBar = document.getElementById('progress-bar');
+  elements.progressFill = elements.progressBar.querySelector('.progress-fill');
+  elements.loadButton = document.getElementById('load-button');
+  elements.copyButton = document.getElementById('copy-button');
+  elements.draftButton = document.getElementById('draft-button');
+  elements.publishButton = document.getElementById('publish-button');
+  elements.helpButton = document.getElementById('help-button');
+  elements.helpModal = document.getElementById('help-modal');
+  elements.helpClose = document.getElementById('help-close');
+  elements.warningModal = document.getElementById('warning-modal');
+  elements.warningList = document.getElementById('warning-list');
+  elements.warningCancel = document.getElementById('warning-cancel');
+  elements.warningContinue = document.getElementById('warning-continue');
+  elements.skeletonOverlay = document.getElementById('skeleton-overlay');
+}
+
+function renderCards() {
+  const template = document.getElementById('card-template');
+  elements.cardGrid.innerHTML = '';
+  elements.cardGrid.appendChild(elements.skeletonOverlay);
+
+  for (let i = 1; i <= TOTAL_SLOTS; i += 1) {
+    const node = template.content.cloneNode(true);
+    const article = node.querySelector('.menu-card');
+    article.dataset.slot = i;
+    node.querySelector('.slot-number').textContent = i.toString().padStart(2, '0');
+
+    const nameInput = node.querySelector('input[name="name"]');
+    const descTextarea = node.querySelector('textarea[name="desc"]');
+    const altInput = node.querySelector('input[name="alt"]');
+    const dropzone = node.querySelector('[data-dropzone]');
+    const fileInput = node.querySelector('.file-input');
+    const previewImg = node.querySelector('.preview img');
+    const previewPlaceholder = node.querySelector('.preview-placeholder');
+    const fileNameLabel = node.querySelector('.file-name');
+    const clearButton = node.querySelector('[data-clear]');
+    const counter = node.querySelector('.char-counter .count');
+
+    nameInput.id = `name-${i}`;
+    descTextarea.id = `desc-${i}`;
+    altInput.id = `alt-${i}`;
+    nameInput.closest('.field').querySelector('label').setAttribute('for', nameInput.id);
+    descTextarea.closest('.field').querySelector('label').setAttribute('for', descTextarea.id);
+    altInput.closest('.field').querySelector('label').setAttribute('for', altInput.id);
+
+    descTextarea.addEventListener('input', () => {
+      const remaining = DESCRIPTION_LIMIT - descTextarea.value.length;
+      counter.textContent = remaining.toString();
+    });
+
+    const updateState = () => {
+      const slotState = state.items.get(i) || {};
+      state.items.set(i, {
+        slot: i,
+        name: nameInput.value.trim(),
+        desc: descTextarea.value.trim(),
+        alt: altInput.value.trim(),
+        hasImage: slotState.hasImage || false,
+        imageName: slotState.imageName || ''
+      });
+    };
+
+    nameInput.addEventListener('input', updateState);
+    descTextarea.addEventListener('input', updateState);
+    altInput.addEventListener('input', updateState);
+
+    fileInput.addEventListener('change', (event) => {
+      const file = event.target.files[0];
+      handleFile(file, { slot: i, previewImg, previewPlaceholder, fileNameLabel });
+    });
+
+    dropzone.addEventListener('click', () => fileInput.click());
+    dropzone.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        fileInput.click();
+      }
+    });
+    dropzone.addEventListener('dragover', (event) => {
+      event.preventDefault();
+      dropzone.classList.add('drag-over');
+    });
+    dropzone.addEventListener('dragleave', () => {
+      dropzone.classList.remove('drag-over');
+    });
+    dropzone.addEventListener('drop', (event) => {
+      event.preventDefault();
+      dropzone.classList.remove('drag-over');
+      const file = event.dataTransfer.files[0];
+      handleFile(file, { slot: i, previewImg, previewPlaceholder, fileNameLabel });
+    });
+
+    clearButton.addEventListener('click', () => {
+      clearCard(article);
+    });
+
+    article.addEventListener('focusin', () => {
+      state.activeCard = article;
+    });
+
+    elements.cardGrid.appendChild(node);
+  }
+}
+
+function bindEvents() {
+  elements.dateInput.addEventListener('change', () => {
+    state.date = elements.dateInput.value;
+    loadData(state.date);
+  });
+
+  elements.cardGrid.addEventListener('focusout', gatherCardState);
+
+  elements.loadButton.addEventListener('click', () => {
+    loadData(state.date);
+  });
+
+  elements.copyButton.addEventListener('click', () => {
+    copyFromPreviousDay();
+  });
+
+  elements.draftButton.addEventListener('click', async () => {
+    await saveDraft();
+  });
+
+  elements.publishButton.addEventListener('click', async () => {
+    await attemptPublish();
+  });
+
+  elements.themeSwitch.addEventListener('change', toggleTheme);
+
+  elements.helpButton.addEventListener('click', () => openModal(elements.helpModal));
+  elements.helpClose.addEventListener('click', () => closeModal(elements.helpModal, elements.helpButton));
+  elements.helpModal.addEventListener('click', (event) => {
+    if (event.target === elements.helpModal) closeModal(elements.helpModal, elements.helpButton);
+  });
+
+  elements.warningCancel.addEventListener('click', () => closeModal(elements.warningModal, elements.publishButton));
+  elements.warningContinue.addEventListener('click', async () => {
+    closeModal(elements.warningModal, elements.publishButton);
+    await publish();
+  });
+  elements.warningModal.addEventListener('click', (event) => {
+    if (event.target === elements.warningModal) closeModal(elements.warningModal, elements.publishButton);
+  });
+
+  document.addEventListener('keydown', handleShortcuts);
+}
+
+function initializeDate() {
+  const today = new Date();
+  const dateString = today.toISOString().slice(0, 10);
+  elements.dateInput.value = dateString;
+  state.date = dateString;
+  loadData(state.date);
+
+  const storedTheme = localStorage.getItem('menu-theme');
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const theme = storedTheme || (prefersDark ? 'dark' : 'light');
+  elements.themeSwitch.checked = theme === 'dark';
+  applyTheme(theme);
+}
+
+function loadData(date) {
+  if (!date) return;
+  startSkeleton();
+  api.loadByDate(date).then((data) => {
+    resetCards();
+    if (data) {
+      const items = Array.isArray(data.items) ? data.items : [];
+      state.status = data.status;
+      state.lastUpdated = data.lastUpdated;
+      state.items = new Map(items.map((item) => [item.slot, item]));
+    } else {
+      state.status = 'draft';
+      state.lastUpdated = null;
+      state.items = new Map();
+    }
+    state.previews = new Map();
+    populateCards();
+    updateStatusBadge();
+    stopSkeleton();
+  });
+}
+
+function populateCards() {
+  const cards = elements.cardGrid.querySelectorAll('.menu-card');
+  cards.forEach((card) => {
+    const slot = Number(card.dataset.slot);
+    const item = state.items.get(slot);
+    const nameInput = card.querySelector('input[name="name"]');
+    const descTextarea = card.querySelector('textarea[name="desc"]');
+    const altInput = card.querySelector('input[name="alt"]');
+    const previewImg = card.querySelector('.preview img');
+    const placeholder = card.querySelector('.preview-placeholder');
+    const fileLabel = card.querySelector('.file-name');
+    const counter = card.querySelector('.char-counter .count');
+
+    if (item) {
+      nameInput.value = item.name || '';
+      descTextarea.value = item.desc || '';
+      altInput.value = item.alt || '';
+      fileLabel.textContent = item.hasImage ? (item.imageName || '画像あり') : '画像未選択';
+    } else {
+      nameInput.value = '';
+      descTextarea.value = '';
+      altInput.value = '';
+      fileLabel.textContent = '画像未選択';
+    }
+
+    counter.textContent = (DESCRIPTION_LIMIT - descTextarea.value.length).toString();
+    previewImg.src = '';
+    previewImg.style.display = 'none';
+    placeholder.style.display = 'flex';
+  });
+
+  const timestamp = state.lastUpdated ? new Date(state.lastUpdated) : null;
+  elements.lastUpdated.textContent = timestamp ? `保存済み ${formatTime(timestamp)}` : '保存済み --:--';
+}
+
+function resetCards() {
+  const cards = elements.cardGrid.querySelectorAll('.menu-card');
+  cards.forEach((card) => {
+    card.querySelector('input[name="name"]').value = '';
+    card.querySelector('textarea[name="desc"]').value = '';
+    card.querySelector('input[name="alt"]').value = '';
+    card.querySelector('.preview img').style.display = 'none';
+    card.querySelector('.preview-placeholder').style.display = 'flex';
+    card.querySelector('.file-name').textContent = '画像未選択';
+    card.querySelector('.char-counter .count').textContent = DESCRIPTION_LIMIT.toString();
+  });
+}
+
+function clearCard(card) {
+  const slot = Number(card.dataset.slot);
+  card.querySelector('input[name="name"]').value = '';
+  card.querySelector('textarea[name="desc"]').value = '';
+  card.querySelector('input[name="alt"]').value = '';
+  const fileInput = card.querySelector('.file-input');
+  if (fileInput) {
+    fileInput.value = '';
+  }
+  const previewImg = card.querySelector('.preview img');
+  previewImg.src = '';
+  previewImg.style.display = 'none';
+  card.querySelector('.preview-placeholder').style.display = 'flex';
+  card.querySelector('.file-name').textContent = '画像未選択';
+  card.querySelector('.char-counter .count').textContent = DESCRIPTION_LIMIT.toString();
+  state.items.delete(slot);
+  state.previews.delete(slot);
+}
+
+function handleFile(file, { slot, previewImg, previewPlaceholder, fileNameLabel }) {
+  if (!file) return;
+  const validTypes = ['image/jpeg', 'image/png', 'image/webp'];
+  if (!validTypes.includes(file.type)) {
+    showToast('jpg / png / webp 形式のみアップロードできます', 'error');
+    return;
+  }
+
+  const reader = new FileReader();
+  reader.onload = (event) => {
+    previewImg.src = event.target.result;
+    previewImg.style.display = 'block';
+    previewPlaceholder.style.display = 'none';
+    fileNameLabel.textContent = file.name;
+    state.previews.set(slot, event.target.result);
+    const slotState = state.items.get(slot) || { slot };
+    state.items.set(slot, {
+      ...slotState,
+      slot,
+      name: slotState.name || '',
+      desc: slotState.desc || '',
+      alt: slotState.alt || '',
+      hasImage: true,
+      imageName: file.name
+    });
+  };
+
+  reader.readAsDataURL(file);
+}
+
+function toggleTheme(event) {
+  applyTheme(event.target.checked ? 'dark' : 'light');
+}
+
+function applyTheme(theme) {
+  document.documentElement.setAttribute('data-theme', theme);
+  localStorage.setItem('menu-theme', theme);
+}
+
+function updateStatusBadge() {
+  elements.statusBadge.dataset.status = state.status;
+  elements.statusBadge.textContent = state.status === 'published' ? '公開済み' : '下書き';
+}
+
+async function saveDraft() {
+  const payload = buildPayload('draft');
+  await animateProgress(async () => {
+    await api.saveDraft(state.date, payload);
+  });
+  state.status = 'draft';
+  state.lastUpdated = payload.lastUpdated;
+  updateStatusBadge();
+  elements.lastUpdated.textContent = `保存済み ${formatTime(new Date(state.lastUpdated))}`;
+  showToast('下書きを保存しました', 'success');
+}
+
+async function attemptPublish() {
+  const missing = validateBeforePublish();
+  if (missing.length) {
+    elements.warningList.innerHTML = '';
+    missing.forEach((slot) => {
+      const li = document.createElement('li');
+      li.textContent = `スロット ${slot.toString().padStart(2, '0')}`;
+      elements.warningList.appendChild(li);
+    });
+    openModal(elements.warningModal);
+    return;
+  }
+  await publish();
+}
+
+async function publish() {
+  const payload = buildPayload('published');
+  await animateProgress(async () => {
+    await api.publish(state.date, payload);
+  });
+  state.status = 'published';
+  state.lastUpdated = payload.lastUpdated;
+  updateStatusBadge();
+  elements.lastUpdated.textContent = `保存済み ${formatTime(new Date(state.lastUpdated))}`;
+  showToast('公開が完了しました', 'success');
+}
+
+function buildPayload(status) {
+  gatherCardState();
+  const items = [];
+  for (let i = 1; i <= TOTAL_SLOTS; i += 1) {
+    const item = state.items.get(i);
+    if (!item) continue;
+    const hasContent = item.name || item.desc || item.alt || item.hasImage;
+    if (!hasContent) continue;
+    items.push({
+      slot: i,
+      name: item.name || '',
+      desc: item.desc || '',
+      alt: item.alt || '',
+      hasImage: Boolean(item.hasImage),
+      imageName: item.imageName || ''
+    });
+  }
+  const now = toLocalISOString();
+  return {
+    date: state.date,
+    status,
+    lastUpdated: now,
+    items
+  };
+}
+
+function validateBeforePublish() {
+  const missing = [];
+  for (let i = 1; i <= TOTAL_SLOTS; i += 1) {
+    const item = state.items.get(i);
+    const hasName = item && item.name && item.name.length > 0;
+    const hasImage = item && item.hasImage;
+    if (!hasName || !hasImage) {
+      missing.push(i);
+    }
+  }
+  return missing;
+}
+
+function showToast(message, variant = 'success') {
+  const toast = document.createElement('div');
+  toast.className = `toast ${variant}`;
+  toast.textContent = message;
+  elements.toastContainer.appendChild(toast);
+  setTimeout(() => {
+    toast.classList.add('fade-out');
+    setTimeout(() => toast.remove(), 300);
+  }, 3000);
+}
+
+function openModal(modal) {
+  modal.hidden = false;
+  const focusable = modal.querySelector('button, [href], input, textarea');
+  if (focusable) {
+    focusable.focus();
+  }
+}
+
+function closeModal(modal, focusTarget = elements.helpButton) {
+  modal.hidden = true;
+  if (focusTarget) {
+    focusTarget.focus();
+  }
+}
+
+function startSkeleton() {
+  elements.cardGrid.classList.add('loading');
+}
+
+function stopSkeleton() {
+  elements.cardGrid.classList.remove('loading');
+}
+
+function animateProgress(callback) {
+  elements.progressBar.hidden = false;
+  elements.progressFill.style.width = '10%';
+  elements.progressBar.setAttribute('aria-valuenow', '10');
+  return new Promise((resolve) => {
+    setTimeout(async () => {
+      elements.progressFill.style.width = '70%';
+      elements.progressBar.setAttribute('aria-valuenow', '70');
+      await callback();
+      elements.progressFill.style.width = '100%';
+      elements.progressBar.setAttribute('aria-valuenow', '100');
+      setTimeout(() => {
+        elements.progressBar.hidden = true;
+        elements.progressFill.style.width = '0%';
+        elements.progressBar.setAttribute('aria-valuenow', '0');
+        resolve();
+      }, 300);
+    }, 150);
+  });
+}
+
+function copyFromPreviousDay() {
+  const currentDate = new Date(state.date);
+  if (Number.isNaN(currentDate.valueOf())) return;
+  const previous = new Date(currentDate);
+  previous.setDate(previous.getDate() - 1);
+  const prevKey = previous.toISOString().slice(0, 10);
+  api.copyFromDate(prevKey).then((data) => {
+    if (!data) {
+      showToast('前日のデータはありません', 'warning');
+      return;
+    }
+    const items = Array.isArray(data.items) ? data.items : [];
+    state.items = new Map(items.map((item) => [item.slot, { ...item, hasImage: false, imageName: '' }]));
+    state.previews = new Map();
+    state.status = 'draft';
+    state.lastUpdated = toLocalISOString();
+    populateCards();
+    updateStatusBadge();
+    elements.lastUpdated.textContent = `保存済み ${formatTime(new Date(state.lastUpdated))}`;
+    showToast('前日の内容をコピーしました（画像は再設定してください）', 'success');
+  });
+}
+
+function handleShortcuts(event) {
+  const isCtrl = event.ctrlKey || event.metaKey;
+  if (isCtrl && event.key.toLowerCase() === 's') {
+    event.preventDefault();
+    saveDraft();
+  }
+  if (isCtrl && event.key === 'Enter') {
+    event.preventDefault();
+    attemptPublish();
+  }
+  if (event.key === 'Escape') {
+    if (state.activeCard) {
+      clearCard(state.activeCard);
+    }
+  }
+}
+
+function formatTime(date) {
+  const hour = date.getHours().toString().padStart(2, '0');
+  const minute = date.getMinutes().toString().padStart(2, '0');
+  return `${hour}:${minute}`;
+}
+
+function toLocalISOString(date = new Date()) {
+  const pad = (number) => number.toString().padStart(2, '0');
+  const year = date.getFullYear();
+  const month = pad(date.getMonth() + 1);
+  const day = pad(date.getDate());
+  const hours = pad(date.getHours());
+  const minutes = pad(date.getMinutes());
+  const seconds = pad(date.getSeconds());
+  const offsetMinutes = -date.getTimezoneOffset();
+  const sign = offsetMinutes >= 0 ? '+' : '-';
+  const offsetHour = pad(Math.floor(Math.abs(offsetMinutes) / 60));
+  const offsetMinute = pad(Math.abs(offsetMinutes) % 60);
+  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}${sign}${offsetHour}:${offsetMinute}`;
+}
+
+function gatherCardState() {
+  const cards = elements.cardGrid.querySelectorAll('.menu-card');
+  cards.forEach((card) => {
+    const slot = Number(card.dataset.slot);
+    const name = card.querySelector('input[name="name"]').value.trim();
+    const desc = card.querySelector('textarea[name="desc"]').value.trim();
+    const alt = card.querySelector('input[name="alt"]').value.trim();
+    const hasPreview = state.previews.has(slot);
+    const fileLabel = card.querySelector('.file-name').textContent;
+    const hasImage = hasPreview || (state.items.get(slot)?.hasImage ?? false);
+    state.items.set(slot, {
+      slot,
+      name,
+      desc,
+      alt,
+      hasImage,
+      imageName: hasImage ? (state.items.get(slot)?.imageName || fileLabel || '') : ''
+    });
+  });
+}
+
+function openHelp() {
+  openModal(elements.helpModal);
+}
+
+// expose for debugging
+window.dailyMenuApp = {
+  state,
+  saveDraft,
+  attemptPublish,
+  openHelp
+};

--- a/index.html
+++ b/index.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="ja" data-theme="light">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>当日のメニュー管理</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="app" id="app">
+    <header class="app-header">
+      <div class="title-block">
+        <h1>当日のメニュー管理</h1>
+        <p class="subtitle">本日の提供メニューを洗練されたカードで管理します</p>
+      </div>
+      <div class="header-controls">
+        <label class="date-picker">
+          <span>対象日</span>
+          <input type="date" id="menu-date" aria-label="対象日を選択" />
+        </label>
+        <label class="theme-toggle" for="theme-switch">
+          <span class="toggle-label">ライト / ダーク</span>
+          <input type="checkbox" id="theme-switch" aria-label="テーマを切り替え" />
+          <span class="switch-track" aria-hidden="true">
+            <span class="switch-thumb"></span>
+          </span>
+        </label>
+        <button class="icon-button" id="help-button" type="button" aria-haspopup="dialog" aria-controls="help-modal" title="操作ガイドを表示">
+          <span aria-hidden="true">?</span>
+          <span class="sr-only">操作ガイド</span>
+        </button>
+      </div>
+    </header>
+
+    <main>
+      <section class="toolbar" aria-label="操作ツールバー">
+        <div class="toolbar-left">
+          <button type="button" class="ghost" id="load-button">読み込み</button>
+          <button type="button" class="ghost" id="copy-button">前日からコピー</button>
+        </div>
+        <div class="toolbar-right">
+          <span class="status-badge" id="status-badge" data-status="draft" aria-live="polite">下書き</span>
+          <span class="timestamp" id="last-updated">保存済み --:--</span>
+          <button type="button" class="secondary" id="draft-button">下書き保存</button>
+          <button type="button" class="primary" id="publish-button">公開</button>
+        </div>
+      </section>
+      <div class="progress-bar" id="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" hidden>
+        <span class="progress-fill"></span>
+      </div>
+
+      <section class="card-grid" aria-label="メニューカード一覧">
+        <div class="skeleton-overlay" id="skeleton-overlay" aria-hidden="true"></div>
+      </section>
+    </main>
+
+    <footer class="app-footer">
+      <p><strong>ショートカット：</strong><span class="kbd">Ctrl / Cmd + S</span> で下書き保存、<span class="kbd">Ctrl / Cmd + Enter</span> で公開、<span class="kbd">Esc</span> でアクティブカードの入力をクリアできます。</p>
+    </footer>
+  </div>
+
+  <template id="card-template">
+    <article class="menu-card" data-slot="">
+      <header class="card-header">
+        <h2>スロット <span class="slot-number"></span></h2>
+      </header>
+      <div class="dropzone" tabindex="0" role="button" aria-label="画像をドラッグ&ドロップ、またはクリックして選択" data-dropzone>
+        <input type="file" accept="image/png, image/jpeg, image/webp" class="file-input" aria-label="画像ファイルを選択" />
+        <div class="preview" aria-hidden="true">
+          <img alt="" />
+          <div class="preview-placeholder">
+            <span>画像を追加</span>
+          </div>
+        </div>
+      </div>
+      <div class="field">
+        <label for="name-">お酒の名前<span class="required">必須</span></label>
+        <input type="text" id="name-" name="name" maxlength="50" placeholder="例：純米大吟醸 山田錦" autocomplete="off" />
+      </div>
+      <div class="field">
+        <label for="desc-">説明 <span class="optional">任意</span></label>
+        <textarea id="desc-" name="desc" rows="4" maxlength="1000" placeholder="味わいや提供スタイルなどを記入"></textarea>
+        <div class="char-counter" aria-live="polite"><span class="count">1000</span> 字残り</div>
+      </div>
+      <div class="field">
+        <label for="alt-">代替テキスト <span class="optional">任意</span></label>
+        <input type="text" id="alt-" name="alt" maxlength="80" placeholder="画像が表示できない場合の説明" />
+      </div>
+      <div class="card-footer">
+        <span class="file-name" aria-live="polite">画像未選択</span>
+        <button type="button" class="text-button" data-clear>クリア</button>
+      </div>
+    </article>
+  </template>
+
+  <div class="toast-container" aria-live="assertive" aria-atomic="true"></div>
+
+  <div class="modal" id="warning-modal" role="dialog" aria-modal="true" aria-labelledby="warning-title" hidden>
+    <div class="modal-content">
+      <h2 id="warning-title">公開前の確認</h2>
+      <p>以下のスロットで画像または名前が未設定です。内容を確認してください。</p>
+      <ul class="warning-list" id="warning-list"></ul>
+      <div class="modal-actions">
+        <button type="button" class="ghost" id="warning-cancel">キャンセル</button>
+        <button type="button" class="primary" id="warning-continue">公開を続ける</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal" id="help-modal" role="dialog" aria-modal="true" aria-labelledby="help-title" hidden>
+    <div class="modal-content">
+      <h2 id="help-title">操作ガイド</h2>
+      <ul>
+        <li><span class="kbd">Ctrl / Cmd + S</span>：下書き保存</li>
+        <li><span class="kbd">Ctrl / Cmd + Enter</span>：公開</li>
+        <li><span class="kbd">Esc</span>：アクティブカードの入力をクリア</li>
+        <li>ドラッグ&ドロップまたはクリックで画像を追加できます。</li>
+        <li>文字数カウントを確認しながら説明文を編集できます。</li>
+      </ul>
+      <div class="modal-actions">
+        <button type="button" class="primary" id="help-close">閉じる</button>
+      </div>
+    </div>
+  </div>
+
+  <script src="app.js" defer></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,658 @@
+:root {
+  color-scheme: light dark;
+  --bg: rgba(244, 246, 250, 0.9);
+  --bg-strong: #f2f4f8;
+  --card: rgba(255, 255, 255, 0.6);
+  --card-border: rgba(255, 255, 255, 0.7);
+  --text: #1b1f24;
+  --text-muted: rgba(27, 31, 36, 0.65);
+  --accent: #2468f2;
+  --accent-soft: rgba(36, 104, 242, 0.16);
+  --outline: rgba(36, 104, 242, 0.6);
+  --shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+  --ghost-bg: rgba(36, 104, 242, 0.08);
+  --danger: #d64545;
+  --success: #1f8a4d;
+  --warning: #c27d0a;
+}
+
+[data-theme="dark"] {
+  --bg: rgba(17, 20, 25, 0.9);
+  --bg-strong: #11161f;
+  --card: rgba(27, 33, 46, 0.7);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text: #f6f7fb;
+  --text-muted: rgba(246, 247, 251, 0.7);
+  --accent: #598dff;
+  --accent-soft: rgba(89, 141, 255, 0.16);
+  --outline: rgba(133, 177, 255, 0.75);
+  --shadow: 0 18px 40px rgba(0, 0, 0, 0.5);
+  --ghost-bg: rgba(89, 141, 255, 0.18);
+  --danger: #ff6b6b;
+  --success: #39d98a;
+  --warning: #f6bf3b;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "SF Pro Display", "SF Pro Text", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+  background: linear-gradient(120deg, rgba(58, 123, 213, 0.18), rgba(0, 210, 255, 0.15)), var(--bg-strong);
+  color: var(--text);
+  min-height: 100vh;
+  line-height: 1.6;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: url('data:image/svg+xml,%3Csvg width="160" height="160" viewBox="0 0 160 160" xmlns="http://www.w3.org/2000/svg"%3E%3Ccircle cx="80" cy="80" r="68" fill="none" stroke="rgba(255,255,255,0.06)" stroke-width="4"/%3E%3C/svg%3E') center/160px repeat;
+  opacity: 0.4;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.app {
+  margin: 0 auto;
+  padding: clamp(24px, 5vw, 48px);
+  max-width: 1200px;
+}
+
+.app-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 24px;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.title-block h1 {
+  margin: 0;
+  font-size: clamp(28px, 4vw, 40px);
+  letter-spacing: 0.02em;
+}
+
+.subtitle {
+  margin: 8px 0 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.header-controls {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.date-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.date-picker input {
+  background: var(--card);
+  border: 1px solid var(--card-border);
+  padding: 10px 12px;
+  border-radius: 12px;
+  color: var(--text);
+  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.5);
+}
+
+.theme-toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.theme-toggle input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.switch-track {
+  position: relative;
+  display: inline-flex;
+  width: 52px;
+  height: 28px;
+  background: var(--card);
+  border: 1px solid var(--card-border);
+  border-radius: 999px;
+  transition: background 0.3s ease, border-color 0.3s ease;
+}
+
+.switch-thumb {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 4px 10px rgba(36, 104, 242, 0.4);
+  transition: transform 0.3s ease, background 0.3s ease;
+}
+
+.theme-toggle input:checked + .switch-track .switch-thumb {
+  transform: translateX(24px);
+  background: #ffcf56;
+  box-shadow: 0 4px 10px rgba(255, 207, 86, 0.5);
+}
+
+.icon-button {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--card);
+  border: 1px solid var(--card-border);
+  box-shadow: var(--shadow);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text);
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.icon-button:focus-visible {
+  outline: 2px solid var(--outline);
+  outline-offset: 3px;
+}
+
+.icon-button:hover {
+  transform: translateY(-2px);
+}
+
+.toolbar {
+  background: var(--card);
+  border: 1px solid var(--card-border);
+  border-radius: 20px;
+  box-shadow: var(--shadow);
+  padding: 16px 20px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 16px;
+  backdrop-filter: blur(20px);
+}
+
+.toolbar-left,
+.toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.status-badge {
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.status-badge[data-status="draft"] {
+  background: rgba(194, 125, 10, 0.12);
+  color: var(--warning);
+}
+
+.status-badge[data-status="published"] {
+  background: rgba(31, 138, 77, 0.16);
+  color: var(--success);
+}
+
+.timestamp {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+button {
+  font: inherit;
+  border: none;
+  cursor: pointer;
+}
+
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid var(--outline);
+  outline-offset: 3px;
+}
+
+.primary,
+.secondary,
+.ghost,
+.text-button {
+  border-radius: 14px;
+  padding: 10px 18px;
+  font-weight: 600;
+  transition: background 0.2s ease, transform 0.2s ease, color 0.2s ease;
+}
+
+.primary {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(36, 104, 242, 0.3);
+}
+
+.primary:hover {
+  transform: translateY(-1px);
+}
+
+.secondary {
+  background: rgba(36, 104, 242, 0.14);
+  color: var(--accent);
+}
+
+.secondary:hover {
+  background: rgba(36, 104, 242, 0.22);
+}
+
+.ghost {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--card-border);
+}
+
+.ghost:hover {
+  background: var(--ghost-bg);
+}
+
+.text-button {
+  background: transparent;
+  color: var(--accent);
+  padding: 6px 8px;
+}
+
+.text-button:hover {
+  text-decoration: underline;
+}
+
+.card-grid {
+  margin-top: 28px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
+  position: relative;
+}
+
+.menu-card {
+  background: var(--card);
+  border: 1px solid var(--card-border);
+  border-radius: 24px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(24px);
+  position: relative;
+  overflow: hidden;
+}
+
+.menu-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.08), transparent 55%);
+  pointer-events: none;
+}
+
+.card-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.05em;
+}
+
+.dropzone {
+  position: relative;
+  border: 2px dashed rgba(255, 255, 255, 0.4);
+  border-radius: 18px;
+  min-height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.2);
+  transition: border 0.3s ease, box-shadow 0.3s ease;
+}
+
+[data-theme="dark"] .dropzone {
+  background: rgba(27, 33, 46, 0.6);
+  border-color: rgba(255, 255, 255, 0.16);
+}
+
+.dropzone.drag-over {
+  border-style: solid;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px var(--accent-soft), 0 18px 40px rgba(36, 104, 242, 0.2);
+}
+
+.file-input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.preview {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: none;
+}
+
+.preview-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  color: var(--text-muted);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.field label {
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+}
+
+.field input,
+.field textarea {
+  border-radius: 14px;
+  border: 1px solid var(--card-border);
+  background: rgba(255, 255, 255, 0.55);
+  padding: 12px;
+  color: var(--text);
+  backdrop-filter: blur(6px);
+}
+
+[data-theme="dark"] .field input,
+[data-theme="dark"] .field textarea {
+  background: rgba(17, 24, 39, 0.6);
+}
+
+.char-counter {
+  align-self: flex-end;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.required {
+  margin-left: 6px;
+  color: var(--danger);
+  font-size: 0.75rem;
+}
+
+.optional {
+  margin-left: 6px;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+.card-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.skeleton-overlay {
+  position: absolute;
+  inset: 0;
+  border-radius: 32px;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0.05));
+  backdrop-filter: blur(20px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.4s ease;
+}
+
+.card-grid.loading .skeleton-overlay {
+  opacity: 1;
+  animation: shimmer 1.4s infinite;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 0% 50%;
+  }
+  100% {
+    background-position: 200% 50%;
+  }
+}
+
+.toast-container {
+  position: fixed;
+  top: 24px;
+  right: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  z-index: 1000;
+}
+
+.toast {
+  background: var(--card);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  padding: 14px 18px;
+  box-shadow: var(--shadow);
+  min-width: 220px;
+  opacity: 0;
+  transform: translateY(-16px);
+  animation: toast-in 0.3s forwards;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.toast.success {
+  border-left: 4px solid var(--success);
+}
+
+.toast.warning {
+  border-left: 4px solid var(--warning);
+}
+
+.toast.error {
+  border-left: 4px solid var(--danger);
+}
+
+@keyframes toast-in {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.toast.fade-out {
+  opacity: 0;
+  transform: translateY(-16px);
+}
+
+.progress-bar {
+  position: relative;
+  margin-top: 16px;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(36, 104, 242, 0.1);
+  overflow: hidden;
+}
+
+.progress-fill {
+  display: block;
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, rgba(36, 104, 242, 0.2), var(--accent));
+  transition: width 0.4s ease;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(12, 16, 24, 0.45);
+  padding: 24px;
+  z-index: 1200;
+}
+
+.modal[hidden] {
+  display: none;
+}
+
+.modal-content {
+  background: var(--card);
+  border: 1px solid var(--card-border);
+  border-radius: 24px;
+  padding: 28px;
+  max-width: min(480px, 100%);
+  width: 100%;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(30px);
+}
+
+.modal-content h2 {
+  margin-top: 0;
+  font-size: 1.3rem;
+}
+
+.modal-content ul {
+  padding-left: 18px;
+  margin: 16px 0;
+  color: var(--text-muted);
+}
+
+.modal-actions {
+  margin-top: 24px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.app-footer {
+  margin-top: 40px;
+  background: rgba(255, 255, 255, 0.3);
+  border: 1px solid var(--card-border);
+  border-radius: 20px;
+  padding: 16px 20px;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  backdrop-filter: blur(20px);
+  box-shadow: var(--shadow);
+}
+
+.kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  padding: 0 6px;
+  background: rgba(255, 255, 255, 0.35);
+  border: 1px solid var(--card-border);
+  font-size: 0.8rem;
+  margin: 0 4px;
+  color: var(--text);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 768px) {
+  .toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .toolbar-left,
+  .toolbar-right {
+    justify-content: space-between;
+  }
+
+  .header-controls {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 480px) {
+  .app {
+    padding: 20px;
+  }
+
+  .toolbar-left,
+  .toolbar-right {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .toolbar-right {
+    align-items: flex-start;
+  }
+
+  .primary,
+  .secondary,
+  .ghost {
+    width: 100%;
+    text-align: center;
+  }
+
+  .menu-card {
+    padding: 16px;
+  }
+
+  .dropzone {
+    min-height: 160px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- build a Japanese daily menu management dashboard with date picker, theme toggle, and action toolbar
- style the interface with glassmorphism-inspired cards, responsive grid layout, skeleton loading, toasts, modals, and theme variables
- implement LocalStorage-backed state management, image previews, keyboard shortcuts, and publish validations in vanilla JavaScript

## Testing
- manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68eb7642c3848329a6aa18e5b6242852