### PR TITLE
Add offline mock management UI prototype

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,169 @@
+const defaultData = {
+  items: [
+    {
+      id: "alpha-01",
+      name: "Alpha Site",
+      status: "active",
+      owner: "Ops Team",
+      description: "Primary region handling core traffic.",
+    },
+    {
+      id: "beta-04",
+      name: "Beta Node",
+      status: "maintenance",
+      owner: "Platform",
+      description: "Scheduled upgrade window.",
+    },
+    {
+      id: "gamma-12",
+      name: "Gamma Edge",
+      status: "standby",
+      owner: "Edge",
+      description: "Warm standby for failover drills.",
+    },
+  ],
+};
+
+let state = structuredClone(defaultData);
+let activeId = state.items[0]?.id ?? null;
+
+const listEl = document.getElementById("itemList");
+const formEl = document.getElementById("itemForm");
+const previewEl = document.getElementById("jsonPreview");
+const copyBtn = document.getElementById("copyJson");
+const downloadBtn = document.getElementById("downloadJson");
+const resetBtn = document.getElementById("resetForm");
+const addBtn = document.getElementById("addItem");
+const activeLabel = document.getElementById("activeLabel");
+
+const idInput = document.getElementById("itemId");
+const nameInput = document.getElementById("itemName");
+const statusInput = document.getElementById("itemStatus");
+const ownerInput = document.getElementById("itemOwner");
+const descriptionInput = document.getElementById("itemDescription");
+
+function renderList() {
+  listEl.innerHTML = "";
+  state.items.forEach((item) => {
+    const li = document.createElement("li");
+    li.className = "item-row" + (item.id === activeId ? " active" : "");
+    li.tabIndex = 0;
+
+    const title = document.createElement("p");
+    title.className = "item-title";
+    title.textContent = item?.name?.trim() || item.id || "Untitled";
+
+    const meta = document.createElement("p");
+    meta.className = "item-meta";
+    const status = item?.status?.trim() || "—";
+    const owner = item?.owner?.trim() || "Unassigned";
+    meta.textContent = `Status: ${status} · Owner: ${owner}`;
+
+    li.append(title, meta);
+    li.addEventListener("click", () => selectItem(item.id));
+    li.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        selectItem(item.id);
+      }
+    });
+
+    listEl.appendChild(li);
+  });
+}
+
+function selectItem(id) {
+  activeId = id;
+  const item = state.items.find((entry) => entry.id === id);
+  if (!item) return;
+
+  activeLabel.textContent = item.name?.trim() || item.id || "Selected";
+  idInput.value = item.id ?? "";
+  nameInput.value = item.name ?? "";
+  statusInput.value = item.status ?? "";
+  ownerInput.value = item.owner ?? "";
+  descriptionInput.value = item.description ?? "";
+  renderList();
+  updatePreview();
+}
+
+function updatePreview() {
+  previewEl.value = JSON.stringify(state, null, 2);
+}
+
+function safeUpdateFromForm() {
+  const clean = (value) => value?.trim() ?? "";
+  const id = clean(idInput.value);
+  if (!id) return;
+
+  const targetIndex = state.items.findIndex((item) => item.id === activeId);
+  if (targetIndex === -1) return;
+
+  state.items[targetIndex] = {
+    id,
+    name: clean(nameInput.value) || undefined,
+    status: clean(statusInput.value) || undefined,
+    owner: clean(ownerInput.value) || undefined,
+    description: clean(descriptionInput.value) || undefined,
+  };
+  activeId = id;
+  renderList();
+  updatePreview();
+}
+
+function addNewItem() {
+  const newId = `item-${Date.now().toString(36)}`;
+  const newItem = { id: newId, name: "New item", status: "draft" };
+  state.items.unshift(newItem);
+  selectItem(newId);
+}
+
+function resetForm() {
+  const item = state.items.find((entry) => entry.id === activeId);
+  if (!item) return;
+  selectItem(item.id);
+}
+
+function copyJson() {
+  navigator.clipboard
+    .writeText(previewEl.value)
+    .then(() => {
+      copyBtn.textContent = "Copied";
+      setTimeout(() => (copyBtn.textContent = "Copy"), 900);
+    })
+    .catch(() => {
+      copyBtn.textContent = "Error";
+      setTimeout(() => (copyBtn.textContent = "Copy"), 900);
+    });
+}
+
+function downloadJson() {
+  const blob = new Blob([previewEl.value], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = "mock-data.json";
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+formEl.addEventListener("submit", (event) => {
+  event.preventDefault();
+  safeUpdateFromForm();
+});
+
+copyBtn.addEventListener("click", copyJson);
+downloadBtn.addEventListener("click", downloadJson);
+resetBtn.addEventListener("click", resetForm);
+addBtn.addEventListener("click", addNewItem);
+
+window.addEventListener("DOMContentLoaded", () => {
+  renderList();
+  if (activeId) {
+    selectItem(activeId);
+  } else if (state.items.length) {
+    selectItem(state.items[0].id);
+  }
+  updatePreview();
+});
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mock Management UI</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="app-header">
+    <div class="brand">
+      <div class="dot"></div>
+      <div class="titles">
+        <p class="eyebrow">Prototype</p>
+        <h1>Mock Management UI</h1>
+      </div>
+    </div>
+    <p class="subtitle">Offline JSON manager for quick edits and exports.</p>
+  </header>
+
+  <main class="layout">
+    <section class="panel">
+      <div class="panel-header">
+        <h2>Items</h2>
+        <button id="addItem" class="ghost">+ Add</button>
+      </div>
+      <ul id="itemList" class="item-list" aria-label="Items"></ul>
+    </section>
+
+    <section class="panel">
+      <div class="panel-header">
+        <h2>Details</h2>
+        <span id="activeLabel" class="badge">Select an item</span>
+      </div>
+      <form id="itemForm" class="form" autocomplete="off">
+        <label class="field">
+          <span>Identifier</span>
+          <input type="text" name="id" id="itemId" required />
+        </label>
+        <label class="field">
+          <span>Name</span>
+          <input type="text" name="name" id="itemName" placeholder="Enter a name" />
+        </label>
+        <label class="field">
+          <span>Status</span>
+          <input type="text" name="status" id="itemStatus" placeholder="e.g. active" />
+        </label>
+        <label class="field">
+          <span>Owner</span>
+          <input type="text" name="owner" id="itemOwner" placeholder="Owner" />
+        </label>
+        <label class="field">
+          <span>Description</span>
+          <textarea name="description" id="itemDescription" rows="4" placeholder="Short notes"></textarea>
+        </label>
+        <div class="actions">
+          <button type="submit" class="primary">Save changes</button>
+          <button type="button" id="resetForm" class="ghost">Reset</button>
+        </div>
+      </form>
+    </section>
+
+    <section class="panel">
+      <div class="panel-header">
+        <h2>JSON Preview</h2>
+        <div class="controls">
+          <button id="copyJson" class="ghost">Copy</button>
+          <button id="downloadJson" class="primary">Export</button>
+        </div>
+      </div>
+      <textarea id="jsonPreview" class="json-preview" aria-label="JSON preview" readonly></textarea>
+    </section>
+  </main>
+
+  <footer class="footer">Works entirely in your browser. No servers, no external dependencies.</footer>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,247 @@
+:root {
+  --bg: #0f1116;
+  --panel: #161924;
+  --panel-border: #1f2331;
+  --accent: #7c3aed;
+  --accent-strong: #a855f7;
+  --text: #e8ecf8;
+  --muted: #9ca3af;
+  --input: #0d1017;
+  --success: #10b981;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at 20% 20%, rgba(124, 58, 237, 0.08), transparent 20%),
+    radial-gradient(circle at 80% 0%, rgba(16, 185, 129, 0.08), transparent 25%),
+    var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+.app-header {
+  padding: 24px 24px 0;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent), var(--success));
+  box-shadow: 0 0 12px rgba(124, 58, 237, 0.8);
+}
+
+.titles h1 {
+  margin: 2px 0 0;
+  font-size: 22px;
+  letter-spacing: 0.2px;
+}
+
+.eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 1.4px;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.subtitle {
+  color: var(--muted);
+  margin: 6px 0 0;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 260px 1fr 1fr;
+  gap: 16px;
+  padding: 16px 24px 32px;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.24);
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.panel h2 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.badge {
+  background: rgba(124, 58, 237, 0.1);
+  color: var(--accent-strong);
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  border: 1px solid rgba(124, 58, 237, 0.2);
+}
+
+.item-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.item-row {
+  padding: 10px;
+  border-radius: 10px;
+  border: 1px solid var(--panel-border);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.02), transparent);
+  cursor: pointer;
+  transition: border 0.2s ease, transform 0.15s ease;
+}
+
+.item-row:hover {
+  border-color: rgba(124, 58, 237, 0.45);
+  transform: translateY(-1px);
+}
+
+.item-row.active {
+  border-color: var(--accent);
+  box-shadow: 0 10px 30px rgba(124, 58, 237, 0.2);
+}
+
+.item-title {
+  margin: 0;
+  font-weight: 600;
+}
+
+.item-meta {
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field span {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+input,
+textarea,
+button {
+  font-family: inherit;
+}
+
+input,
+textarea {
+  background: var(--input);
+  border: 1px solid var(--panel-border);
+  color: var(--text);
+  padding: 10px 12px;
+  border-radius: 10px;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(124, 58, 237, 0.2);
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+}
+
+button {
+  border: 1px solid var(--panel-border);
+  background: var(--panel-border);
+  color: var(--text);
+  padding: 10px 14px;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.15s ease, border 0.2s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+button:active {
+  transform: translateY(0);
+}
+
+button.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  border-color: rgba(124, 58, 237, 0.65);
+  color: #fff;
+  box-shadow: 0 10px 25px rgba(124, 58, 237, 0.3);
+}
+
+button.ghost {
+  background: transparent;
+  color: var(--muted);
+}
+
+.controls {
+  display: flex;
+  gap: 8px;
+}
+
+.json-preview {
+  width: 100%;
+  background: var(--input);
+  color: var(--text);
+  border: 1px solid var(--panel-border);
+  border-radius: 10px;
+  min-height: 300px;
+  padding: 12px;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  resize: vertical;
+}
+
+.footer {
+  padding: 12px 24px 24px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+@media (max-width: 1080px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .controls {
+    margin-top: 4px;
+  }
+}


### PR DESCRIPTION
## Summary
- build standalone HTML, CSS, and JS for the mock management UI
- allow selecting, editing, and adding items with immediate JSON preview
- provide offline-friendly copy and export controls for the updated JSON data

## Testing
- not run (frontend-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944827cfbfc8329a606b5780a018281)