### PR TITLE
Add iPad-friendly flow guide UI for Markdown/Marp workflows

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,374 @@
+const flows = [
+  {
+    id: "flow-pdf-fast",
+    title: "Markdown → Marp ですぐPDF化",
+    summary: "短時間でPDF資料に変換したい場合の最短ルート",
+    category: ["pdf", "quick"],
+    nodes: ["md-prepare", "marp-preview", "marp-export"],
+  },
+  {
+    id: "flow-canva-slide",
+    title: "Markdown → Canva でスライド仕上げ",
+    summary: "見た目重視でデザインを整えたいとき",
+    category: ["design", "ipad"],
+    nodes: ["md-prepare", "canva-import", "canva-design", "canva-export"],
+  },
+  {
+    id: "flow-figma",
+    title: "Markdown → Figma で共同編集",
+    summary: "チームで設計・レビューしながら資料を作る",
+    category: ["design", "collab"],
+    nodes: ["md-prepare", "figma-frame", "figma-design", "figma-export"],
+  },
+  {
+    id: "flow-ipad",
+    title: "iPad 完結フロー",
+    summary: "iPad mini だけで資料制作を完結させる",
+    category: ["ipad"],
+    nodes: ["md-prepare", "notion-outline", "canva-design", "canva-export"],
+  },
+  {
+    id: "flow-ai",
+    title: "AI で再構成してからデザイン",
+    summary: "AI で構成を整えてから外部デザインへ",
+    category: ["ai", "design"],
+    nodes: ["md-prepare", "ai-structure", "canva-design", "canva-export"],
+  },
+];
+
+const nodes = {
+  "md-prepare": {
+    id: "md-prepare",
+    label: "Markdown 整理",
+    role: "note",
+    description: "構成を整理して、見出しと本文を整える段階",
+    purpose: "素材準備",
+    input: "アイデア・メモ",
+    output: "整理済み Markdown",
+    caution: "1スライド1メッセージを意識する",
+    externalUrl: "https://www.markdownguide.org/basic-syntax/",
+  },
+  "marp-preview": {
+    id: "marp-preview",
+    label: "Marp でプレビュー",
+    role: "note",
+    description: "Marp のテンプレートで見え方を確認",
+    purpose: "レイアウト確認",
+    input: "Markdown",
+    output: "スライドプレビュー",
+    caution: "テーマに合わせて改行量を調整",
+    externalUrl: "https://marp.app/",
+  },
+  "marp-export": {
+    id: "marp-export",
+    label: "PDF 出力",
+    role: "output",
+    description: "Marp からPDFを出力",
+    purpose: "配布用資料作成",
+    input: "Marp スライド",
+    output: "PDF",
+    caution: "余白やフォント埋め込みを確認",
+    externalUrl: "https://marp.app/",
+  },
+  "canva-import": {
+    id: "canva-import",
+    label: "Canva に貼り付け",
+    role: "note",
+    description: "Markdown の内容をCanvaのテキストへ流し込み",
+    purpose: "素材移行",
+    input: "整理済み Markdown",
+    output: "Canva テキスト",
+    caution: "見出しごとにページを分割",
+    externalUrl: "https://www.canva.com/",
+  },
+  "canva-design": {
+    id: "canva-design",
+    label: "Canva でデザイン",
+    role: "design",
+    description: "テンプレートを使いながら装飾を調整",
+    purpose: "デザイン作成",
+    input: "テキスト素材",
+    output: "Canva デザイン",
+    caution: "文字量は控えめに",
+    externalUrl: "https://www.canva.com/",
+  },
+  "canva-export": {
+    id: "canva-export",
+    label: "Canva で書き出し",
+    role: "output",
+    description: "PDF または PPTX で書き出し",
+    purpose: "共有用データ出力",
+    input: "Canva デザイン",
+    output: "PDF / PPTX",
+    caution: "用途に合わせて形式を選択",
+    externalUrl: "https://www.canva.com/",
+  },
+  "figma-frame": {
+    id: "figma-frame",
+    label: "Figma フレーム準備",
+    role: "note",
+    description: "スライドサイズのフレームを作成",
+    purpose: "構成準備",
+    input: "Markdown",
+    output: "Figma フレーム",
+    caution: "サイズは16:9を基準に",
+    externalUrl: "https://www.figma.com/",
+  },
+  "figma-design": {
+    id: "figma-design",
+    label: "Figma デザイン",
+    role: "design",
+    description: "コンポーネントを使いデザインを調整",
+    purpose: "共同編集",
+    input: "フレーム",
+    output: "デザイン資料",
+    caution: "コメント機能でレビューを残す",
+    externalUrl: "https://www.figma.com/",
+  },
+  "figma-export": {
+    id: "figma-export",
+    label: "Figma 書き出し",
+    role: "output",
+    description: "PDF や PNG として書き出し",
+    purpose: "配布用出力",
+    input: "Figma デザイン",
+    output: "PDF / PNG",
+    caution: "ページ単位で書き出し設定",
+    externalUrl: "https://www.figma.com/",
+  },
+  "notion-outline": {
+    id: "notion-outline",
+    label: "Notion で構成整理",
+    role: "note",
+    description: "iPad で構成を調整しながら整理",
+    purpose: "アウトライン作成",
+    input: "Markdown",
+    output: "整理済み構成",
+    caution: "見出し階層を明確に",
+    externalUrl: "https://www.notion.so/",
+  },
+  "ai-structure": {
+    id: "ai-structure",
+    label: "AI で再構成",
+    role: "note",
+    description: "AI ツールで構成や表現をブラッシュアップ",
+    purpose: "構成調整",
+    input: "Markdown",
+    output: "再構成されたテキスト",
+    caution: "最終チェックは人が行う",
+    externalUrl: "https://chat.openai.com/",
+  },
+};
+
+const tools = [
+  {
+    name: "Marp",
+    role: "変換",
+    usage: "Markdown から PDF / PPTX",
+    device: "PC",
+    flows: ["flow-pdf-fast"],
+  },
+  {
+    name: "Canva",
+    role: "デザイン",
+    usage: "テンプレートで仕上げ",
+    device: "iPad / PC",
+    flows: ["flow-canva-slide", "flow-ipad", "flow-ai"],
+  },
+  {
+    name: "Figma",
+    role: "デザイン / 共同編集",
+    usage: "チームで構成レビュー",
+    device: "PC",
+    flows: ["flow-figma"],
+  },
+  {
+    name: "Notion",
+    role: "構成整理",
+    usage: "アウトライン共有",
+    device: "iPad / PC",
+    flows: ["flow-ipad"],
+  },
+  {
+    name: "AI Assist",
+    role: "AI 補助",
+    usage: "構成の再構成",
+    device: "PC / iPad",
+    flows: ["flow-ai"],
+  },
+];
+
+const state = {
+  view: "home",
+  flowId: flows[0].id,
+  nodeId: flows[0].nodes[0],
+};
+
+const viewButtons = document.querySelectorAll(".nav-button");
+const views = document.querySelectorAll(".view");
+
+const flowGrid = document.getElementById("flow-grid");
+const detailTitle = document.getElementById("detail-title");
+const detailSummary = document.getElementById("detail-summary");
+const detailTags = document.getElementById("detail-tags");
+const flowNodes = document.getElementById("flow-nodes");
+const nodeTitle = document.getElementById("node-title");
+const nodeDescription = document.getElementById("node-description");
+const nodePurpose = document.getElementById("node-purpose");
+const nodeInput = document.getElementById("node-input");
+const nodeOutput = document.getElementById("node-output");
+const nodeCaution = document.getElementById("node-caution");
+const nodeLink = document.getElementById("node-link");
+const toolsGrid = document.getElementById("tools-grid");
+
+const roleLabel = {
+  note: "記述",
+  design: "デザイン",
+  output: "出力",
+};
+
+function setView(nextView) {
+  state.view = nextView;
+  views.forEach((view) => {
+    view.classList.toggle("active", view.id === nextView);
+  });
+  viewButtons.forEach((button) => {
+    button.classList.toggle("active", button.dataset.view === nextView);
+  });
+  if (nextView === "detail") {
+    renderDetail();
+  }
+}
+
+function selectFlow(flowId) {
+  const flow = flows.find((item) => item.id === flowId);
+  if (!flow) return;
+  state.flowId = flowId;
+  state.nodeId = flow.nodes[0];
+  setView("detail");
+}
+
+function selectNode(nodeId) {
+  state.nodeId = nodeId;
+  renderDetail();
+}
+
+function renderHome() {
+  flowGrid.innerHTML = "";
+  flows.forEach((flow) => {
+    const card = document.createElement("article");
+    card.className = "flow-card";
+
+    const title = document.createElement("div");
+    title.className = "tagline";
+    title.textContent = flow.title;
+
+    const summary = document.createElement("p");
+    summary.textContent = flow.summary;
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.textContent = "フローを見る";
+    button.addEventListener("click", () => selectFlow(flow.id));
+
+    card.append(title, summary, button);
+    flowGrid.appendChild(card);
+  });
+}
+
+function renderDetail() {
+  const flow = flows.find((item) => item.id === state.flowId);
+  if (!flow) return;
+
+  detailTitle.textContent = flow.title;
+  detailSummary.textContent = flow.summary;
+  detailTags.innerHTML = "";
+  flow.category.forEach((tag) => {
+    const span = document.createElement("span");
+    span.className = "tag";
+    span.textContent = tag;
+    detailTags.appendChild(span);
+  });
+
+  flowNodes.innerHTML = "";
+  flow.nodes.forEach((nodeId) => {
+    const node = nodes[nodeId];
+    if (!node) return;
+    const card = document.createElement("button");
+    card.type = "button";
+    card.className = `node-card ${state.nodeId === nodeId ? "active" : ""}`;
+    card.addEventListener("click", () => selectNode(nodeId));
+
+    const label = document.createElement("strong");
+    label.textContent = node.label;
+
+    const pill = document.createElement("div");
+    pill.className = `node-pill role-${node.role}`;
+    const dot = document.createElement("span");
+    const text = document.createElement("span");
+    text.textContent = roleLabel[node.role];
+    pill.append(dot, text);
+
+    const detail = document.createElement("p");
+    detail.textContent = node.description;
+    detail.className = "muted";
+
+    card.append(label, pill, detail);
+    flowNodes.appendChild(card);
+  });
+
+  const activeNode = nodes[state.nodeId];
+  if (!activeNode) return;
+
+  nodeTitle.textContent = activeNode.label;
+  nodeDescription.textContent = activeNode.description;
+  nodePurpose.textContent = activeNode.purpose;
+  nodeInput.textContent = activeNode.input;
+  nodeOutput.textContent = activeNode.output;
+  nodeCaution.textContent = activeNode.caution;
+  nodeLink.href = activeNode.externalUrl;
+}
+
+function renderTools() {
+  toolsGrid.innerHTML = "";
+  tools.forEach((tool) => {
+    const card = document.createElement("article");
+    card.className = "tool-card";
+
+    const title = document.createElement("h3");
+    title.textContent = tool.name;
+
+    const role = document.createElement("p");
+    role.textContent = `役割: ${tool.role}`;
+
+    const usage = document.createElement("p");
+    usage.textContent = `向いている用途: ${tool.usage}`;
+
+    const device = document.createElement("p");
+    device.textContent = `対応デバイス: ${tool.device}`;
+
+    const tags = document.createElement("div");
+    tags.className = "tool-tags";
+    tool.flows.forEach((flowId) => {
+      const flow = flows.find((item) => item.id === flowId);
+      if (!flow) return;
+      const tag = document.createElement("button");
+      tag.type = "button";
+      tag.className = "tool-tag";
+      tag.textContent = flow.title;
+      tag.addEventListener("click", () => selectFlow(flowId));
+      tags.appendChild(tag);
+    });
+
+    card.append(title, role, usage, device, tags);
+    toolsGrid.appendChild(card);
+  });
+}
+
+viewButtons.forEach((button) => {
+  button.addEventListener("click", () => setView(button.dataset.view));
+});
+
+renderHome();
+renderTools();
+setView(state.view);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Markdown / Marp Flow Guide</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="app">
+      <header class="app-header">
+        <div>
+          <p class="eyebrow">Markdown / Marp Flow Guide</p>
+          <h1>用途別スライド制作フロー</h1>
+          <p class="subtitle">
+            Markdown を起点に、用途に合わせた資料作成ルートを可視化します。すべての操作は外部サイトへ遷移します。
+          </p>
+        </div>
+        <nav class="app-nav" aria-label="Primary">
+          <button class="nav-button" data-view="home">Home</button>
+          <button class="nav-button" data-view="detail">Flow Detail</button>
+          <button class="nav-button" data-view="tools">Tools List</button>
+        </nav>
+      </header>
+
+      <main>
+        <section id="home" class="view">
+          <h2 class="section-title">用途別フロー一覧</h2>
+          <p class="section-lead">タップでフロー詳細へ移動します。</p>
+          <div class="flow-grid" id="flow-grid" aria-live="polite"></div>
+        </section>
+
+        <section id="detail" class="view">
+          <div class="detail-header">
+            <div>
+              <h2 id="detail-title"></h2>
+              <p id="detail-summary"></p>
+            </div>
+            <div class="detail-meta">
+              <span id="detail-tags"></span>
+              <p class="notice">※ このサイトで処理は行いません。外部サイトを新しいタブで開きます。</p>
+            </div>
+          </div>
+
+          <div class="flow-nodes" id="flow-nodes"></div>
+
+          <div class="node-detail" id="node-detail">
+            <h3 id="node-title"></h3>
+            <p id="node-description"></p>
+            <ul class="node-info">
+              <li><strong>目的:</strong> <span id="node-purpose"></span></li>
+              <li><strong>入力:</strong> <span id="node-input"></span></li>
+              <li><strong>出力:</strong> <span id="node-output"></span></li>
+              <li><strong>注意点:</strong> <span id="node-caution"></span></li>
+            </ul>
+            <a id="node-link" class="cta" target="_blank" rel="noreferrer">外部サイトを開く</a>
+          </div>
+        </section>
+
+        <section id="tools" class="view">
+          <h2 class="section-title">ツール一覧</h2>
+          <p class="section-lead">用途別フローとツールの関係を把握できます。</p>
+          <div class="tools-grid" id="tools-grid"></div>
+        </section>
+      </main>
+    </div>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,340 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f8f8fb;
+  --surface: #ffffff;
+  --text: #1b1b22;
+  --muted: #5c5c70;
+  --accent: #5a67d8;
+  --border: #e0e0ea;
+  --role-note: #8e8e9a;
+  --role-design: #3b82f6;
+  --role-output: #22c55e;
+  font-family: "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Yu Gothic", sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0f1116;
+    --surface: #171a22;
+    --text: #f2f2f4;
+    --muted: #a9abb8;
+    --accent: #818cf8;
+    --border: #2a2e3a;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.app {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 24px 20px 48px;
+}
+
+.app-header {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding-bottom: 24px;
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--accent);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+h1 {
+  margin: 4px 0 12px;
+  font-size: clamp(24px, 4vw, 36px);
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.app-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.nav-button {
+  min-height: 44px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.nav-button.active {
+  background: var(--accent);
+  border-color: transparent;
+  color: white;
+}
+
+.section-title {
+  margin: 0 0 12px;
+  font-size: clamp(20px, 3vw, 28px);
+}
+
+.section-lead {
+  margin: 0 0 20px;
+  color: var(--muted);
+}
+
+.flow-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.flow-card {
+  min-height: 120px;
+  padding: 16px;
+  border-radius: 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.flow-card button {
+  min-height: 44px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: none;
+  background: var(--accent);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.flow-card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.flow-card .tagline {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.detail-header {
+  display: grid;
+  gap: 16px;
+  padding: 16px;
+  border-radius: 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+}
+
+.detail-meta {
+  display: grid;
+  gap: 8px;
+  color: var(--muted);
+}
+
+.notice {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.flow-nodes {
+  display: grid;
+  gap: 12px;
+  margin: 20px 0;
+}
+
+.node-card {
+  padding: 14px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  display: grid;
+  gap: 8px;
+  cursor: pointer;
+  min-height: 80px;
+}
+
+.node-card.active {
+  border: 2px solid var(--accent);
+  box-shadow: 0 10px 20px rgba(90, 103, 216, 0.15);
+}
+
+.node-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.node-pill span {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.node-detail {
+  padding: 18px;
+  border-radius: 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  display: grid;
+  gap: 12px;
+}
+
+.node-detail h3 {
+  margin: 0;
+}
+
+.node-detail p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.node-info {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  text-decoration: none;
+  background: var(--accent);
+  color: white;
+  font-weight: 600;
+  width: fit-content;
+}
+
+.tools-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.tool-card {
+  padding: 16px;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  display: grid;
+  gap: 8px;
+}
+
+.tool-card h3 {
+  margin: 0;
+}
+
+.tool-card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.tool-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tool-tag {
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  font-size: 0.8rem;
+}
+
+@media (min-width: 768px) {
+  .app-header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .detail-header {
+    grid-template-columns: 2fr 1fr;
+  }
+
+  .flow-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .flow-nodes {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .tools-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .tools-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.view {
+  display: none;
+}
+
+.view.active {
+  display: block;
+}
+
+.role-note span {
+  background: var(--role-note);
+}
+
+.role-design span {
+  background: var(--role-design);
+}
+
+.role-output span {
+  background: var(--role-output);
+}
+
+.tag {
+  display: inline-flex;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(90, 103, 216, 0.12);
+  color: var(--accent);
+  font-size: 0.8rem;
+  font-weight: 600;
+  margin-right: 6px;
+}
+
+@media (orientation: landscape) and (max-width: 1024px) {
+  .app {
+    padding-bottom: 32px;
+  }
+
+  .flow-nodes {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight, data-driven single-page UI that visualizes Markdown/Marp → Canva/Figma workflows without performing any file conversion.
- Target iPad mini usage with large tap targets, a single-screen flow overview, and responsive layouts for other devices.
- Surface external tools and guidance while ensuring all external links open in a new tab and clarifying that no processing happens on-site.

### Description
- Add three new files: `index.html`, `styles.css`, and `app.js` to implement Home, Flow Detail, and Tools List views driven by in-code flow/node/tool data.
- Implement data structures for `flows`, `nodes`, and `tools` and rendering functions `renderHome()`, `renderDetail()`, and `renderTools()` with navigation via `setView()` and selection handlers `selectFlow()`/`selectNode()`.
- Style the UI with an iPad-focused responsive grid, large tap targets (`min-height: 44px`), role-based node coloring, and an explicit notice that external sites are opened in a new tab (`target="_blank"` / `rel="noreferrer"`).
- Ensure no upload/processing features are included and all external URLs are provided as simple links only.

### Testing
- Started a local static server with `python -m http.server 8000` which served the files successfully.
- Attempted an automated screenshot via Playwright, but the headless Chromium process crashed with a SIGSEGV during launch and the Playwright run failed.
- No unit or integration test suite was executed; the changes are static UI assets and were committed after manual local verification steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954865dc83c8329a6845349a94c65d2)