### PR TITLE
Add sake bar HACCP management UI mock

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,365 @@
+const equipments = [
+  { name: "日本酒用冷蔵庫A", range: "0〜8℃" },
+  { name: "日本酒用冷蔵庫B", range: "0〜8℃" },
+  { name: "低温ショーケース", range: "0〜10℃" },
+  { name: "冷凍庫", range: "-20〜-15℃" }
+];
+
+const cleanItems = [
+  "カウンター清掃",
+  "シンク・作業台清掃",
+  "ゴミ処理・分別確認",
+  "グラス棚の拭き上げ",
+  "トイレ清掃",
+  "床清掃"
+];
+
+const sakeList = [
+  {
+    id: 1,
+    name: "鳳凰美田 純米吟醸",
+    type: "純米吟醸",
+    storage: "日本酒用冷蔵庫A",
+    openedDate: "2025-03-01",
+    recommendedDays: 7,
+    status: "良好",
+    note: "華やかな香り。フレッシュさを保ちたい。",
+    lastChecked: null
+  },
+  {
+    id: 2,
+    name: "寫樂 純米酒",
+    type: "純米",
+    storage: "日本酒用冷蔵庫B",
+    openedDate: "2025-02-25",
+    recommendedDays: 10,
+    status: "良好",
+    note: "食中酒に。フレッシュ感を確認。",
+    lastChecked: null
+  },
+  {
+    id: 3,
+    name: "新政 No.6 R-type 生酒",
+    type: "生酒",
+    storage: "低温ショーケース",
+    openedDate: "2025-03-05",
+    recommendedDays: 5,
+    status: "良好",
+    note: "低温管理必須。日々確認。",
+    lastChecked: null
+  },
+  {
+    id: 4,
+    name: "黒龍 いっちょらい",
+    type: "吟醸",
+    storage: "日本酒用冷蔵庫A",
+    openedDate: "2025-02-20",
+    recommendedDays: 14,
+    status: "そろそろ飲み切りたい",
+    note: "熟成感が出る前に提供。",
+    lastChecked: null
+  },
+  {
+    id: 5,
+    name: "而今 特別純米",
+    type: "特別純米",
+    storage: "日本酒用冷蔵庫B",
+    openedDate: "2025-02-28",
+    recommendedDays: 9,
+    status: "良好",
+    note: "香りが落ちないよう注意。",
+    lastChecked: null
+  }
+];
+
+let temperatureLogs = [];
+let cleanLogs = [];
+let staffLogs = [];
+let logEntries = [];
+
+const formatDateTime = (date) => {
+  const d = new Date(date);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  return `${y}-${m}-${day} ${hh}:${mm}`;
+};
+
+const isToday = (date) => {
+  const now = new Date();
+  const d = new Date(date);
+  return (
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate()
+  );
+};
+
+const daysSince = (dateString) => {
+  const opened = new Date(dateString);
+  const now = new Date();
+  const diff = now - opened;
+  return Math.floor(diff / (1000 * 60 * 60 * 24));
+};
+
+const addLog = (category, content) => {
+  const entry = { time: new Date(), category, content };
+  logEntries.unshift(entry);
+  renderRecentLogs();
+  renderAllLogs();
+  renderDashboard();
+};
+
+const renderDate = () => {
+  const today = new Date();
+  const text = today.toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    weekday: "short"
+  });
+  document.getElementById("todayDate").textContent = text;
+};
+
+const renderTemperatureTable = () => {
+  const tbody = document.querySelector("#tempTable tbody");
+  tbody.innerHTML = "";
+  equipments.forEach((eq, index) => {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td>${eq.name}</td>
+      <td>${eq.range}</td>
+      <td><input type="number" step="0.1" class="input" data-eq="${index}" placeholder="5.0"></td>
+      <td><button class="primary" data-action="record" data-index="${index}">記録</button></td>
+    `;
+    tbody.appendChild(tr);
+  });
+
+  tbody.addEventListener("click", (e) => {
+    const target = e.target;
+    if (target.dataset.action === "record") {
+      const idx = Number(target.dataset.index);
+      const input = tbody.querySelector(`input[data-eq="${idx}"]`);
+      recordTemperature(idx, input.value);
+    }
+  });
+};
+
+const recordTemperature = (index, value) => {
+  const temp = parseFloat(value);
+  if (Number.isNaN(temp)) {
+    alert("温度を入力してください");
+    return;
+  }
+  const eq = equipments[index];
+  const abnormal = temp < 0 || temp > 15;
+  const time = new Date();
+  temperatureLogs.push({ equipment: eq.name, temp, time, abnormal });
+  addLog("温度", `${eq.name} ${temp.toFixed(1)}℃ ${abnormal ? "(基準外)" : "記録"}`);
+  renderDashboard();
+};
+
+const renderSakeTable = () => {
+  const tbody = document.querySelector("#sakeTable tbody");
+  tbody.innerHTML = "";
+  sakeList.forEach((sake) => {
+    const days = daysSince(sake.openedDate);
+    const over = days > sake.recommendedDays;
+    const tr = document.createElement("tr");
+    if (over) tr.classList.add("overdue");
+
+    const statusClass = over ? "danger" : sake.status.includes("そろそろ") ? "warn" : "";
+    const selectId = `status-${sake.id}`;
+
+    tr.innerHTML = `
+      <td>
+        <div>${sake.name}</div>
+        <div class="text-muted">${sake.note || ""}</div>
+      </td>
+      <td>${sake.type}</td>
+      <td>${sake.storage}</td>
+      <td>${sake.openedDate}</td>
+      <td>${days}日経過</td>
+      <td>推奨 ${sake.recommendedDays}日</td>
+      <td><span class="status-chip ${statusClass}">${sake.status}</span></td>
+      <td>
+        <select id="${selectId}" class="input">
+          <option value="良好">良好</option>
+          <option value="そろそろ飲み切りたい">そろそろ飲み切りたい</option>
+          <option value="廃棄検討">廃棄検討</option>
+        </select>
+        <button class="ghost" data-action="update-sake" data-id="${sake.id}">更新</button>
+      </td>
+    `;
+    tbody.appendChild(tr);
+    document.getElementById(selectId).value = sake.status;
+  });
+
+  if (!tbody.dataset.bound) {
+    tbody.addEventListener("click", (e) => {
+      const target = e.target;
+      if (target.dataset.action === "update-sake") {
+        const id = Number(target.dataset.id);
+        const select = document.getElementById(`status-${id}`);
+        updateSakeStatus(id, select.value);
+      }
+    });
+    tbody.dataset.bound = "true";
+  }
+};
+
+const updateSakeStatus = (id, newStatus) => {
+  const sake = sakeList.find((s) => s.id === id);
+  if (!sake) return;
+  sake.status = newStatus;
+  sake.lastChecked = new Date();
+  addLog("酒", `${sake.name} 状態更新: ${newStatus}`);
+  renderSakeTable();
+  renderDashboard();
+};
+
+const renderCleanChecklist = () => {
+  const form = document.getElementById("cleanForm");
+  form.innerHTML = "";
+  cleanItems.forEach((item, idx) => {
+    const id = `clean-${idx}`;
+    const label = document.createElement("label");
+    label.innerHTML = `<input type="checkbox" id="${id}" value="${item}"> ${item}`;
+    form.appendChild(label);
+  });
+};
+
+const saveCleanChecklist = () => {
+  const staff = document.getElementById("cleanStaff").value || "未入力";
+  const checkboxes = Array.from(document.querySelectorAll("#cleanForm input[type='checkbox']"));
+  const completed = checkboxes.filter((c) => c.checked);
+  if (completed.length === 0) {
+    alert("完了した項目にチェックを入れてください");
+    return;
+  }
+  const time = new Date();
+  completed.forEach((cb) => {
+    cleanLogs.push({ item: cb.value, staff, time, done: true });
+    addLog("清掃", `${cb.value} 完了 (${staff})`);
+    cb.checked = false;
+  });
+  renderDashboard();
+};
+
+const handleStaffSubmit = (e) => {
+  e.preventDefault();
+  const name = document.getElementById("staffName").value.trim();
+  if (!name) {
+    alert("スタッフ名を入力してください");
+    return;
+  }
+  const hand = document.querySelector("input[name='hand']:checked").value;
+  const attire = document.querySelector("input[name='attire']:checked").value;
+  const condition = document.querySelector("input[name='condition']:checked").value;
+  const time = new Date();
+  const record = { name, hand, attire, condition, time };
+  staffLogs.push(record);
+  addLog("スタッフ", `${name} 衛生チェック: 手 ${hand} / 服装 ${attire} / 体調 ${condition}`);
+  e.target.reset();
+};
+
+const renderRecentLogs = () => {
+  const list = document.getElementById("recentLogs");
+  list.innerHTML = "";
+  logEntries.slice(0, 3).forEach((log) => {
+    const li = document.createElement("li");
+    li.innerHTML = `
+      <div class="time">${formatDateTime(log.time)}</div>
+      <div><span class="cat">${log.category}</span>${log.content}</div>
+    `;
+    list.appendChild(li);
+  });
+};
+
+const renderAllLogs = () => {
+  const list = document.getElementById("allLogs");
+  list.innerHTML = "";
+  logEntries.forEach((log) => {
+    const li = document.createElement("li");
+    li.innerHTML = `
+      <div class="time">${formatDateTime(log.time)}</div>
+      <div><span class="cat">${log.category}</span>${log.content}</div>
+    `;
+    list.appendChild(li);
+  });
+};
+
+const computeCleanProgress = () => {
+  const todayLogs = cleanLogs.filter((log) => isToday(log.time) && log.done);
+  const completedItems = new Set(todayLogs.map((l) => l.item));
+  return { done: completedItems.size, total: cleanItems.length };
+};
+
+const computeSakeChecksToday = () => {
+  return sakeList.filter((s) => s.lastChecked && isToday(s.lastChecked)).length;
+};
+
+const computeTempProgress = () => {
+  const todayLogs = temperatureLogs.filter((log) => isToday(log.time));
+  return { done: todayLogs.length, total: equipments.length };
+};
+
+const computeStaffProgress = () => {
+  const today = staffLogs.filter((log) => isToday(log.time));
+  return { done: today.length, total: 5 };
+};
+
+const setBar = (id, percent) => {
+  const bar = document.getElementById(id);
+  bar.style.width = `${Math.min(percent, 100)}%`;
+};
+
+const renderDashboard = () => {
+  const temp = computeTempProgress();
+  document.getElementById("tempProgress").textContent = `${temp.done} / ${temp.total} 記録`;
+  setBar("tempBar", (temp.done / Math.max(temp.total, 1)) * 100);
+
+  const sakeChecked = computeSakeChecksToday();
+  document.getElementById("sakeProgress").textContent = `${sakeChecked}本 確認済み / ${sakeList.length}本`;
+  setBar("sakeBar", (sakeChecked / Math.max(sakeList.length, 1)) * 100);
+
+  const clean = computeCleanProgress();
+  document.getElementById("cleanProgress").textContent = `${clean.done} / ${clean.total} 完了`;
+  setBar("cleanBar", (clean.done / Math.max(clean.total, 1)) * 100);
+
+  const staff = computeStaffProgress();
+  document.getElementById("staffProgress").textContent = `${staff.done}人 チェック / 目標5人`;
+  setBar("staffBar", (staff.done / 5) * 100);
+};
+
+const bindTabs = () => {
+  const buttons = document.querySelectorAll(".tab-btn");
+  const views = document.querySelectorAll(".view");
+  buttons.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      buttons.forEach((b) => b.classList.remove("active"));
+      btn.classList.add("active");
+      const target = btn.dataset.target;
+      views.forEach((v) => v.classList.remove("active"));
+      document.getElementById(target).classList.add("active");
+    });
+  });
+};
+
+const bootstrap = () => {
+  renderDate();
+  renderTemperatureTable();
+  renderSakeTable();
+  renderCleanChecklist();
+  renderRecentLogs();
+  renderAllLogs();
+  renderDashboard();
+
+  document.getElementById("saveClean").addEventListener("click", saveCleanChecklist);
+  document.getElementById("staffForm").addEventListener("submit", handleStaffSubmit);
+  bindTabs();
+};
+
+document.addEventListener("DOMContentLoaded", bootstrap);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>日本酒バー HACCP 管理モック</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="topbar">
+    <div class="logo">Sake HACCP Mock</div>
+    <div class="today" id="todayDate"></div>
+  </header>
+
+  <nav class="tab-nav">
+    <button class="tab-btn active" data-target="H_TOP">ダッシュボード</button>
+    <button class="tab-btn" data-target="H_TEMP">温度記録</button>
+    <button class="tab-btn" data-target="H_SAKE">日本酒管理</button>
+    <button class="tab-btn" data-target="H_CLEAN">清掃チェック</button>
+    <button class="tab-btn" data-target="H_STAFF">従業員衛生</button>
+    <button class="tab-btn" data-target="H_LOG">記録ログ</button>
+  </nav>
+
+  <main>
+    <section id="H_TOP" class="view active">
+      <h1>今日の HACCP 状況</h1>
+      <div class="grid dashboard">
+        <div class="card">
+          <h3>温度管理</h3>
+          <p class="progress" id="tempProgress"></p>
+          <div class="bar"><span id="tempBar"></span></div>
+        </div>
+        <div class="card">
+          <h3>日本酒管理</h3>
+          <p class="progress" id="sakeProgress"></p>
+          <div class="bar"><span id="sakeBar"></span></div>
+        </div>
+        <div class="card">
+          <h3>清掃（日次）</h3>
+          <p class="progress" id="cleanProgress"></p>
+          <div class="bar"><span id="cleanBar"></span></div>
+        </div>
+        <div class="card">
+          <h3>従業員衛生</h3>
+          <p class="progress" id="staffProgress"></p>
+          <div class="bar"><span id="staffBar"></span></div>
+        </div>
+      </div>
+
+      <div class="card recent">
+        <div class="card-header">
+          <h3>最近のログ</h3>
+        </div>
+        <ul id="recentLogs" class="timeline"></ul>
+      </div>
+    </section>
+
+    <section id="H_TEMP" class="view">
+      <div class="section-header">
+        <div>
+          <h2>温度記録</h2>
+          <p>冷蔵庫・ショーケースの温度を入力して保存します。</p>
+        </div>
+      </div>
+      <div class="card">
+        <table class="table" id="tempTable">
+          <thead>
+            <tr>
+              <th>設備</th>
+              <th>基準</th>
+              <th>温度入力（℃）</th>
+              <th>操作</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </section>
+
+    <section id="H_SAKE" class="view">
+      <div class="section-header">
+        <div>
+          <h2>日本酒ボトル管理</h2>
+          <p>開栓からの日数と状態を確認します。</p>
+        </div>
+      </div>
+      <div class="card">
+        <table class="table" id="sakeTable">
+          <thead>
+            <tr>
+              <th>酒名</th>
+              <th>種類</th>
+              <th>保存</th>
+              <th>開栓日</th>
+              <th>経過日数</th>
+              <th>推奨</th>
+              <th>状態</th>
+              <th>更新</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </section>
+
+    <section id="H_CLEAN" class="view">
+      <div class="section-header">
+        <div>
+          <h2>清掃チェック（日次）</h2>
+          <p>完了した項目にチェックを入れて保存します。</p>
+        </div>
+        <div class="inline">
+          <label for="cleanStaff">担当者：</label>
+          <input id="cleanStaff" type="text" placeholder="例：佐藤" />
+        </div>
+      </div>
+      <div class="card">
+        <form id="cleanForm" class="checklist"></form>
+        <div class="actions">
+          <button id="saveClean" class="primary">保存</button>
+        </div>
+      </div>
+    </section>
+
+    <section id="H_STAFF" class="view">
+      <div class="section-header">
+        <div>
+          <h2>従業員衛生チェック</h2>
+          <p>出勤時に衛生状態を確認します。</p>
+        </div>
+      </div>
+      <div class="card">
+        <form id="staffForm" class="staff-form">
+          <label>スタッフ名<input type="text" id="staffName" placeholder="例：田中" required></label>
+          <div class="columns">
+            <div class="group">
+              <h4>手洗い・爪・傷</h4>
+              <label><input type="radio" name="hand" value="良好" checked> 良好</label>
+              <label><input type="radio" name="hand" value="要確認"> 要確認</label>
+            </div>
+            <div class="group">
+              <h4>服装</h4>
+              <label><input type="radio" name="attire" value="清潔" checked> 清潔</label>
+              <label><input type="radio" name="attire" value="改善必要"> 改善必要</label>
+            </div>
+            <div class="group">
+              <h4>体調</h4>
+              <label><input type="radio" name="condition" value="問題なし" checked> 問題なし</label>
+              <label><input type="radio" name="condition" value="要注意"> 要注意</label>
+            </div>
+          </div>
+          <div class="actions">
+            <button type="submit" class="primary">記録</button>
+          </div>
+        </form>
+      </div>
+    </section>
+
+    <section id="H_LOG" class="view">
+      <div class="section-header">
+        <div>
+          <h2>記録ログ一覧</h2>
+          <p>温度・清掃・スタッフ・酒の更新履歴を確認します。</p>
+        </div>
+      </div>
+      <div class="card">
+        <ul id="allLogs" class="timeline full"></ul>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <p>日本酒バー HACCP 管理モック</p>
+  </footer>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,274 @@
+:root {
+  --bg: #0f172a;
+  --surface: #111827;
+  --card: #161f37;
+  --accent: #34d399;
+  --accent-2: #22c55e;
+  --muted: #9ca3af;
+  --text: #e5e7eb;
+  --border: #1f2937;
+  --danger: #f97316;
+  --warn: #f59e0b;
+  --shadow: 0 16px 40px rgba(0, 0, 0, 0.35);
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: 'Inter', 'Noto Sans JP', system-ui, -apple-system, sans-serif;
+  background: radial-gradient(circle at 20% 20%, rgba(52, 211, 153, 0.08), transparent 30%),
+              radial-gradient(circle at 80% 0%, rgba(59, 130, 246, 0.08), transparent 35%),
+              var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+a { color: inherit; }
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 24px;
+  background: rgba(17, 24, 39, 0.8);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.logo { font-weight: 700; letter-spacing: 0.02em; }
+.today { color: var(--muted); font-size: 0.95rem; }
+
+.tab-nav {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 8px;
+  padding: 12px 16px;
+  background: rgba(17, 24, 39, 0.7);
+  border-bottom: 1px solid var(--border);
+}
+
+.tab-btn {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 10px 12px;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-weight: 600;
+}
+
+.tab-btn:hover { border-color: var(--accent); }
+.tab-btn.active {
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  color: #0b1221;
+  border-color: transparent;
+  box-shadow: var(--shadow);
+}
+
+main { padding: 20px; max-width: 1200px; margin: auto; }
+
+.view { display: none; }
+.view.active { display: block; }
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 16px;
+  margin: 16px 0;
+  box-shadow: var(--shadow);
+}
+
+.grid.dashboard {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+}
+
+.card h3 { margin: 0 0 6px; }
+.card .progress { color: var(--muted); margin: 0 0 10px; }
+
+.bar {
+  width: 100%;
+  height: 10px;
+  background: var(--surface);
+  border-radius: 999px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+
+.bar span {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent), var(--accent-2));
+  width: 0%;
+  transition: width 0.3s ease;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  color: var(--text);
+}
+
+.table thead { background: #0b1020; }
+.table th, .table td {
+  padding: 12px;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+}
+
+.table tbody tr:hover { background: rgba(255, 255, 255, 0.02); }
+
+.input, input[type="text"], input[type="number"] {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 8px 10px;
+  border-radius: 8px;
+  width: 100%;
+}
+
+button {
+  cursor: pointer;
+  font-weight: 700;
+}
+
+button.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  color: #0b1221;
+  border: none;
+  padding: 10px 16px;
+  border-radius: 10px;
+  box-shadow: var(--shadow);
+}
+
+button.ghost {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--border);
+  padding: 8px 12px;
+  border-radius: 10px;
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 12px;
+  font-size: 0.85rem;
+  gap: 6px;
+  background: rgba(52, 211, 153, 0.15);
+  border: 1px solid rgba(52, 211, 153, 0.4);
+}
+
+.status-chip.warn {
+  background: rgba(245, 158, 11, 0.15);
+  border-color: rgba(245, 158, 11, 0.4);
+}
+
+.status-chip.danger {
+  background: rgba(249, 115, 22, 0.12);
+  border-color: rgba(249, 115, 22, 0.5);
+}
+
+.highlight { color: var(--warn); font-weight: 700; }
+.text-muted { color: var(--muted); font-size: 0.9rem; }
+
+.checklist {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.checklist label {
+  display: block;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+}
+
+.actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  margin-top: 12px;
+}
+
+.timeline {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.timeline li {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.timeline .time { color: var(--muted); font-size: 0.9rem; }
+.timeline .cat {
+  display: inline-block;
+  padding: 4px 8px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.07);
+  margin-right: 8px;
+}
+
+.timeline.full li { grid-template-columns: 160px 1fr; }
+
+.overdue { background: rgba(249, 115, 22, 0.12); }
+
+.staff-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.staff-form .columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.staff-form .group {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+}
+
+.staff-form h4 { margin: 0 0 8px; }
+
+.inline { display: flex; align-items: center; gap: 8px; }
+
+footer {
+  text-align: center;
+  color: var(--muted);
+  padding: 24px;
+  border-top: 1px solid var(--border);
+  background: rgba(17, 24, 39, 0.6);
+  margin-top: 20px;
+}
+
+@media (max-width: 640px) {
+  .timeline li { grid-template-columns: 1fr; }
+  .timeline.full li { grid-template-columns: 1fr; }
+  .topbar { flex-direction: column; gap: 6px; }
+}


### PR DESCRIPTION
## Summary
- build SPA-style HACCP mock UI with dashboard, temperature entry, sake bottle management, cleaning, staff hygiene, and log views
- add styling for cards, tables, progress bars, and emphasis on overdue bottles or abnormal statuses
- implement mock data handling with in-memory logs for temperature, cleaning, staff checks, and sake status updates

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945e1e285a48329a1cf2320a22614d9)