### PR TITLE
Create Japanese sake SPA mockup

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,295 @@
+const sections = document.querySelectorAll('.section');
+const drawer = document.getElementById('drawer');
+const scrim = document.querySelector('.scrim');
+const hamburger = document.querySelector('.hamburger');
+const sakeGrid = document.getElementById('sake-grid');
+const paginationEl = document.getElementById('pagination');
+const dataNotice = document.getElementById('data-notice');
+const modal = document.getElementById('sake-modal');
+const modalClose = modal.querySelector('.modal-close');
+const modalImage = document.getElementById('modal-image');
+const modalName = document.getElementById('modal-name');
+const modalDesc = document.getElementById('modal-desc');
+const modalRice = document.getElementById('modal-rice');
+const modalPolish = document.getElementById('modal-polish');
+const modalAbv = document.getElementById('modal-abv');
+const modalPrice = document.getElementById('modal-price');
+
+const PER_PAGE = 6;
+let sakes = [];
+let currentPage = 1;
+
+const localFallbackData = [
+  {
+    "id": 1,
+    "name": "獺祭 純米大吟醸 45",
+    "desc": "華やかな吟醸香とキレの良さ。",
+    "rice": "山田錦",
+    "polish": 45,
+    "abv": 16,
+    "img": "./img/img001.jpg",
+    "price": 6000
+  },
+  {
+    "id": 2,
+    "name": "十四代 吟撰",
+    "desc": "蜜のような甘みと透明感のある余韻。",
+    "rice": "兵庫産特A山田錦",
+    "polish": 40,
+    "abv": 15,
+    "img": "./img/img002.jpg",
+    "price": 7200
+  },
+  {
+    "id": 3,
+    "name": "新政 No.6 X-type",
+    "desc": "ジューシーな酸とフレッシュな香り。",
+    "rice": "秋田県産酒こまち",
+    "polish": 45,
+    "abv": 14,
+    "img": "./img/img003.jpg",
+    "price": 5500
+  },
+  {
+    "id": 4,
+    "name": "而今 特別純米",
+    "desc": "果実味と旨味のバランスが秀逸。",
+    "rice": "山田錦",
+    "polish": 55,
+    "abv": 16,
+    "img": "./img/img004.jpg",
+    "price": 4800
+  },
+  {
+    "id": 5,
+    "name": "田酒 特別純米",
+    "desc": "米の旨味が広がる王道の一本。",
+    "rice": "華吹雪",
+    "polish": 55,
+    "abv": 16,
+    "img": "./img/img005.jpg",
+    "price": 4200
+  },
+  {
+    "id": 6,
+    "name": "黒龍 しずく",
+    "desc": "柔らかな口当たりと透明感。",
+    "rice": "山田錦",
+    "polish": 35,
+    "abv": 16,
+    "img": "./img/img006.jpg",
+    "price": 9800
+  },
+  {
+    "id": 7,
+    "name": "作 IMPRESSION Type-G",
+    "desc": "瑞々しい香りとシャープなキレ。",
+    "rice": "三重県産米",
+    "polish": 50,
+    "abv": 15,
+    "img": "./img/img007.jpg",
+    "price": 3800
+  },
+  {
+    "id": 8,
+    "name": "風の森 ALPHA 風の森愛山",
+    "desc": "ミネラル感と甘やかな香りが共鳴。",
+    "rice": "愛山",
+    "polish": 50,
+    "abv": 14,
+    "img": "./img/img008.jpg",
+    "price": 4500
+  },
+  {
+    "id": 9,
+    "name": "花陽浴 八反錦",
+    "desc": "トロピカルで艶やかな甘み。",
+    "rice": "八反錦",
+    "polish": 50,
+    "abv": 16,
+    "img": "./img/img009.jpg",
+    "price": 4300
+  },
+  {
+    "id": 10,
+    "name": "醸し人九平次 別誂",
+    "desc": "熟した果実の香りとエレガントな酸。",
+    "rice": "山田錦",
+    "polish": 40,
+    "abv": 16,
+    "img": "./img/img010.jpg",
+    "price": 6800
+  },
+  {
+    "id": 11,
+    "name": "飛露喜 特別純米",
+    "desc": "旨味とキレが調和する食中酒の定番。",
+    "rice": "五百万石",
+    "polish": 55,
+    "abv": 16,
+    "img": "./img/img011.jpg",
+    "price": 3900
+  },
+  {
+    "id": 12,
+    "name": "仙禽 かぶとむし",
+    "desc": "ジューシーな酸と軽快なボディ。",
+    "rice": "栃木県産亀ノ尾",
+    "polish": 50,
+    "abv": 13,
+    "img": "./img/img012.jpg",
+    "price": 3600
+  }
+];
+
+function updateSections() {
+  const hash = window.location.hash || '#intro';
+  sections.forEach(section => {
+    section.classList.toggle('active', `#${section.id}` === hash);
+  });
+}
+
+function toggleDrawer(open) {
+  const isOpen = open ?? !drawer.classList.contains('open');
+  drawer.classList.toggle('open', isOpen);
+  hamburger.classList.toggle('active', isOpen);
+  hamburger.setAttribute('aria-expanded', String(isOpen));
+  drawer.setAttribute('aria-hidden', String(!isOpen));
+  if (isOpen) {
+    scrim.hidden = false;
+  } else {
+    scrim.hidden = true;
+  }
+}
+
+function renderSakes() {
+  sakeGrid.innerHTML = '';
+  if (!sakes.length) {
+    sakeGrid.innerHTML = '<p>表示できる日本酒がありません。</p>';
+    return;
+  }
+  const start = (currentPage - 1) * PER_PAGE;
+  const pageItems = sakes.slice(start, start + PER_PAGE);
+
+  pageItems.forEach(item => {
+    const card = document.createElement('article');
+    card.className = 'sake-card';
+    card.tabIndex = 0;
+    card.innerHTML = `
+      <img src="${item.img}" alt="${item.name}">
+      <div class="sake-card-content">
+        <h3>${item.name}</h3>
+        <p>${item.desc}</p>
+      </div>
+    `;
+    card.addEventListener('click', () => openModal(item));
+    card.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        openModal(item);
+      }
+    });
+    sakeGrid.appendChild(card);
+  });
+}
+
+function renderPagination() {
+  paginationEl.innerHTML = '';
+  const pageCount = Math.ceil(sakes.length / PER_PAGE);
+  if (pageCount <= 1) return;
+
+  for (let i = 1; i <= pageCount; i += 1) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = i;
+    button.classList.toggle('active', i === currentPage);
+    button.addEventListener('click', () => {
+      currentPage = i;
+      renderSakes();
+      renderPagination();
+      sakeGrid.scrollIntoView({ behavior: 'smooth' });
+    });
+    paginationEl.appendChild(button);
+  }
+}
+
+function openModal(item) {
+  modalImage.src = item.img;
+  modalImage.alt = item.name;
+  modalName.textContent = item.name;
+  modalDesc.textContent = item.desc;
+  modalRice.textContent = item.rice;
+  modalPolish.textContent = item.polish;
+  modalAbv.textContent = item.abv;
+  modalPrice.textContent = item.price.toLocaleString();
+
+  modal.classList.add('open');
+  modal.setAttribute('aria-hidden', 'false');
+  document.body.style.overflow = 'hidden';
+}
+
+function closeModal() {
+  modal.classList.remove('open');
+  modal.setAttribute('aria-hidden', 'true');
+  document.body.style.overflow = '';
+}
+
+async function loadSakes() {
+  dataNotice.textContent = 'データを取得しています…';
+  try {
+    const response = await fetch('/api/sakes');
+    if (!response.ok) {
+      throw new Error(`API responded with status ${response.status}`);
+    }
+    const data = await response.json();
+    sakes = Array.isArray(data) ? data : [];
+    dataNotice.textContent = 'サーバAPIから取得したデータを表示しています。';
+  } catch (error) {
+    console.warn('API fetch failed. Falling back to local mock.', error);
+    try {
+      const localResponse = await fetch('sakes.json');
+      if (!localResponse.ok) {
+        throw new Error('Local JSON failed');
+      }
+      const localData = await localResponse.json();
+      sakes = Array.isArray(localData) ? localData : localFallbackData;
+      dataNotice.textContent = 'ローカルモックデータを表示しています。';
+    } catch (localError) {
+      console.warn('Local JSON fetch failed. Using inline mock data.', localError);
+      sakes = localFallbackData;
+      dataNotice.textContent = 'ローカルモックデータを表示しています。';
+    }
+  }
+  currentPage = 1;
+  renderSakes();
+  renderPagination();
+}
+
+hamburger.addEventListener('click', () => toggleDrawer());
+scrim.addEventListener('click', () => toggleDrawer(false));
+drawer.querySelectorAll('a').forEach(link => {
+  link.addEventListener('click', () => toggleDrawer(false));
+});
+
+modalClose.addEventListener('click', closeModal);
+modal.addEventListener('click', (event) => {
+  if (event.target === modal) {
+    closeModal();
+  }
+});
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' && modal.classList.contains('open')) {
+    closeModal();
+  }
+});
+
+window.addEventListener('hashchange', updateSections);
+window.addEventListener('load', () => {
+  if (!window.location.hash) {
+    window.location.hash = '#intro';
+  } else {
+    updateSections();
+  }
+  loadSakes();
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SAKURA Grotto | 日本酒セレクション</title>
+  <link rel="stylesheet" href="styles.css">
+  <script defer src="app.js"></script>
+</head>
+<body>
+  <div class="background-veil"></div>
+  <header class="top-bar">
+    <div class="brand">
+      <span class="brand-kanji">櫻窟</span>
+      <span class="brand-roman">SAKURA GROTTO</span>
+    </div>
+    <button class="hamburger" aria-label="メニューを開く" aria-expanded="false" aria-controls="drawer">
+      <span></span>
+      <span></span>
+      <span></span>
+    </button>
+  </header>
+
+  <div class="scrim" hidden></div>
+  <nav id="drawer" class="drawer" aria-hidden="true">
+    <ul>
+      <li><a href="#intro">サイト紹介</a></li>
+      <li><a href="#list">日本酒一覧</a></li>
+      <li><a href="#howto">日本酒の飲み方</a></li>
+      <li><a href="#shops">おすすめのお店</a></li>
+      <li><a href="#contact">問い合わせ先</a></li>
+    </ul>
+  </nav>
+
+  <main>
+    <section id="intro" class="section active">
+      <div class="section-inner">
+        <h1>隠れ家で味わう、珠玉の日本酒体験</h1>
+        <p>「櫻窟 - SAKURA GROTTO」は、小規模飲食店向けに厳選した日本酒の魅力を伝えるためのモックサイトです。四季折々に寄り添う酒蔵の想い、料理との調和、香り立つ瞬間を丁寧にお届けします。</p>
+        <p>本サイトは HTML+Vanilla JS の SPA で、日本酒一覧はサーバサイドAPIから取得します。APIが利用できない場合でもローカルのモックデータでフェイルセーフに表示されます。</p>
+        <p>気になる点やお取り扱いのご相談は <a href="mailto:info@sakura-grotto.example">info@sakura-grotto.example</a> までお気軽にご連絡ください。</p>
+      </div>
+    </section>
+
+    <section id="list" class="section">
+      <div class="section-inner">
+        <div class="section-header">
+          <h2>日本酒一覧</h2>
+          <p class="data-notice" id="data-notice"></p>
+        </div>
+        <div class="sake-grid" id="sake-grid" aria-live="polite"></div>
+        <div class="pagination" id="pagination"></div>
+      </div>
+    </section>
+
+    <section id="howto" class="section">
+      <div class="section-inner">
+        <h2>日本酒の飲み方</h2>
+        <div class="howto-grid">
+          <article>
+            <h3>温度で楽しむ</h3>
+            <p>冷酒・常温・燗酒など、温度によって香りや味わいが劇的に変化します。繊細な香りを引き出したいときは冷やして、米の旨味を感じたいときはぬる燗で。</p>
+          </article>
+          <article>
+            <h3>器を選ぶ</h3>
+            <p>薄張りグラスや錫製のちろりなど、器の質感が舌触りに影響します。料理やシーンに合わせて器を変えることで、隠れ家の時間がより一層深まります。</p>
+          </article>
+          <article>
+            <h3>ペアリングを意識する</h3>
+            <p>海鮮にはキレのある吟醸酒、肉料理には濃醇な純米酒。食材の旨味と酒の酸味・甘味を重ね合わせ、余韻を楽しむのが真の贅沢です。</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="shops" class="section">
+      <div class="section-inner">
+        <h2>おすすめのお店</h2>
+        <div class="shops-list">
+          <article>
+            <h3>灯 - Akari</h3>
+            <p>ほの暗い灯りと季節の料理が迎える、12席だけの割烹バー。ペアリングコースで日本酒の奥深さを体験できます。</p>
+          </article>
+          <article>
+            <h3>滴 - Shizuku</h3>
+            <p>地下の石畳を抜けた先にある、カウンター8席の隠れ家。温度帯の違いを楽しめる酒器がずらりと並び、酒器のセレクトも購入可能です。</p>
+          </article>
+          <article>
+            <h3>透 - Suishō</h3>
+            <p>ガラス越しに庭園を望むラウンジ。静謐な時間の中、店主厳選の熟成酒と季節のフィンガーフードを合わせて提供しています。</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="contact" class="section">
+      <div class="section-inner">
+        <h2>問い合わせ先</h2>
+        <p>取り扱い希望・仕入れのご相談・イベント開催のご依頼など、こちらからお問い合わせください。</p>
+        <ul class="contact-list">
+          <li>メール：<a href="mailto:info@sakura-grotto.example">info@sakura-grotto.example</a></li>
+          <li>電話：03-1234-5678（平日 12:00 - 20:00）</li>
+          <li>所在地：東京都港区南青山 3-12-7 地下1階</li>
+        </ul>
+      </div>
+    </section>
+  </main>
+
+  <div class="modal" id="sake-modal" aria-hidden="true" role="dialog" aria-modal="true">
+    <div class="modal-content" role="document">
+      <button class="modal-close" aria-label="モーダルを閉じる">×</button>
+      <div class="modal-body">
+        <img src="" alt="" id="modal-image">
+        <div class="modal-details">
+          <h3 id="modal-name"></h3>
+          <p id="modal-desc"></p>
+          <dl>
+            <div>
+              <dt>原料米</dt>
+              <dd id="modal-rice"></dd>
+            </div>
+            <div>
+              <dt>精米歩合</dt>
+              <dd><span id="modal-polish"></span>%</dd>
+            </div>
+            <div>
+              <dt>アルコール度数</dt>
+              <dd><span id="modal-abv"></span>%</dd>
+            </div>
+            <div>
+              <dt>価格</dt>
+              <dd>¥<span id="modal-price"></span></dd>
+            </div>
+          </dl>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <footer class="site-footer">
+    <small>© 2024 Sakura Grotto. Crafted for intimate dining experiences.</small>
+  </footer>
+</body>
+</html>

--- a/sakes.json
+++ b/sakes.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": 1,
+    "name": "獺祭 純米大吟醸 45",
+    "desc": "華やかな吟醸香とキレの良さ。",
+    "rice": "山田錦",
+    "polish": 45,
+    "abv": 16,
+    "img": "./img/img001.jpg",
+    "price": 6000
+  },
+  {
+    "id": 2,
+    "name": "十四代 吟撰",
+    "desc": "蜜のような甘みと透明感のある余韻。",
+    "rice": "兵庫産特A山田錦",
+    "polish": 40,
+    "abv": 15,
+    "img": "./img/img002.jpg",
+    "price": 7200
+  },
+  {
+    "id": 3,
+    "name": "新政 No.6 X-type",
+    "desc": "ジューシーな酸とフレッシュな香り。",
+    "rice": "秋田県産酒こまち",
+    "polish": 45,
+    "abv": 14,
+    "img": "./img/img003.jpg",
+    "price": 5500
+  },
+  {
+    "id": 4,
+    "name": "而今 特別純米",
+    "desc": "果実味と旨味のバランスが秀逸。",
+    "rice": "山田錦",
+    "polish": 55,
+    "abv": 16,
+    "img": "./img/img004.jpg",
+    "price": 4800
+  },
+  {
+    "id": 5,
+    "name": "田酒 特別純米",
+    "desc": "米の旨味が広がる王道の一本。",
+    "rice": "華吹雪",
+    "polish": 55,
+    "abv": 16,
+    "img": "./img/img005.jpg",
+    "price": 4200
+  },
+  {
+    "id": 6,
+    "name": "黒龍 しずく",
+    "desc": "柔らかな口当たりと透明感。",
+    "rice": "山田錦",
+    "polish": 35,
+    "abv": 16,
+    "img": "./img/img006.jpg",
+    "price": 9800
+  },
+  {
+    "id": 7,
+    "name": "作 IMPRESSION Type-G",
+    "desc": "瑞々しい香りとシャープなキレ。",
+    "rice": "三重県産米",
+    "polish": 50,
+    "abv": 15,
+    "img": "./img/img007.jpg",
+    "price": 3800
+  },
+  {
+    "id": 8,
+    "name": "風の森 ALPHA 風の森愛山",
+    "desc": "ミネラル感と甘やかな香りが共鳴。",
+    "rice": "愛山",
+    "polish": 50,
+    "abv": 14,
+    "img": "./img/img008.jpg",
+    "price": 4500
+  },
+  {
+    "id": 9,
+    "name": "花陽浴 八反錦",
+    "desc": "トロピカルで艶やかな甘み。",
+    "rice": "八反錦",
+    "polish": 50,
+    "abv": 16,
+    "img": "./img/img009.jpg",
+    "price": 4300
+  },
+  {
+    "id": 10,
+    "name": "醸し人九平次 別誂",
+    "desc": "熟した果実の香りとエレガントな酸。",
+    "rice": "山田錦",
+    "polish": 40,
+    "abv": 16,
+    "img": "./img/img010.jpg",
+    "price": 6800
+  },
+  {
+    "id": 11,
+    "name": "飛露喜 特別純米",
+    "desc": "旨味とキレが調和する食中酒の定番。",
+    "rice": "五百万石",
+    "polish": 55,
+    "abv": 16,
+    "img": "./img/img011.jpg",
+    "price": 3900
+  },
+  {
+    "id": 12,
+    "name": "仙禽 かぶとむし",
+    "desc": "ジューシーな酸と軽快なボディ。",
+    "rice": "栃木県産亀ノ尾",
+    "polish": 50,
+    "abv": 13,
+    "img": "./img/img012.jpg",
+    "price": 3600
+  }
+]

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,422 @@
+@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600&family=Noto+Serif+JP:wght@400;600&display=swap');
+
+:root {
+  --bg-color: #0a0d10;
+  --surface-color: rgba(18, 22, 27, 0.85);
+  --accent: #d9a441;
+  --accent-soft: rgba(217, 164, 65, 0.2);
+  --text-primary: #f1efe5;
+  --text-muted: #c1b8a4;
+  --shadow: rgba(0, 0, 0, 0.4);
+  --transition: 0.3s ease;
+  --max-width: 1100px;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Noto Serif JP', serif;
+  background: radial-gradient(circle at 20% 20%, rgba(217, 164, 65, 0.12), transparent 50%),
+              radial-gradient(circle at 80% 10%, rgba(135, 206, 250, 0.1), transparent 40%),
+              var(--bg-color);
+  color: var(--text-primary);
+  min-height: 100vh;
+  position: relative;
+}
+
+.background-veil {
+  position: fixed;
+  inset: 0;
+  background: linear-gradient(130deg, rgba(8, 10, 13, 0.9), rgba(12, 14, 18, 0.75));
+  z-index: -2;
+}
+
+.top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 2rem;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(12px);
+  background: rgba(10, 13, 16, 0.75);
+  border-bottom: 1px solid rgba(217, 164, 65, 0.15);
+}
+
+.brand {
+  display: flex;
+  flex-direction: column;
+  letter-spacing: 0.16em;
+}
+
+.brand-kanji {
+  font-family: 'Cinzel', serif;
+  font-size: 1.5rem;
+  color: var(--accent);
+}
+
+.brand-roman {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.hamburger {
+  width: 2.5rem;
+  height: 2.5rem;
+  border: none;
+  background: transparent;
+  display: grid;
+  gap: 0.4rem;
+  cursor: pointer;
+}
+
+.hamburger span {
+  display: block;
+  width: 100%;
+  height: 2px;
+  background: var(--text-primary);
+  transition: transform var(--transition), opacity var(--transition);
+}
+
+.hamburger.active span:nth-child(1) {
+  transform: translateY(8px) rotate(45deg);
+}
+
+.hamburger.active span:nth-child(2) {
+  opacity: 0;
+}
+
+.hamburger.active span:nth-child(3) {
+  transform: translateY(-8px) rotate(-45deg);
+}
+
+.scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 9;
+  backdrop-filter: blur(2px);
+}
+
+.drawer {
+  position: fixed;
+  top: 0;
+  right: -320px;
+  width: 280px;
+  height: 100vh;
+  background: rgba(15, 18, 23, 0.95);
+  box-shadow: -4px 0 20px rgba(0, 0, 0, 0.45);
+  padding: 4rem 2rem;
+  transition: right var(--transition);
+  z-index: 10;
+}
+
+.drawer.open {
+  right: 0;
+}
+
+.drawer ul {
+  list-style: none;
+  display: grid;
+  gap: 1.4rem;
+}
+
+.drawer a {
+  color: var(--text-primary);
+  text-decoration: none;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  position: relative;
+}
+
+.drawer a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -0.2rem;
+  width: 100%;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--accent), transparent);
+  transform: scaleX(0);
+  transform-origin: center;
+  transition: transform var(--transition);
+}
+
+.drawer a:hover::after,
+.drawer a:focus-visible::after {
+  transform: scaleX(1);
+}
+
+main {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 4rem 2rem 6rem;
+}
+
+.section {
+  display: none;
+  animation: fadeIn 0.6s ease forwards;
+}
+
+.section.active {
+  display: block;
+}
+
+.section-inner {
+  background: var(--surface-color);
+  border: 1px solid rgba(217, 164, 65, 0.12);
+  border-radius: 20px;
+  padding: 3rem;
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(18px);
+}
+
+.section h1, .section h2 {
+  font-family: 'Cinzel', serif;
+  letter-spacing: 0.12em;
+  margin-bottom: 1rem;
+}
+
+.section p {
+  line-height: 1.8;
+  color: var(--text-muted);
+  margin-bottom: 1.5rem;
+}
+
+.section a {
+  color: var(--accent);
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.data-notice {
+  font-size: 0.85rem;
+  color: var(--accent);
+}
+
+.sake-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.8rem;
+}
+
+.sake-card {
+  background: rgba(14, 18, 23, 0.85);
+  border-radius: 18px;
+  overflow: hidden;
+  border: 1px solid rgba(217, 164, 65, 0.1);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.sake-card:hover,
+.sake-card:focus-visible {
+  transform: translateY(-6px);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5);
+}
+
+.sake-card img {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  filter: saturate(0.9);
+}
+
+.sake-card-content {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.sake-card h3 {
+  font-size: 1.1rem;
+  letter-spacing: 0.05em;
+}
+
+.sake-card p {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.pagination {
+  margin-top: 2.5rem;
+  display: flex;
+  justify-content: center;
+  gap: 0.6rem;
+}
+
+.pagination button {
+  background: transparent;
+  color: var(--text-primary);
+  border: 1px solid rgba(217, 164, 65, 0.4);
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition);
+}
+
+.pagination button.active,
+.pagination button:hover {
+  background: var(--accent);
+  color: #1a1105;
+}
+
+.howto-grid,
+.shops-list {
+  display: grid;
+  gap: 2rem;
+}
+
+.howto-grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.howto-grid article,
+.shops-list article {
+  background: rgba(12, 15, 20, 0.8);
+  padding: 2rem;
+  border-radius: 18px;
+  border: 1px solid rgba(217, 164, 65, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.contact-list {
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+  color: var(--text-muted);
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition);
+  z-index: 20;
+}
+
+.modal.open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.modal-content {
+  background: rgba(15, 18, 23, 0.95);
+  border-radius: 22px;
+  padding: 2.5rem;
+  max-width: 760px;
+  width: min(90vw, 760px);
+  box-shadow: 0 30px 70px rgba(0, 0, 0, 0.6);
+  position: relative;
+}
+
+.modal-close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: transparent;
+  border: none;
+  color: var(--text-primary);
+  font-size: 1.6rem;
+  cursor: pointer;
+}
+
+.modal-body {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  align-items: start;
+}
+
+.modal-body img {
+  width: 100%;
+  border-radius: 16px;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+}
+
+.modal-details h3 {
+  font-family: 'Cinzel', serif;
+  letter-spacing: 0.1em;
+  margin-bottom: 0.75rem;
+}
+
+.modal-details dl {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.modal-details dt {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  letter-spacing: 0.08em;
+}
+
+.modal-details dd {
+  font-size: 1.1rem;
+  color: var(--text-primary);
+}
+
+.site-footer {
+  text-align: center;
+  padding: 3rem 1rem 2rem;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 768px) {
+  .top-bar {
+    padding: 1rem 1.5rem;
+  }
+
+  .section-inner {
+    padding: 2rem;
+  }
+
+  .modal-body {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 520px) {
+  main {
+    padding: 3rem 1.25rem 5rem;
+  }
+
+  .drawer {
+    width: 80vw;
+  }
+}


### PR DESCRIPTION
## Summary
- build a hash-based single page layout for the sake showcase sections
- implement sake listing with API fallback to local mock data and modal details
- craft high-design styling and provide local JSON data for graceful degradation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fc4dc842808329bea35012ccc7bd8a