### PR TITLE
Add Xserver-ready PHP JSON admin UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
-# mock-private
-private mockup
+# Xserver 向け PHP JSON 管理UI サンプル
+
+Xserver (PHP) 上で JSON + 画像を管理するための最小構成。`public_html` をそのままアップロードするだけで動作します。
+
+## 構成
+- `public_html/index.html` : 管理UIへの入口。
+- `public_html/admin/index.php` : 管理画面 (vanilla JS)。
+- `public_html/api/*.php` : load/save/upload API。CSRF トークンを発行し、同一オリジンのみ許可。
+- `public_html/data/*.json` : 編集対象の JSON。書き込みには `644` / `604` を想定。
+- `public_html/images/` : 画像アップロード先 (705/755 推奨)。
+- `public_html/.htaccess` : ディレクトリリスティング禁止・文字化け防止・CORS/セッション強化。
+
+## 使い方
+1. `public_html` 以下を Xserver の同階層へ配置。
+2. `admin/` を開き、データセット (sake / menu) を選択。
+3. 画像を選択して送信すると `sake001.jpg` 形式で自動採番され、JSON に反映されます。
+4. 並び替えは `▲/▼` を押して保存するだけ。
+
+詳細な設計・テストケースは `public_html/admin/DESIGN.md` を参照してください。

--- a/public_html/.htaccess
+++ b/public_html/.htaccess
@@ -1,0 +1,14 @@
+Options -Indexes
+AddDefaultCharset UTF-8
+Header always set X-Content-Type-Options "nosniff"
+# 同一オリジンのみ許可
+<IfModule mod_headers.c>
+    SetEnvIf Origin "^https?://([^/]+)$" ORIGIN=$1
+    Header always set Access-Control-Allow-Origin "%{HTTP_ORIGIN}e" env=ORIGIN
+    Header always set Vary "Origin"
+</IfModule>
+
+# セッション固定攻撃対策
+php_flag session.use_strict_mode On
+php_flag session.cookie_httponly On
+php_flag session.use_only_cookies On

