### PR TITLE
Add landing page for restaurant Web & AI launch support

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,29 @@
         font-size: 1.05rem;
       }
 
+      header .audience {
+        margin-top: 18px;
+        padding: 6px 16px;
+        border-radius: 999px;
+        background: #f7f3ec;
+        border: 1px solid var(--soft);
+        color: var(--accent);
+        font-size: 0.95rem;
+        letter-spacing: 0.04em;
+        display: inline-flex;
+        gap: 8px;
+        align-items: center;
+      }
+
+      header .audience::before {
+        content: "";
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: #b7c4cd;
+        display: inline-block;
+      }
+
       section {
         margin-top: 56px;
         padding: 40px 48px;
@@ -149,6 +172,12 @@
         letter-spacing: 0.04em;
       }
 
+      .note {
+        margin-top: 10px;
+        color: var(--muted);
+        font-size: 0.95rem;
+      }
+
       .cta:hover {
         background: var(--accent);
         color: #ffffff;
@@ -176,6 +205,7 @@
           <span>作って終わらない</span>
           <span>運用前提の設計</span>
         </div>
+        <div class="audience">小規模飲食店・開業者に合わせた伴走支援</div>
       </header>
 
       <section>
@@ -183,6 +213,7 @@
         <div class="stack">
           <p>内装・仕入れ・人手・手続き…</p>
           <p class="emphasis">WebやITは<br />後回しになりがちです。</p>
+          <p class="note">焦らなくても大丈夫。まずは状況整理から一緒に進めます。</p>
         </div>
       </section>
 
@@ -193,6 +224,7 @@
           <li>高いWebサイトで失敗したくない</li>
           <li>開業後、更新や管理ができるか不安</li>
         </ul>
+        <p class="note">同じ悩みを抱えた小規模飲食店様が多くいらっしゃいます。</p>
       </section>
 
       <section>
@@ -205,11 +237,12 @@
             を最優先にします。
           </p>
         </div>
+        <p class="note">小さな店舗が安心して運用できる規模感に合わせます。</p>
       </section>
 
       <section>
         <h2>提供するサービス</h2>
-        <p>小規模飲食店・開業者向け</p>
+        <p class="emphasis">小規模飲食店・開業者向け</p>
         <div class="cards">
           <article class="card">
             <h3>Webサイト × AI 業務効率化</h3>
@@ -224,6 +257,7 @@
             <p>開業後も安心して相談できる体制</p>
           </article>
         </div>
+        <p class="note">過剰な提案ではなく、必要な分だけをご提案します。</p>
       </section>
 
       <section class="closing">
@@ -234,6 +268,7 @@
           <p class="emphasis">無料相談対応</p>
           <p class="highlight">開業後に<br />「やっておいて良かった」<br />と思える設計を。</p>
         </div>
+        <p class="note">準備の状況に合わせて、無理のない進め方をご案内します。</p>
         <a class="cta" href="#">無料相談の予約</a>
       </section>
     </main>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>飲食店開業向け Web・AIサポート</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f8f6f2;
+        --panel: #ffffff;
+        --ink: #1f1f1f;
+        --muted: #6b6b6b;
+        --accent: #3f5a6b;
+        --soft: #e4e0d8;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        font-family: "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Yu Gothic", sans-serif;
+        background: var(--bg);
+        color: var(--ink);
+        line-height: 1.7;
+      }
+
+      .page {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 64px 24px 120px;
+      }
+
+      header {
+        text-align: center;
+        padding: 72px 24px;
+        background: linear-gradient(180deg, #ffffff 0%, #f3efe7 100%);
+        border-radius: 28px;
+        border: 1px solid var(--soft);
+        box-shadow: 0 30px 60px rgba(31, 31, 31, 0.06);
+      }
+
+      header p {
+        margin: 0;
+        color: var(--muted);
+        font-size: 1rem;
+        letter-spacing: 0.08em;
+      }
+
+      header h1 {
+        margin: 20px 0 24px;
+        font-size: clamp(2rem, 3vw, 3.2rem);
+        font-weight: 600;
+        line-height: 1.4;
+      }
+
+      header .subline {
+        display: grid;
+        gap: 12px;
+        justify-items: center;
+        color: var(--muted);
+        font-size: 1.05rem;
+      }
+
+      section {
+        margin-top: 56px;
+        padding: 40px 48px;
+        background: var(--panel);
+        border-radius: 24px;
+        border: 1px solid var(--soft);
+        box-shadow: 0 20px 50px rgba(31, 31, 31, 0.04);
+      }
+
+      section h2 {
+        margin: 0 0 24px;
+        font-size: 1.4rem;
+        font-weight: 600;
+        color: var(--accent);
+        letter-spacing: 0.04em;
+      }
+
+      .stack {
+        display: grid;
+        gap: 16px;
+      }
+
+      .list {
+        display: grid;
+        gap: 14px;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+
+      .list li {
+        padding-left: 12px;
+        border-left: 3px solid #d1c9bd;
+      }
+
+      .emphasis {
+        font-weight: 600;
+      }
+
+      .cards {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 20px;
+        margin-top: 12px;
+      }
+
+      .card {
+        padding: 20px 22px;
+        border-radius: 18px;
+        background: #faf8f4;
+        border: 1px solid var(--soft);
+      }
+
+      .card h3 {
+        margin: 0 0 10px;
+        font-size: 1rem;
+        color: var(--accent);
+      }
+
+      .closing {
+        text-align: center;
+      }
+
+      .closing h2 {
+        margin-bottom: 18px;
+      }
+
+      .closing .highlight {
+        font-size: clamp(1.4rem, 2.6vw, 2.2rem);
+        font-weight: 600;
+        margin: 8px 0 0;
+      }
+
+      .cta {
+        display: inline-block;
+        margin-top: 24px;
+        padding: 12px 32px;
+        border-radius: 999px;
+        border: 1px solid var(--accent);
+        color: var(--accent);
+        text-decoration: none;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+      }
+
+      .cta:hover {
+        background: var(--accent);
+        color: #ffffff;
+        transition: 0.2s ease;
+      }
+
+      @media (max-width: 720px) {
+        header,
+        section {
+          padding: 32px 24px;
+        }
+
+        header h1 {
+          font-size: 2.2rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <header>
+        <p>開業予定の飲食店様へ</p>
+        <h1>WebとAIで<br />「失敗しないスタート」を</h1>
+        <div class="subline">
+          <span>作って終わらない</span>
+          <span>運用前提の設計</span>
+        </div>
+      </header>
+
+      <section>
+        <h2>開業準備で忙しい今だからこそ</h2>
+        <div class="stack">
+          <p>内装・仕入れ・人手・手続き…</p>
+          <p class="emphasis">WebやITは<br />後回しになりがちです。</p>
+        </div>
+      </section>
+
+      <section>
+        <h2>よくあるお悩み</h2>
+        <ul class="list">
+          <li>Webは必要だが、何を作ればいいかわからない</li>
+          <li>高いWebサイトで失敗したくない</li>
+          <li>開業後、更新や管理ができるか不安</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>私たちの考え方</h2>
+        <div class="stack">
+          <p class="emphasis">立派なWebは作りません。</p>
+          <p class="emphasis">無理にAIも使いません。</p>
+          <p>
+            <span class="emphasis">最低限・正しく・続くこと</span>
+            を最優先にします。
+          </p>
+        </div>
+      </section>
+
+      <section>
+        <h2>提供するサービス</h2>
+        <p>小規模飲食店・開業者向け</p>
+        <div class="cards">
+          <article class="card">
+            <h3>Webサイト × AI 業務効率化</h3>
+            <p>情報をまとめるシンプルなWeb</p>
+          </article>
+          <article class="card">
+            <h3>自分で更新できる仕組み</h3>
+            <p>運用が負担にならない形で設計</p>
+          </article>
+          <article class="card">
+            <h3>必要な時だけ使えるAIサポート</h3>
+            <p>開業後も安心して相談できる体制</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="closing">
+        <h2>まずはご相談ください</h2>
+        <div class="stack">
+          <p>開業前の整理だけでもOK</p>
+          <p>物件・メニュー未確定でも可</p>
+          <p class="emphasis">無料相談対応</p>
+          <p class="highlight">開業後に<br />「やっておいて良かった」<br />と思える設計を。</p>
+        </div>
+        <a class="cta" href="#">無料相談の予約</a>
+      </section>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a calm, trust-focused landing page targeted at prospective restaurant owners to communicate the value of correctly designing Web and AI from the start. 
- Lower the psychological barrier to a free consultation with a low-pressure, companion-style tone and restrained visual emphasis. 
- Present the six-slide content as a single, scannable page with clear, minimal messages that match the requested reading rhythm. 

### Description
- Add `index.html` containing a one-page landing layout that maps to each requested slide/section (hero, empathy, common concerns, philosophy, services, closing/CTA). 
- Implement a muted palette, generous whitespace, soft panel styling, and minimal typographic emphasis using CSS variables and responsive rules. 
- Include semantic sections, a simple card grid for services, and a prominent but gentle CTA (`無料相談の予約`). 

### Testing
- Served the page locally using `python -m http.server` to verify the static file is reachable and layout loads. 
- Attempted an automated screenshot with Playwright, but Chromium crashed in this environment so no screenshot could be captured. 
- No unit/CI tests were applicable for this static HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69538a36f56c8329933778d9320be1df)