--- a/public_html/admin/DESIGN.md
+++ b/public_html/admin/DESIGN.md
@@ -1,0 +1,82 @@
+# Xserver × PHP × JSON 管理UI 設計書
+
+## ディレクトリ構成 (デプロイ先 `/public_html`)
+```
+/public_html/
+  ├─ index.html              # 案内ページ
+  ├─ .htaccess               # ディレクトリリスティング禁止/セキュリティヘッダ
+  ├─ api/
+  │    ├─ load.php           # JSON 読み込み
+  │    ├─ save.php           # JSON 保存
+  │    └─ upload.php         # 画像アップロード & 採番
+  ├─ data/
+  │    ├─ sake.json          # 日本酒データ
+  │    ├─ menu.json          # メニューデータ
+  │    └─ .htaccess          # 直リンク抑止・no-store
+  ├─ images/                 # アップロード先 (705/755 推奨)
+  └─ admin/
+       ├─ index.php          # 管理UI本体 (vanilla JS)
+       └─ DESIGN.md          # 本ドキュメント
+```
+
+## API 仕様
+```mermaid
+flowchart TD
+  A[admin/index.php] -- fetch GET --> B[api/load.php]
+  A -- fetch POST --> C[api/save.php]
+  A -- FormData POST --> D[api/upload.php]
+  B -- JSON + CSRF token --> A
+  C -- ok/error --> A
+  D -- path/filename --> A
+```
+- **CSRF**: `load.php` でセッション開始・token 発行。`save.php` / `upload.php` は `token` が一致しないと 403。
+- **CORS**: `HTTP_ORIGIN` のホストが `HTTP_HOST` と一致する場合のみ `Access-Control-Allow-Origin` を返却。
+- **エラー処理**: 400/403/405/500 を明示。メッセージは JSON `error` に格納。
+
+### パラメータ
+- `load.php?dataset=sake|menu`
+- `save.php` (POST `application/x-www-form-urlencoded`)
+  - `dataset`: `sake` or `menu`
+  - `token`: CSRF トークン
+  - `data`: JSON 文字列 (配列)
+- `upload.php` (POST `multipart/form-data`)
+  - `dataset`: `sake` or `menu`
+  - `token`: CSRF トークン
+  - `image`: 画像ファイル (jpg/png/gif)
+
+### 画像ファイル名採番
+- `upload.php` 内 `nextFilename()` が `sake001.jpg` → `sake002.jpg` のように 3 桁ゼロ埋め。
+- dataset=`sake` は `sake###.ext`、それ以外は `img###.ext`。
+- MIME + 拡張子一致チェック、`move_uploaded_file` 後に `0644` へ chmod。
+
+## 管理UI 画面構成
+- **画面ID**: `ADMIN01`
+- **ワイヤー**: 上段に dataset 切替 + ステータス、中央に一覧/並び替えテーブル、下段にフォーム (新規・編集) + 画像プレビュー。
+- **イベント一覧**
+  - `dataset` change → JSON 再読込、フォーム項目の切替。
+  - `▲/▼` → display_order 更新 + 再描画。
+  - `編集` → フォームへ値差し替え。
+  - `削除` → 配列から削除 → display_order 再採番。
+  - `submit` → 画像があればアップロード → JSON 合体 → `save.php` へ保存。
+  - `再読込` → `load.php` を強制再取得。
+- **必須/任意フィールド**
+  - sake: `id/name/region/abv/description/display_order` 必須、`image` 任意。
+  - menu: `id/name/price/display_order` 必須、`tags/image` 任意。
+- **表示例 JSON**: `data/sake.json`, `data/menu.json` を参照。
+
+## よくあるトラブルと対策
+- **文字化け**: `.htaccess` で `AddDefaultCharset UTF-8`。PHP のヘッダも `charset=UTF-8` 指定。
+- **権限**: `data/*.json` → 604/644、`images/` ディレクトリ → 705/755 推奨。
+- **パスずれ**: 返却パスは相対 `images/xxxx.jpg`。HTML 側は `../` を付与してプレビュー。
+- **画像が表示されない**: MIME/拡張子不一致で 400。`Header set X-Content-Type-Options "nosniff"` でブラウザ強制判定を抑止。
+
+## テストシナリオ
+1. **新規JSON作成**: admin からアイテムを追加 → 保存 → `data/*.json` をダウンロードして内容確認。
+2. **画像アップロード**: file input 選択 → 送信後レスポンス `path` が `images/sake00X.jpg` になっていること、`images/` に実ファイル生成を確認。
+3. **並び替え**: 一覧で `▲/▼` を操作 → `display_order` が 1,2,... で連番になっていることを保存後ファイルで確認。
+4. **保存後反映**: `再読込` でサーバー上 JSON を再取得し、一覧に新しい値が反映されること。
+
+## 改善案 (必要に応じて)
+- `X-Frame-Options` や `Content-Security-Policy` を `.htaccess` へ追加。
+- `images/.htaccess` にファイルサイズ上限 (LimitRequestBody) を設定。
+- バックアップ用に `data/*.json` 保存前に `*.bak` を自動生成する薄いラッパーを追加。

--- a/public_html/admin/index.php
+++ b/public_html/admin/index.php
@@ -1,0 +1,387 @@
+<?php
+session_start();
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+$token = $_SESSION['csrf_token'];
+?>
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>JSON + 画像 管理UI</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg: #f6f7fb;
+      --card: #fff;
+      --primary: #2563eb;
+      --danger: #dc2626;
+      --border: #e5e7eb;
+    }
+    * { box-sizing: border-box; }
+    body { font-family: 'Noto Sans JP', sans-serif; margin: 0; background: var(--bg); color: #1f2937; }
+    header { background: #0f172a; color: #fff; padding: 16px 24px; }
+    header h1 { margin: 0; font-size: 1.4rem; }
+    main { max-width: 1080px; margin: 24px auto; padding: 0 16px 32px; }
+    .card { background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 18px; box-shadow: 0 8px 22px rgba(0,0,0,.04); margin-bottom: 16px; }
+    .flex { display: flex; gap: 12px; flex-wrap: wrap; }
+    label { display: block; font-weight: 600; margin-bottom: 4px; }
+    input, select, textarea { width: 100%; padding: 10px; border-radius: 8px; border: 1px solid var(--border); font-size: 14px; }
+    button { padding: 10px 16px; border: none; border-radius: 8px; cursor: pointer; font-weight: 700; }
+    .primary { background: var(--primary); color: #fff; }
+    .ghost { background: #e5e7eb; color: #111827; }
+    .danger { background: var(--danger); color: #fff; }
+    table { width: 100%; border-collapse: collapse; font-size: 14px; }
+    th, td { padding: 10px; border-bottom: 1px solid var(--border); text-align: left; vertical-align: middle; }
+    th { background: #f8fafc; }
+    .actions button { margin-right: 6px; }
+    .preview { width: 96px; height: 96px; object-fit: cover; border-radius: 10px; border: 1px solid var(--border); background: #f8fafc; }
+    .note { font-size: 12px; color: #6b7280; }
+    .grid-2 { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 12px; }
+    .status { padding: 8px 10px; border-radius: 8px; font-size: 13px; margin-top: 8px; }
+    .status.ok { background: #ecfdf3; color: #166534; border: 1px solid #bbf7d0; }
+    .status.error { background: #fef2f2; color: #991b1b; border: 1px solid #fecdd3; }
+    .pill { display: inline-block; padding: 4px 8px; border-radius: 999px; background: #e0f2fe; color: #0ea5e9; margin-right: 6px; font-size: 12px; }
+  </style>
+</head>
+<body>
+<header>
+  <h1>JSON + 画像 管理UI (Xserver 対応)</h1>
+</header>
+<main>
+  <section class="card">
+    <div class="flex" style="align-items:center; justify-content: space-between;">
+      <div>
+        <label for="dataset">編集対象データセット</label>
+        <select id="dataset">
+          <option value="sake">日本酒 (sake.json)</option>
+          <option value="menu">メニュー (menu.json)</option>
+        </select>
+        <p class="note">ファイルは <code>/public_html/data/</code> に保存。画像は <code>/public_html/images/</code>。</p>
+      </div>
+      <button class="ghost" id="reload">再読込</button>
+    </div>
+    <div id="status" class="status" style="display:none;"></div>
+  </section>
+
+  <section class="card">
+    <h2 style="margin-top:0;">一覧・並び替え</h2>
+    <div class="note">行の上下移動で <code>display_order</code> を変更します。保存ボタンで JSON へ反映します。</div>
+    <div class="table-wrap" style="overflow-x:auto; margin-top:12px;">
+      <table>
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>名称</th>
+            <th>補足</th>
+            <th>画像</th>
+            <th>display_order</th>
+            <th>操作</th>
+          </tr>
+        </thead>
+        <tbody id="list"></tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="card">
+    <h2 style="margin-top:0;">新規追加 / 編集</h2>
+    <form id="item-form">
+      <input type="hidden" id="edit-index" value="">
+      <div class="grid-2" id="fields"></div>
+      <div class="grid-2" style="margin-top:12px; align-items:center;">
+        <div>
+          <label for="image">画像アップロード</label>
+          <input type="file" id="image" accept="image/*">
+          <p class="note">jpg/png/gif。ファイル名は自動採番 (sake001.jpg など)</p>
+        </div>
+        <div style="text-align:center;">
+          <img id="preview" class="preview" alt="preview">
+          <div class="note" id="image-path-note"></div>
+        </div>
+      </div>
+      <div class="flex" style="justify-content: flex-end; margin-top:12px;">
+        <button type="button" class="ghost" id="reset">リセット</button>
+        <button type="submit" class="primary">保存 (JSON 更新)</button>
+      </div>
+    </form>
+  </section>
+</main>
+<script>
+  const datasetConfig = {
+    sake: {
+      fields: [
+        { key: 'id', label: 'ID (例: sake001)', type: 'text', required: true },
+        { key: 'name', label: '名称', type: 'text', required: true },
+        { key: 'region', label: '産地', type: 'text', required: true },
+        { key: 'abv', label: '度数(%)', type: 'number', step: '0.1', required: true },
+        { key: 'description', label: '説明', type: 'textarea', required: true },
+        { key: 'image', label: '画像パス', type: 'text', required: false },
+        { key: 'display_order', label: 'display_order', type: 'number', required: true }
+      ],
+    },
+    menu: {
+      fields: [
+        { key: 'id', label: 'ID (例: dish001)', type: 'text', required: true },
+        { key: 'name', label: '料理名', type: 'text', required: true },
+        { key: 'price', label: '価格 (税込)', type: 'number', step: '1', required: true },
+        { key: 'tags', label: 'タグ (カンマ区切り)', type: 'text', required: false },
+        { key: 'image', label: '画像パス', type: 'text', required: false },
+        { key: 'display_order', label: 'display_order', type: 'number', required: true }
+      ],
+    }
+  };
+
+  let state = { dataset: 'sake', token: '<?php echo htmlspecialchars($token, ENT_QUOTES, 'UTF-8'); ?>', data: [] };
+
+  const datasetSelect = document.getElementById('dataset');
+  const listEl = document.getElementById('list');
+  const statusEl = document.getElementById('status');
+  const formEl = document.getElementById('item-form');
+  const fieldsEl = document.getElementById('fields');
+  const imageInput = document.getElementById('image');
+  const preview = document.getElementById('preview');
+  const imagePathNote = document.getElementById('image-path-note');
+  const editIndexEl = document.getElementById('edit-index');
+
+  function showStatus(message, ok = true) {
+    statusEl.textContent = message;
+    statusEl.className = 'status ' + (ok ? 'ok' : 'error');
+    statusEl.style.display = 'block';
+    setTimeout(() => { statusEl.style.display = 'none'; }, 4000);
+  }
+
+  function buildFields(dataset) {
+    fieldsEl.innerHTML = '';
+    datasetConfig[dataset].fields.forEach(field => {
+      const wrapper = document.createElement('div');
+      const label = document.createElement('label');
+      label.setAttribute('for', field.key);
+      label.textContent = field.label;
+      wrapper.appendChild(label);
+
+      let input;
+      if (field.type === 'textarea') {
+        input = document.createElement('textarea');
+        input.rows = 3;
+      } else {
+        input = document.createElement('input');
+        input.type = field.type;
+        if (field.step) input.step = field.step;
+      }
+      input.id = field.key;
+      input.required = !!field.required;
+      wrapper.appendChild(input);
+      fieldsEl.appendChild(wrapper);
+    });
+  }
+
+  function renderList() {
+    state.data.sort((a, b) => (a.display_order || 0) - (b.display_order || 0));
+    listEl.innerHTML = '';
+    state.data.forEach((item, index) => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td>${index + 1}</td>
+        <td>${item.name || ''}</td>
+        <td>${item.region || item.price || ''}</td>
+        <td>${item.image ? `<span class="pill">${item.image}</span>` : '-'}</td>
+        <td>${item.display_order || index + 1}</td>
+        <td class="actions">
+          <button type="button" class="ghost" data-action="up" data-index="${index}">▲</button>
+          <button type="button" class="ghost" data-action="down" data-index="${index}">▼</button>
+          <button type="button" class="primary" data-action="edit" data-index="${index}">編集</button>
+          <button type="button" class="danger" data-action="delete" data-index="${index}">削除</button>
+        </td>`;
+      listEl.appendChild(tr);
+    });
+  }
+
+  function populateForm(item = null) {
+    datasetConfig[state.dataset].fields.forEach(field => {
+      const el = document.getElementById(field.key);
+      if (!el) return;
+      const value = item ? item[field.key] : '';
+      if (field.key === 'tags' && Array.isArray(value)) {
+        el.value = value.join(',');
+      } else {
+        el.value = value ?? '';
+      }
+    });
+    if (item && item.image) {
+      preview.src = '../' + item.image;
+      imagePathNote.textContent = item.image;
+    } else {
+      preview.removeAttribute('src');
+      imagePathNote.textContent = '';
+    }
+    editIndexEl.value = item ? state.data.indexOf(item) : '';
+  }
+
+  async function fetchData(dataset) {
+    const res = await fetch(`../api/load.php?dataset=${encodeURIComponent(dataset)}`, {
+      credentials: 'same-origin',
+    });
+    const json = await res.json();
+    if (json.error) throw new Error(json.error);
+    state = { ...state, dataset: json.dataset, data: json.data || [], token: json.token };
+  }
+
+  function normalizeItem(formData) {
+    const item = {};
+    datasetConfig[state.dataset].fields.forEach(field => {
+      let value = formData.get(field.key);
+      if (field.type === 'number') {
+        value = value ? Number(value) : 0;
+      }
+      if (field.key === 'tags') {
+        value = value ? value.split(',').map(v => v.trim()).filter(Boolean) : [];
+      }
+      item[field.key] = value;
+    });
+    if (!item.display_order || Number.isNaN(item.display_order)) {
+      item.display_order = state.data.length + 1;
+    }
+    return item;
+  }
+
+  function reorder() {
+    state.data.forEach((item, idx) => item.display_order = idx + 1);
+  }
+
+  async function uploadImage() {
+    if (!imageInput.files.length) return null;
+    const form = new FormData();
+    form.append('image', imageInput.files[0]);
+    form.append('dataset', state.dataset);
+    form.append('token', state.token);
+    const res = await fetch('../api/upload.php', { method: 'POST', body: form, credentials: 'same-origin' });
+    const json = await res.json();
+    if (!json.ok) throw new Error(json.error || 'upload failed');
+    return json.path;
+  }
+
+  async function saveToServer() {
+    const payload = new URLSearchParams();
+    payload.append('dataset', state.dataset);
+    payload.append('token', state.token);
+    payload.append('data', JSON.stringify(state.data));
+    const res = await fetch('../api/save.php', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: payload.toString(),
+      credentials: 'same-origin',
+    });
+    const json = await res.json();
+    if (!json.ok) throw new Error(json.error || 'save failed');
+    showStatus('JSONを保存しました');
+  }
+
+  listEl.addEventListener('click', (e) => {
+    if (e.target.dataset.action) {
+      const idx = Number(e.target.dataset.index);
+      const action = e.target.dataset.action;
+      if (action === 'edit') {
+        populateForm(state.data[idx]);
+      } else if (action === 'delete') {
+        state.data.splice(idx, 1);
+        reorder();
+        renderList();
+      } else if (action === 'up' && idx > 0) {
+        [state.data[idx - 1], state.data[idx]] = [state.data[idx], state.data[idx - 1]];
+        reorder();
+        renderList();
+      } else if (action === 'down' && idx < state.data.length - 1) {
+        [state.data[idx + 1], state.data[idx]] = [state.data[idx], state.data[idx + 1]];
+        reorder();
+        renderList();
+      }
+    }
+  });
+
+  imageInput.addEventListener('change', () => {
+    if (!imageInput.files.length) return;
+    const file = imageInput.files[0];
+    const reader = new FileReader();
+    reader.onload = e => { preview.src = e.target.result; };
+    reader.readAsDataURL(file);
+    imagePathNote.textContent = '未アップロード (保存時に送信)';
+  });
+
+  formEl.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    try {
+      const uploadedPath = await uploadImage();
+      const formData = new FormData(formEl);
+      const item = normalizeItem(formData);
+      if (uploadedPath) {
+        item.image = uploadedPath;
+      }
+      const editIndex = editIndexEl.value !== '' ? Number(editIndexEl.value) : null;
+      if (editIndex !== null && !Number.isNaN(editIndex)) {
+        state.data[editIndex] = item;
+      } else {
+        state.data.push(item);
+      }
+      reorder();
+      await saveToServer();
+      renderList();
+      populateForm();
+      formEl.reset();
+      imagePathNote.textContent = '';
+      preview.removeAttribute('src');
+    } catch (err) {
+      console.error(err);
+      showStatus(err.message, false);
+    }
+  });
+
+  document.getElementById('reset').addEventListener('click', () => {
+    formEl.reset();
+    imagePathNote.textContent = '';
+    preview.removeAttribute('src');
+    populateForm();
+  });
+
+  document.getElementById('reload').addEventListener('click', async () => {
+    try {
+      await fetchData(state.dataset);
+      renderList();
+      populateForm();
+      showStatus('最新のJSONを読み込みました');
+    } catch (err) {
+      showStatus(err.message, false);
+    }
+  });
+
+  datasetSelect.addEventListener('change', async () => {
+    state.dataset = datasetSelect.value;
+    buildFields(state.dataset);
+    populateForm();
+    try {
+      await fetchData(state.dataset);
+      renderList();
+      populateForm();
+    } catch (err) {
+      showStatus(err.message, false);
+    }
+  });
+
+  async function init() {
+    buildFields(state.dataset);
+    try {
+      await fetchData(state.dataset);
+      renderList();
+    } catch (err) {
+      showStatus(err.message, false);
+    }
+  }
+
+  init();
+</script>
+</body>
+</html>

--- a/public_html/api/load.php
+++ b/public_html/api/load.php
@@ -1,0 +1,53 @@
+<?php
+// JSON読み込みAPI: GET /api/load.php?dataset=sake
+session_start();
+
+header('Content-Type: application/json; charset=UTF-8');
+header('X-Content-Type-Options: nosniff');
+
+$origin = $_SERVER['HTTP_ORIGIN'] ?? '';
+$host = $_SERVER['HTTP_HOST'] ?? '';
+if ($origin && parse_url($origin, PHP_URL_HOST) === $host) {
+    header('Access-Control-Allow-Origin: ' . $origin);
+    header('Vary: Origin');
+}
+
+$allowed = [
+    'sake' => __DIR__ . '/../data/sake.json',
+    'menu' => __DIR__ . '/../data/menu.json',
+];
+
+$dataset = $_GET['dataset'] ?? 'sake';
+if (!isset($allowed[$dataset])) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid dataset']);
+    exit;
+}
+
+// CSRFトークン生成
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+
+$path = realpath($allowed[$dataset]);
+if ($path === false || !is_readable($path)) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Data file is not readable. Check permissions.']);
+    exit;
+}
+
+$json = file_get_contents($path);
+$data = json_decode($json, true);
+if (!is_array($data)) {
+    $data = [];
+}
+
+usort($data, function ($a, $b) {
+    return ($a['display_order'] ?? 0) <=> ($b['display_order'] ?? 0);
+});
+
+echo json_encode([
+    'dataset' => $dataset,
+    'data' => $data,
+    'token' => $_SESSION['csrf_token'],
+]);

--- a/public_html/api/save.php
+++ b/public_html/api/save.php
@@ -1,0 +1,70 @@
+<?php
+// JSON保存API: POST dataset, token, data(JSON文字列)
+session_start();
+
+header('Content-Type: application/json; charset=UTF-8');
+header('X-Content-Type-Options: nosniff');
+
+$origin = $_SERVER['HTTP_ORIGIN'] ?? '';
+$host = $_SERVER['HTTP_HOST'] ?? '';
+if ($origin && parse_url($origin, PHP_URL_HOST) === $host) {
+    header('Access-Control-Allow-Origin: ' . $origin);
+    header('Vary: Origin');
+}
+
+if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Method not allowed']);
+    exit;
+}
+
+if (empty($_SESSION['csrf_token']) || ($_POST['token'] ?? '') !== $_SESSION['csrf_token']) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Invalid CSRF token']);
+    exit;
+}
+
+$allowed = [
+    'sake' => __DIR__ . '/../data/sake.json',
+    'menu' => __DIR__ . '/../data/menu.json',
+];
+
+$dataset = $_POST['dataset'] ?? '';
+if (!isset($allowed[$dataset])) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid dataset']);
+    exit;
+}
+
+$raw = $_POST['data'] ?? '';
+if ($raw === '') {
+    http_response_code(400);
+    echo json_encode(['error' => 'No data payload']);
+    exit;
+}
+
+$decoded = json_decode($raw, true);
+if (!is_array($decoded)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Malformed JSON payload']);
+    exit;
+}
+
+// display_order を再計算して整列
+usort($decoded, function ($a, $b) {
+    return ($a['display_order'] ?? 0) <=> ($b['display_order'] ?? 0);
+});
+foreach ($decoded as $index => &$item) {
+    $item['display_order'] = $index + 1;
+}
+unset($item);
+
+$json = json_encode($decoded, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+$path = $allowed[$dataset];
+if (file_put_contents($path, $json, LOCK_EX) === false) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Failed to write data file. Check file permissions (recommend 604 or 644).']);
+    exit;
+}
+
+echo json_encode(['ok' => true]);

--- a/public_html/api/upload.php
+++ b/public_html/api/upload.php
@@ -1,0 +1,109 @@
+<?php
+// 画像アップロードAPI: POST dataset, token, image(file)
+session_start();
+
+header('Content-Type: application/json; charset=UTF-8');
+header('X-Content-Type-Options: nosniff');
+
+$origin = $_SERVER['HTTP_ORIGIN'] ?? '';
+$host = $_SERVER['HTTP_HOST'] ?? '';
+if ($origin && parse_url($origin, PHP_URL_HOST) === $host) {
+    header('Access-Control-Allow-Origin: ' . $origin);
+    header('Vary: Origin');
+}
+
+if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Method not allowed']);
+    exit;
+}
+
+if (empty($_SESSION['csrf_token']) || ($_POST['token'] ?? '') !== $_SESSION['csrf_token']) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Invalid CSRF token']);
+    exit;
+}
+
+$allowedDatasets = ['sake', 'menu'];
+$dataset = $_POST['dataset'] ?? 'sake';
+if (!in_array($dataset, $allowedDatasets, true)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid dataset']);
+    exit;
+}
+
+if (!isset($_FILES['image'])) {
+    http_response_code(400);
+    echo json_encode(['error' => 'No file uploaded']);
+    exit;
+}
+
+$imagesDir = realpath(__DIR__ . '/../images');
+if ($imagesDir === false) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Images directory not found']);
+    exit;
+}
+
+$tmpName = $_FILES['image']['tmp_name'];
+$error = $_FILES['image']['error'];
+if ($error !== UPLOAD_ERR_OK) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Upload error: ' . $error]);
+    exit;
+}
+
+$finfo = finfo_open(FILEINFO_MIME_TYPE);
+$mime = finfo_file($finfo, $tmpName);
+finfo_close($finfo);
+$allowedMime = [
+    'image/jpeg' => 'jpg',
+    'image/png' => 'png',
+    'image/gif' => 'gif',
+];
+if (!isset($allowedMime[$mime])) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Unsupported file type']);
+    exit;
+}
+
+// 拡張子チェック
+$originalName = $_FILES['image']['name'] ?? '';
+$ext = strtolower(pathinfo($originalName, PATHINFO_EXTENSION));
+if ($ext !== $allowedMime[$mime]) {
+    http_response_code(400);
+    echo json_encode(['error' => 'File extension does not match MIME type']);
+    exit;
+}
+
+function nextFilename(string $dir, string $prefix, string $ext): string
+{
+    $max = 0;
+    foreach (glob($dir . '/' . $prefix . '*.' . $ext) as $file) {
+        if (preg_match('/' . preg_quote($prefix, '/') . '(\d{3})\.' . preg_quote($ext, '/') . '$/', basename($file), $m)) {
+            $max = max($max, (int)$m[1]);
+        }
+    }
+    $number = $max + 1;
+    return sprintf('%s%03d.%s', $prefix, $number, $ext);
+}
+
+$prefix = $dataset === 'sake' ? 'sake' : 'img';
+$nextName = nextFilename($imagesDir, $prefix, $ext);
+$destination = $imagesDir . '/' . $nextName;
+
+if (!move_uploaded_file($tmpName, $destination)) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Failed to save file. Check directory permissions (recommend 705 or 755).']);
+    exit;
+}
+
+chmod($destination, 0644);
+
+$relativePath = 'images/' . $nextName;
+
+echo json_encode([
+    'ok' => true,
+    'path' => $relativePath,
+    'filename' => $nextName,
+]);

--- a/public_html/data/.htaccess
+++ b/public_html/data/.htaccess
@@ -1,0 +1,5 @@
+Options -Indexes
+<FilesMatch "\.json$">
+  Header set Access-Control-Allow-Origin "same-origin"
+  Header set Cache-Control "no-store"
+</FilesMatch>

--- a/public_html/data/menu.json
+++ b/public_html/data/menu.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "dish001",
+    "name": "Seasonal Sashimi",
+    "price": 1800,
+    "tags": ["fish", "raw"],
+    "image": "images/dish001.jpg",
+    "display_order": 1
+  },
+  {
+    "id": "dish002",
+    "name": "Grilled Mackerel",
+    "price": 1400,
+    "tags": ["fish", "grill"],
+    "image": "images/dish002.jpg",
+    "display_order": 2
+  }
+]

--- a/public_html/data/sake.json
+++ b/public_html/data/sake.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "sake001",
+    "name": "Junmai Daiginjo",
+    "region": "Niigata",
+    "abv": 15.5,
+    "description": "Clean and crisp with notes of melon and apple.",
+    "image": "images/sake001.jpg",
+    "display_order": 1
+  },
+  {
+    "id": "sake002",
+    "name": "Yamahai",
+    "region": "Ishikawa",
+    "abv": 16.0,
+    "description": "Rich umami with earthy aroma and a dry finish.",
+    "image": "images/sake002.jpg",
+    "display_order": 2
+  }
+]

--- a/public_html/index.html
+++ b/public_html/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>JSON 管理UIサンプル</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Noto Sans JP', sans-serif; padding: 2rem; background: #f6f7fb; color: #1f2937; }
+    main { max-width: 720px; margin: 0 auto; background: #fff; border-radius: 12px; padding: 24px; box-shadow: 0 10px 25px rgba(0,0,0,.05); }
+    h1 { font-size: 1.6rem; margin-bottom: .5rem; }
+    p { line-height: 1.6; }
+    a.button { display: inline-block; margin-top: 1rem; padding: .75rem 1.2rem; background: #2563eb; color: #fff; border-radius: 8px; text-decoration: none; font-weight: 600; }
+    ul { margin: 1rem 0 0; padding-left: 1.2rem; }
+    li { margin: .35rem 0; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>JSON + 画像 管理UIデモ</h1>
+    <p>このサンプルは Xserver の標準 PHP 環境で JSON と画像を扱う管理画面の雛形です。<br>
+    <strong>admin/</strong> に移動して編集を行ってください。</p>
+    <a class="button" href="admin/">管理UIを開く</a>
+    <ul>
+      <li>データ: <code>public_html/data/*.json</code></li>
+      <li>画像: <code>public_html/images/</code></li>
+      <li>API: <code>public_html/api/</code></li>
+    </ul>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an Xserver-ready admin UI for managing sake and menu JSON data with ordering, editing, and image preview
- implement PHP APIs for loading, saving, and uploading with CSRF validation, MIME/extension checks, and display_order normalization
- document the deployment structure, .htaccess hardening, and test flows for the JSON/asset management setup

## Testing
- php -l public_html/api/load.php
- php -l public_html/api/save.php
- php -l public_html/api/upload.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e8ba6cf648329bad26227020410b3)