### PR TITLE
Switch translation card app to HTML/JavaScript mock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+/dist
+.vite
+.env
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,50 @@
-# mock-private
-private mockup
+# 翻訳カードWebアプリ（HTML + JavaScript モック）
+
+iPad mini を主対象にした翻訳カードWebアプリのモック実装です。HTML と JavaScript のみで構成し、
+カードデータはローカル JSON、回答や履歴は localStorage に保存されます。
+
+## 起動方法
+
+簡易サーバーで静的ファイルを配信してください。
+
+```bash
+python -m http.server 5173
+```
+
+ブラウザで `http://localhost:5173` を開きます。
+
+## データ追加方法
+
+- `data/cards.json` にカードを追加してください。
+- `data/categories.json` にカテゴリを追加できます。
+
+`cards.json` の必須フィールド例：
+
+```json
+{
+  "id": "card-001",
+  "categoryId": "daily",
+  "tags": ["daily"],
+  "text": {
+    "ja": "こんにちは",
+    "en": "Hello",
+    "zh": "你好",
+    "ko": "안녕하세요"
+  },
+  "replyPresets": ["ok", "yes", "no", "wait", "custom"]
+}
+```
+
+新しい言語を追加する場合は `assets/app.js` の `languageOptions` と `replyLabels` を拡張してください。
+
+## localStorage キー
+
+- `translation-cards.responses`: カードごとの直近回答
+- `translation-cards.history`: 回答・メモ履歴（最大20件）
+- `translation-cards.language`: 外国語表示の選択言語
+
+## 仮定した仕様
+
+- 外国語表示の選択言語は `EN / ZH / KO` の3つのみ選べる前提で UI を構成しています。
+- `CUSTOM` は任意メモを外国語表示側にそのまま表示します。
+- メモ保存は回答とは独立して履歴に追加されます（回答が未設定の場合は `idle` のまま履歴に残ります）。

--- a/assets/app.js
+++ b/assets/app.js
@@ -1,0 +1,434 @@
+const state = {
+  language: 'en',
+  categoryId: 'all',
+  search: '',
+  cards: [],
+  categories: [],
+  responses: {},
+  history: [],
+  activeCardId: null,
+};
+
+const storageKeys = {
+  responses: 'translation-cards.responses',
+  history: 'translation-cards.history',
+  language: 'translation-cards.language',
+};
+
+const replyLabels = {
+  ok: { ja: 'OK', en: 'OK', zh: '好的', ko: '확인' },
+  yes: { ja: 'はい', en: 'Yes', zh: '是的', ko: '네' },
+  no: { ja: 'いいえ', en: 'No', zh: '不', ko: '아니요' },
+  wait: { ja: '少々お待ちください', en: 'Please wait', zh: '请稍等', ko: '잠시만요' },
+  custom: { ja: 'メモ', en: 'Note', zh: '备注', ko: '메모' },
+};
+
+const languageOptions = [
+  { code: 'en', label: 'English' },
+  { code: 'zh', label: '中文' },
+  { code: 'ko', label: '한국어' },
+];
+
+const appElements = {
+  cardGrid: document.getElementById('cardGrid'),
+  categoryFilter: document.getElementById('categoryFilter'),
+  languageSelector: document.getElementById('languageSelector'),
+  searchInput: document.getElementById('searchInput'),
+  detailCard: document.getElementById('detailCard'),
+  homeView: document.getElementById('homeView'),
+  detailView: document.getElementById('detailView'),
+  historyView: document.getElementById('historyView'),
+  backButton: document.getElementById('backButton'),
+  historyList: document.getElementById('historyList'),
+  navButtons: document.querySelectorAll('.nav-button'),
+};
+
+const loadStorage = () => {
+  const storedResponses = localStorage.getItem(storageKeys.responses);
+  const storedHistory = localStorage.getItem(storageKeys.history);
+  const storedLanguage = localStorage.getItem(storageKeys.language);
+
+  if (storedResponses) {
+    try {
+      state.responses = JSON.parse(storedResponses);
+    } catch {
+      state.responses = {};
+    }
+  }
+
+  if (storedHistory) {
+    try {
+      state.history = JSON.parse(storedHistory);
+    } catch {
+      state.history = [];
+    }
+  }
+
+  if (storedLanguage && ['en', 'zh', 'ko'].includes(storedLanguage)) {
+    state.language = storedLanguage;
+  }
+};
+
+const saveResponses = () => {
+  localStorage.setItem(storageKeys.responses, JSON.stringify(state.responses));
+};
+
+const saveHistory = () => {
+  localStorage.setItem(storageKeys.history, JSON.stringify(state.history));
+};
+
+const saveLanguage = () => {
+  localStorage.setItem(storageKeys.language, state.language);
+};
+
+const setActiveView = (view) => {
+  ['home', 'detail', 'history'].forEach((id) => {
+    const element = appElements[`${id}View`];
+    if (element) {
+      element.classList.toggle('view-active', id === view);
+    }
+  });
+
+  appElements.navButtons.forEach((button) => {
+    button.classList.toggle('active', button.dataset.view === view);
+  });
+};
+
+const getStatus = (cardId) => state.responses[cardId]?.status ?? 'idle';
+
+const addHistory = (item) => {
+  state.history = [item, ...state.history].slice(0, 20);
+  saveHistory();
+  renderHistory();
+};
+
+const renderLanguageSelector = () => {
+  appElements.languageSelector.innerHTML = '';
+  languageOptions.forEach((option) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = option.label;
+    button.classList.toggle('active', state.language === option.code);
+    button.addEventListener('click', () => {
+      state.language = option.code;
+      saveLanguage();
+      renderLanguageSelector();
+      renderCards();
+      if (state.activeCardId) {
+        renderDetail();
+      }
+    });
+    appElements.languageSelector.appendChild(button);
+  });
+};
+
+const renderCategories = () => {
+  const fragment = document.createDocumentFragment();
+  const allButton = document.createElement('button');
+  allButton.type = 'button';
+  allButton.textContent = 'すべて';
+  allButton.classList.toggle('active', state.categoryId === 'all');
+  allButton.addEventListener('click', () => {
+    state.categoryId = 'all';
+    renderCategories();
+    renderCards();
+  });
+  fragment.appendChild(allButton);
+
+  state.categories.forEach((category) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = category.name_ja;
+    button.classList.toggle('active', state.categoryId === category.id);
+    button.addEventListener('click', () => {
+      state.categoryId = category.id;
+      renderCategories();
+      renderCards();
+    });
+    fragment.appendChild(button);
+  });
+
+  appElements.categoryFilter.innerHTML = '';
+  appElements.categoryFilter.appendChild(fragment);
+};
+
+const renderCards = () => {
+  const searchTerm = state.search.trim().toLowerCase();
+  const filtered = state.cards.filter((card) => {
+    const matchesCategory = state.categoryId === 'all' || card.categoryId === state.categoryId;
+    const matchesSearch =
+      !searchTerm ||
+      card.text.ja.toLowerCase().includes(searchTerm) ||
+      card.text[state.language].toLowerCase().includes(searchTerm);
+    return matchesCategory && matchesSearch;
+  });
+
+  appElements.cardGrid.innerHTML = '';
+
+  filtered.forEach((card) => {
+    const cardElement = document.createElement('div');
+    cardElement.className = 'card-item';
+    cardElement.addEventListener('click', () => {
+      state.activeCardId = card.id;
+      renderDetail();
+      setActiveView('detail');
+    });
+
+    const badge = document.createElement('span');
+    const status = getStatus(card.id);
+    badge.className = `status-badge status-${status}`;
+    badge.textContent = status === 'idle' ? '未回答' : status.toUpperCase();
+
+    const foreignText = document.createElement('div');
+    foreignText.className = 'foreign-text';
+    foreignText.textContent = card.text[state.language];
+
+    const japaneseText = document.createElement('div');
+    japaneseText.className = 'japanese-text';
+    japaneseText.textContent = card.text.ja;
+
+    cardElement.appendChild(badge);
+    cardElement.appendChild(foreignText);
+    cardElement.appendChild(japaneseText);
+
+    appElements.cardGrid.appendChild(cardElement);
+  });
+};
+
+const renderDetail = () => {
+  const card = state.cards.find((item) => item.id === state.activeCardId);
+  if (!card) return;
+
+  const response = state.responses[card.id];
+  const status = response?.status ?? 'idle';
+  const replyLabel = response?.status ? replyLabels[response.status][state.language] : '';
+  const replyText = response?.status === 'custom' && response?.memo ? response.memo : replyLabel;
+  const japaneseLabel = response?.status ? replyLabels[response.status].ja : '';
+
+  appElements.detailCard.innerHTML = '';
+  appElements.detailCard.className = `detail-card status-${status}`;
+
+  const foreignSection = document.createElement('div');
+  foreignSection.className = 'detail-section foreign';
+  foreignSection.innerHTML = `
+    <p class="section-label">Foreign</p>
+    <p class="foreign-text">${card.text[state.language]}</p>
+  `;
+
+  if (status !== 'idle') {
+    const replyDisplay = document.createElement('div');
+    replyDisplay.className = 'reply-display';
+    replyDisplay.innerHTML = `
+      <p class="reply-label">Reply</p>
+      <p class="reply-text">${replyText}</p>
+    `;
+    foreignSection.appendChild(replyDisplay);
+  }
+
+  const japaneseSection = document.createElement('div');
+  japaneseSection.className = 'detail-section japanese';
+  japaneseSection.innerHTML = `
+    <p class="section-label">日本語</p>
+    <p class="japanese-text">${card.text.ja}</p>
+  `;
+
+  if (status !== 'idle') {
+    const jpReply = document.createElement('p');
+    jpReply.className = 'japanese-reply';
+    jpReply.textContent = japaneseLabel;
+    japaneseSection.appendChild(jpReply);
+  }
+
+  const actions = document.createElement('div');
+  actions.className = 'detail-actions';
+
+  const buttons = document.createElement('div');
+  buttons.className = 'reply-buttons';
+
+  ['ok', 'yes', 'no', 'wait'].forEach((statusKey) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = statusKey.toUpperCase();
+    button.addEventListener('click', () => {
+      const updatedAt = new Date().toISOString();
+      state.responses[card.id] = { status: statusKey, memo: '', updatedAt };
+      saveResponses();
+      addHistory({
+        id: `${card.id}-${updatedAt}`,
+        cardId: card.id,
+        status: statusKey,
+        memo: '',
+        createdAt: updatedAt,
+      });
+      renderCards();
+      renderDetail();
+    });
+    buttons.appendChild(button);
+  });
+
+  const resetButton = document.createElement('button');
+  resetButton.type = 'button';
+  resetButton.className = 'reset-button';
+  resetButton.textContent = 'リセット';
+  resetButton.addEventListener('click', () => {
+    delete state.responses[card.id];
+    saveResponses();
+    renderCards();
+    renderDetail();
+  });
+  buttons.appendChild(resetButton);
+
+  actions.appendChild(buttons);
+
+  const customSection = document.createElement('div');
+  customSection.innerHTML = `
+    <label>任意メモで返答</label>
+    <div class="input-row">
+      <input type="text" placeholder="例：今は満席です" />
+      <button type="button">送信</button>
+    </div>
+  `;
+
+  const customInput = customSection.querySelector('input');
+  const customButton = customSection.querySelector('button');
+  customButton.addEventListener('click', () => {
+    const value = customInput.value.trim();
+    if (!value) return;
+    const updatedAt = new Date().toISOString();
+    state.responses[card.id] = { status: 'custom', memo: value, updatedAt };
+    saveResponses();
+    addHistory({
+      id: `${card.id}-${updatedAt}`,
+      cardId: card.id,
+      status: 'custom',
+      memo: value,
+      createdAt: updatedAt,
+    });
+    customInput.value = '';
+    renderCards();
+    renderDetail();
+  });
+
+  actions.appendChild(customSection);
+
+  const memoSection = document.createElement('div');
+  memoSection.innerHTML = `
+    <label>メモを残す</label>
+    <div class="input-row">
+      <input type="text" placeholder="短いメモを入力" />
+      <button type="button">保存</button>
+    </div>
+  `;
+
+  const memoInput = memoSection.querySelector('input');
+  const memoButton = memoSection.querySelector('button');
+  memoButton.addEventListener('click', () => {
+    const value = memoInput.value.trim();
+    if (!value) return;
+    const createdAt = new Date().toISOString();
+    addHistory({
+      id: `${card.id}-memo-${createdAt}`,
+      cardId: card.id,
+      status: state.responses[card.id]?.status ?? 'idle',
+      memo: value,
+      createdAt,
+    });
+    memoInput.value = '';
+  });
+
+  actions.appendChild(memoSection);
+
+  appElements.detailCard.appendChild(foreignSection);
+  appElements.detailCard.appendChild(japaneseSection);
+  appElements.detailCard.appendChild(actions);
+};
+
+const renderHistory = () => {
+  appElements.historyList.innerHTML = '';
+  if (state.history.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.textContent = 'まだ履歴がありません。';
+    appElements.historyList.appendChild(empty);
+    return;
+  }
+
+  state.history.forEach((item) => {
+    const card = state.cards.find((cardItem) => cardItem.id === item.cardId);
+    const row = document.createElement('div');
+    row.className = 'history-item';
+
+    const info = document.createElement('div');
+    info.innerHTML = `
+      <p class="card-title">${card?.text.ja ?? item.cardId}</p>
+      <p class="timestamp">${new Date(item.createdAt).toLocaleString()}</p>
+    `;
+
+    const detail = document.createElement('div');
+    detail.className = 'history-detail';
+    const status = document.createElement('span');
+    status.className = 'history-status';
+    status.textContent = item.status.toUpperCase();
+    detail.appendChild(status);
+
+    if (item.memo) {
+      const memo = document.createElement('span');
+      memo.className = 'history-memo';
+      memo.textContent = item.memo;
+      detail.appendChild(memo);
+    }
+
+    row.appendChild(info);
+    row.appendChild(detail);
+
+    appElements.historyList.appendChild(row);
+  });
+};
+
+const initNav = () => {
+  appElements.navButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const view = button.dataset.view;
+      if (view === 'home') {
+        setActiveView('home');
+      }
+      if (view === 'history') {
+        renderHistory();
+        setActiveView('history');
+      }
+    });
+  });
+
+  appElements.backButton.addEventListener('click', () => {
+    setActiveView('home');
+  });
+};
+
+const initSearch = () => {
+  appElements.searchInput.addEventListener('input', (event) => {
+    state.search = event.target.value;
+    renderCards();
+  });
+};
+
+const bootstrap = async () => {
+  loadStorage();
+  initNav();
+  initSearch();
+
+  const [cardsResponse, categoriesResponse] = await Promise.all([
+    fetch('/data/cards.json'),
+    fetch('/data/categories.json'),
+  ]);
+
+  state.cards = await cardsResponse.json();
+  state.categories = (await categoriesResponse.json()).sort(
+    (a, b) => a.sortOrder - b.sortOrder
+  );
+
+  renderLanguageSelector();
+  renderCategories();
+  renderCards();
+};
+
+bootstrap();

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,507 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap');
+
+:root {
+  color-scheme: light;
+  font-family: 'Noto Sans JP', 'Inter', system-ui, -apple-system, sans-serif;
+  background-color: #f6f4f0;
+  color: #1f2328;
+  line-height: 1.6;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+button,
+input {
+  font-family: inherit;
+}
+
+.app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg, #f6f4f0 0%, #eef1f5 100%);
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px clamp(16px, 4vw, 40px);
+  background: rgba(255, 255, 255, 0.92);
+  border-bottom: 1px solid rgba(34, 34, 34, 0.08);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(6px);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.brand-mark {
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  background: #1d2a42;
+  color: #f7f2e8;
+  font-weight: 700;
+  font-size: 18px;
+}
+
+.brand h1 {
+  margin: 0;
+  font-size: 20px;
+}
+
+.brand p {
+  margin: 0;
+  font-size: 12px;
+  color: #6b6f76;
+}
+
+.nav {
+  display: flex;
+  gap: 10px;
+}
+
+.nav-button {
+  border: none;
+  padding: 8px 16px;
+  border-radius: 999px;
+  background: rgba(29, 42, 66, 0.08);
+  cursor: pointer;
+  font-size: 14px;
+  color: #394150;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.nav-button.active,
+.nav-button:hover {
+  background: rgba(29, 42, 66, 0.18);
+  color: #1d2a42;
+  font-weight: 600;
+}
+
+.app-main {
+  flex: 1;
+  padding: 24px clamp(16px, 4vw, 48px) 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.toolbar {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.language-selector {
+  display: inline-flex;
+  gap: 8px;
+  padding: 6px;
+  border-radius: 999px;
+  background: #fff;
+  box-shadow: 0 8px 20px rgba(33, 41, 54, 0.08);
+}
+
+.language-selector button {
+  border: none;
+  background: transparent;
+  padding: 8px 16px;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  color: #4a4f55;
+  min-width: 72px;
+  transition: all 0.2s ease;
+}
+
+.language-selector button.active {
+  background: #1d2a42;
+  color: #f7f2e8;
+}
+
+.search {
+  flex: 1;
+}
+
+.search input {
+  width: 100%;
+  padding: 12px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(29, 42, 66, 0.15);
+  background: #fff;
+  font-size: 14px;
+}
+
+.search input:focus {
+  outline: 2px solid rgba(29, 42, 66, 0.25);
+  border-color: transparent;
+}
+
+.category-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.category-filter button {
+  border: none;
+  background: rgba(255, 255, 255, 0.8);
+  padding: 8px 16px;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 13px;
+  color: #3c4350;
+  transition: all 0.2s ease;
+}
+
+.category-filter button.active {
+  background: #1d2a42;
+  color: #f7f2e8;
+  font-weight: 600;
+}
+
+.view {
+  display: none;
+}
+
+.view-active {
+  display: block;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.card-item {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 20px;
+  border-radius: 20px;
+  background: #fff;
+  box-shadow: 0 12px 28px rgba(29, 42, 66, 0.12);
+  min-height: 150px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card-item:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 18px 32px rgba(29, 42, 66, 0.16);
+}
+
+.card-item .status-badge {
+  align-self: flex-end;
+}
+
+.card-item .foreign-text {
+  font-size: clamp(18px, 2.8vw, 28px);
+  font-weight: 600;
+  margin: 8px 0 12px;
+}
+
+.card-item .japanese-text {
+  font-size: 13px;
+  color: #60656c;
+}
+
+.status-badge {
+  font-size: 11px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.status-idle {
+  background: rgba(129, 134, 142, 0.18);
+  color: #4a4f55;
+}
+
+.status-ok {
+  background: rgba(49, 147, 125, 0.16);
+  color: #256b5e;
+}
+
+.status-yes {
+  background: rgba(54, 123, 208, 0.18);
+  color: #1c4b8f;
+}
+
+.status-no {
+  background: rgba(198, 84, 91, 0.18);
+  color: #9a2f34;
+}
+
+.status-wait {
+  background: rgba(199, 159, 82, 0.2);
+  color: #8a5b13;
+}
+
+.status-custom {
+  background: rgba(110, 89, 153, 0.18);
+  color: #5a3f88;
+}
+
+.detail-card {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+  padding: clamp(16px, 4vw, 32px);
+  border-radius: 24px;
+  background: #fff;
+  box-shadow: 0 18px 36px rgba(29, 42, 66, 0.15);
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.detail-card.status-idle {
+  border: 1px solid rgba(129, 134, 142, 0.3);
+}
+
+.detail-card.status-ok {
+  border: 1px solid rgba(49, 147, 125, 0.35);
+  box-shadow: 0 18px 36px rgba(49, 147, 125, 0.2);
+}
+
+.detail-card.status-yes {
+  border: 1px solid rgba(54, 123, 208, 0.35);
+  box-shadow: 0 18px 36px rgba(54, 123, 208, 0.2);
+}
+
+.detail-card.status-no {
+  border: 1px solid rgba(198, 84, 91, 0.35);
+  box-shadow: 0 18px 36px rgba(198, 84, 91, 0.2);
+}
+
+.detail-card.status-wait {
+  border: 1px solid rgba(199, 159, 82, 0.35);
+  box-shadow: 0 18px 36px rgba(199, 159, 82, 0.2);
+}
+
+.detail-card.status-custom {
+  border: 1px solid rgba(110, 89, 153, 0.35);
+  box-shadow: 0 18px 36px rgba(110, 89, 153, 0.2);
+}
+
+.detail-section {
+  padding: clamp(16px, 4vw, 28px);
+  border-radius: 18px;
+}
+
+.detail-section.foreign {
+  background: linear-gradient(180deg, rgba(29, 42, 66, 0.08), rgba(29, 42, 66, 0.02));
+}
+
+.detail-section.japanese {
+  background: rgba(247, 242, 232, 0.9);
+}
+
+.section-label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #6a7078;
+  margin: 0 0 8px;
+}
+
+.foreign-text {
+  font-size: clamp(24px, 4vw, 40px);
+  font-weight: 700;
+  margin: 0;
+}
+
+.japanese-text {
+  font-size: clamp(18px, 3vw, 26px);
+  font-weight: 600;
+  margin: 0;
+}
+
+.reply-display {
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(29, 42, 66, 0.15);
+}
+
+.reply-display .reply-label {
+  margin: 0;
+  font-size: 12px;
+  color: #555;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.reply-display .reply-text {
+  margin: 4px 0 0;
+  font-size: clamp(20px, 3.5vw, 32px);
+  font-weight: 600;
+  color: #1d2a42;
+}
+
+.japanese-reply {
+  margin: 12px 0 0;
+  font-size: 14px;
+  color: #4f555c;
+  font-weight: 500;
+}
+
+.detail-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 20px;
+}
+
+.reply-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.reply-buttons button {
+  border: none;
+  padding: 12px 20px;
+  border-radius: 16px;
+  background: #1d2a42;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  min-width: 96px;
+}
+
+.reply-buttons button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(29, 42, 66, 0.2);
+}
+
+.reply-buttons .reset-button {
+  background: rgba(29, 42, 66, 0.15);
+  color: #1d2a42;
+}
+
+.detail-actions label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #2d3440;
+}
+
+.input-row {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.input-row input {
+  flex: 1;
+  min-width: 220px;
+  padding: 12px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(29, 42, 66, 0.2);
+}
+
+.input-row button {
+  border: none;
+  padding: 12px 20px;
+  border-radius: 14px;
+  background: #324c73;
+  color: #fff;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.back-button {
+  border: none;
+  background: transparent;
+  color: #1d2a42;
+  font-size: 14px;
+  cursor: pointer;
+  margin-bottom: 12px;
+}
+
+.history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.history-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px;
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 12px 24px rgba(29, 42, 66, 0.1);
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.history-item .card-title {
+  margin: 0 0 4px;
+  font-weight: 600;
+}
+
+.history-item .timestamp {
+  margin: 0;
+  font-size: 12px;
+  color: #6a7078;
+}
+
+.history-item .history-detail {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.history-item .history-status {
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(29, 42, 66, 0.12);
+  font-weight: 600;
+}
+
+.history-item .history-memo {
+  font-size: 13px;
+  color: #2e3542;
+}
+
+.empty-state {
+  padding: 24px;
+  background: #fff;
+  border-radius: 16px;
+  color: #60656c;
+}
+
+@media (min-width: 900px) {
+  .detail-card {
+    grid-template-columns: 1.2fr 0.8fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+}

--- a/data/cards.json
+++ b/data/cards.json
@@ -1,0 +1,2002 @@
+[
+  {
+    "id": "card-001",
+    "categoryId": "greeting",
+    "tags": [
+      "greeting"
+    ],
+    "text": {
+      "ja": "こんにちは",
+      "en": "Hello",
+      "zh": "你好",
+      "ko": "안녕하세요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-002",
+    "categoryId": "greeting",
+    "tags": [
+      "greeting"
+    ],
+    "text": {
+      "ja": "おはようございます",
+      "en": "Good morning",
+      "zh": "早上好",
+      "ko": "좋은 아침이에요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-003",
+    "categoryId": "greeting",
+    "tags": [
+      "greeting"
+    ],
+    "text": {
+      "ja": "こんばんは",
+      "en": "Good evening",
+      "zh": "晚上好",
+      "ko": "좋은 저녁이에요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-004",
+    "categoryId": "greeting",
+    "tags": [
+      "greeting"
+    ],
+    "text": {
+      "ja": "はじめまして",
+      "en": "Nice to meet you",
+      "zh": "很高兴认识你",
+      "ko": "처음 뵙겠습니다"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-005",
+    "categoryId": "greeting",
+    "tags": [
+      "greeting"
+    ],
+    "text": {
+      "ja": "さようなら",
+      "en": "Goodbye",
+      "zh": "再见",
+      "ko": "안녕히 가세요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-006",
+    "categoryId": "daily",
+    "tags": [
+      "daily"
+    ],
+    "text": {
+      "ja": "元気ですか",
+      "en": "How are you?",
+      "zh": "你好吗？",
+      "ko": "잘 지내세요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-007",
+    "categoryId": "daily",
+    "tags": [
+      "daily"
+    ],
+    "text": {
+      "ja": "はい、元気です",
+      "en": "I am fine",
+      "zh": "我很好",
+      "ko": "네, 잘 지내요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-008",
+    "categoryId": "daily",
+    "tags": [
+      "daily"
+    ],
+    "text": {
+      "ja": "少し疲れました",
+      "en": "I am a bit tired",
+      "zh": "我有点累",
+      "ko": "조금 피곤해요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-009",
+    "categoryId": "daily",
+    "tags": [
+      "daily"
+    ],
+    "text": {
+      "ja": "もう一度言ってください",
+      "en": "Please say it again",
+      "zh": "请再说一遍",
+      "ko": "다시 말씀해 주세요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-010",
+    "categoryId": "daily",
+    "tags": [
+      "daily"
+    ],
+    "text": {
+      "ja": "ゆっくり話してください",
+      "en": "Please speak slowly",
+      "zh": "请慢点说",
+      "ko": "천천히 말해 주세요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-011",
+    "categoryId": "daily",
+    "tags": [
+      "daily"
+    ],
+    "text": {
+      "ja": "大丈夫です",
+      "en": "It is okay",
+      "zh": "没关系",
+      "ko": "괜찮아요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-012",
+    "categoryId": "daily",
+    "tags": [
+      "daily"
+    ],
+    "text": {
+      "ja": "わかりました",
+      "en": "I understand",
+      "zh": "我明白了",
+      "ko": "알겠습니다"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-013",
+    "categoryId": "daily",
+    "tags": [
+      "daily"
+    ],
+    "text": {
+      "ja": "わかりません",
+      "en": "I do not understand",
+      "zh": "我不明白",
+      "ko": "잘 모르겠습니다"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-014",
+    "categoryId": "daily",
+    "tags": [
+      "daily"
+    ],
+    "text": {
+      "ja": "英語は話せますか",
+      "en": "Do you speak English?",
+      "zh": "你会说英语吗？",
+      "ko": "영어를 할 수 있나요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-015",
+    "categoryId": "daily",
+    "tags": [
+      "daily"
+    ],
+    "text": {
+      "ja": "日本語が少しできます",
+      "en": "I speak a little Japanese",
+      "zh": "我会一点日语",
+      "ko": "일본어를 조금 할 수 있어요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-016",
+    "categoryId": "thanks",
+    "tags": [
+      "thanks"
+    ],
+    "text": {
+      "ja": "ありがとうございます",
+      "en": "Thank you",
+      "zh": "谢谢",
+      "ko": "감사합니다"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-017",
+    "categoryId": "thanks",
+    "tags": [
+      "thanks"
+    ],
+    "text": {
+      "ja": "助かりました",
+      "en": "That helped a lot",
+      "zh": "帮了大忙",
+      "ko": "큰 도움이 되었어요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-018",
+    "categoryId": "thanks",
+    "tags": [
+      "thanks"
+    ],
+    "text": {
+      "ja": "親切にしてくれてありがとう",
+      "en": "Thank you for your kindness",
+      "zh": "谢谢你的好意",
+      "ko": "친절하게 대해줘서 고마워요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-019",
+    "categoryId": "thanks",
+    "tags": [
+      "thanks"
+    ],
+    "text": {
+      "ja": "すみません、助けてくれて",
+      "en": "Thanks for helping",
+      "zh": "谢谢帮忙",
+      "ko": "도와줘서 고마워요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-020",
+    "categoryId": "apology",
+    "tags": [
+      "apology"
+    ],
+    "text": {
+      "ja": "すみません",
+      "en": "Excuse me",
+      "zh": "不好意思",
+      "ko": "실례합니다"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-021",
+    "categoryId": "apology",
+    "tags": [
+      "apology"
+    ],
+    "text": {
+      "ja": "申し訳ありません",
+      "en": "I am sorry",
+      "zh": "非常抱歉",
+      "ko": "죄송합니다"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-022",
+    "categoryId": "apology",
+    "tags": [
+      "apology"
+    ],
+    "text": {
+      "ja": "遅れてすみません",
+      "en": "Sorry for being late",
+      "zh": "抱歉迟到了",
+      "ko": "늦어서 죄송합니다"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-023",
+    "categoryId": "apology",
+    "tags": [
+      "apology"
+    ],
+    "text": {
+      "ja": "間違えました",
+      "en": "I made a mistake",
+      "zh": "我弄错了",
+      "ko": "제가 잘못했어요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-024",
+    "categoryId": "directions",
+    "tags": [
+      "directions"
+    ],
+    "text": {
+      "ja": "駅はどこですか",
+      "en": "Where is the station?",
+      "zh": "车站在哪里？",
+      "ko": "역이 어디예요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-025",
+    "categoryId": "directions",
+    "tags": [
+      "directions"
+    ],
+    "text": {
+      "ja": "この道で合っていますか",
+      "en": "Is this the right way?",
+      "zh": "这条路对吗？",
+      "ko": "이 길이 맞나요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-026",
+    "categoryId": "directions",
+    "tags": [
+      "directions"
+    ],
+    "text": {
+      "ja": "まっすぐ行ってください",
+      "en": "Please go straight",
+      "zh": "请直走",
+      "ko": "곧장 가세요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-027",
+    "categoryId": "directions",
+    "tags": [
+      "directions"
+    ],
+    "text": {
+      "ja": "右に曲がってください",
+      "en": "Please turn right",
+      "zh": "请右转",
+      "ko": "오른쪽으로 도세요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-028",
+    "categoryId": "directions",
+    "tags": [
+      "directions"
+    ],
+    "text": {
+      "ja": "左に曲がってください",
+      "en": "Please turn left",
+      "zh": "请左转",
+      "ko": "왼쪽으로 도세요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-029",
+    "categoryId": "directions",
+    "tags": [
+      "directions"
+    ],
+    "text": {
+      "ja": "ここで降ります",
+      "en": "I will get off here",
+      "zh": "我在这里下车",
+      "ko": "여기서 내릴게요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-030",
+    "categoryId": "shopping",
+    "tags": [
+      "shopping"
+    ],
+    "text": {
+      "ja": "これはいくらですか",
+      "en": "How much is this?",
+      "zh": "这个多少钱？",
+      "ko": "이거 얼마예요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-031",
+    "categoryId": "shopping",
+    "tags": [
+      "shopping"
+    ],
+    "text": {
+      "ja": "試着できますか",
+      "en": "Can I try it on?",
+      "zh": "可以试穿吗？",
+      "ko": "입어봐도 되나요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-032",
+    "categoryId": "shopping",
+    "tags": [
+      "shopping"
+    ],
+    "text": {
+      "ja": "別の色はありますか",
+      "en": "Do you have another color?",
+      "zh": "有别的颜色吗？",
+      "ko": "다른 색 있나요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-033",
+    "categoryId": "shopping",
+    "tags": [
+      "shopping"
+    ],
+    "text": {
+      "ja": "小さいサイズはありますか",
+      "en": "Do you have a smaller size?",
+      "zh": "有小号吗？",
+      "ko": "더 작은 사이즈 있나요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-034",
+    "categoryId": "shopping",
+    "tags": [
+      "shopping"
+    ],
+    "text": {
+      "ja": "これをください",
+      "en": "I will take this",
+      "zh": "我要这个",
+      "ko": "이걸로 주세요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-035",
+    "categoryId": "shopping",
+    "tags": [
+      "shopping"
+    ],
+    "text": {
+      "ja": "カードで払えますか",
+      "en": "Can I pay by card?",
+      "zh": "可以刷卡吗？",
+      "ko": "카드로 결제할 수 있나요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-036",
+    "categoryId": "shopping",
+    "tags": [
+      "shopping"
+    ],
+    "text": {
+      "ja": "免税はできますか",
+      "en": "Is tax-free available?",
+      "zh": "可以免税吗？",
+      "ko": "면세 되나요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-037",
+    "categoryId": "dining",
+    "tags": [
+      "dining"
+    ],
+    "text": {
+      "ja": "おすすめはありますか",
+      "en": "Do you have a recommendation?",
+      "zh": "有什么推荐吗？",
+      "ko": "추천이 있나요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-038",
+    "categoryId": "dining",
+    "tags": [
+      "dining"
+    ],
+    "text": {
+      "ja": "メニューをください",
+      "en": "Can I have a menu?",
+      "zh": "请给我菜单",
+      "ko": "메뉴 주세요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-039",
+    "categoryId": "dining",
+    "tags": [
+      "dining"
+    ],
+    "text": {
+      "ja": "これを注文します",
+      "en": "I will order this",
+      "zh": "我要点这个",
+      "ko": "이걸 주문할게요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-040",
+    "categoryId": "dining",
+    "tags": [
+      "dining"
+    ],
+    "text": {
+      "ja": "辛くないですか",
+      "en": "Is it not spicy?",
+      "zh": "不辣吗？",
+      "ko": "안 맵나요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-041",
+    "categoryId": "dining",
+    "tags": [
+      "dining"
+    ],
+    "text": {
+      "ja": "水をください",
+      "en": "Water, please",
+      "zh": "请给我水",
+      "ko": "물 주세요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-042",
+    "categoryId": "dining",
+    "tags": [
+      "dining"
+    ],
+    "text": {
+      "ja": "お会計お願いします",
+      "en": "Check, please",
+      "zh": "请结账",
+      "ko": "계산 부탁드립니다"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-043",
+    "categoryId": "transport",
+    "tags": [
+      "transport"
+    ],
+    "text": {
+      "ja": "次の電車は何時ですか",
+      "en": "When is the next train?",
+      "zh": "下一班电车几点？",
+      "ko": "다음 열차는 언제예요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-044",
+    "categoryId": "transport",
+    "tags": [
+      "transport"
+    ],
+    "text": {
+      "ja": "このバスは空港に行きますか",
+      "en": "Does this bus go to the airport?",
+      "zh": "这辆巴士去机场吗？",
+      "ko": "이 버스는 공항에 가나요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-045",
+    "categoryId": "transport",
+    "tags": [
+      "transport"
+    ],
+    "text": {
+      "ja": "切符を買いたいです",
+      "en": "I want to buy a ticket",
+      "zh": "我想买票",
+      "ko": "표를 사고 싶어요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-046",
+    "categoryId": "transport",
+    "tags": [
+      "transport"
+    ],
+    "text": {
+      "ja": "乗り換えはどこですか",
+      "en": "Where do I transfer?",
+      "zh": "在哪里换乘？",
+      "ko": "환승은 어디에서 하나요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-047",
+    "categoryId": "transport",
+    "tags": [
+      "transport"
+    ],
+    "text": {
+      "ja": "タクシーを呼んでください",
+      "en": "Please call a taxi",
+      "zh": "请帮我叫出租车",
+      "ko": "택시를 불러 주세요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-048",
+    "categoryId": "hotel",
+    "tags": [
+      "hotel"
+    ],
+    "text": {
+      "ja": "チェックインしたいです",
+      "en": "I would like to check in",
+      "zh": "我想办理入住",
+      "ko": "체크인하고 싶어요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-049",
+    "categoryId": "hotel",
+    "tags": [
+      "hotel"
+    ],
+    "text": {
+      "ja": "チェックアウトは何時ですか",
+      "en": "What time is check-out?",
+      "zh": "退房时间是几点？",
+      "ko": "체크아웃 시간은 언제인가요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-050",
+    "categoryId": "hotel",
+    "tags": [
+      "hotel"
+    ],
+    "text": {
+      "ja": "部屋にタオルを追加できますか",
+      "en": "Can I get extra towels?",
+      "zh": "可以多给毛巾吗？",
+      "ko": "수건을 더 받을 수 있나요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-051",
+    "categoryId": "hotel",
+    "tags": [
+      "hotel"
+    ],
+    "text": {
+      "ja": "Wi-Fiのパスワードは何ですか",
+      "en": "What is the Wi-Fi password?",
+      "zh": "Wi-Fi密码是什么？",
+      "ko": "와이파이 비밀번호가 뭐예요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-052",
+    "categoryId": "hotel",
+    "tags": [
+      "hotel"
+    ],
+    "text": {
+      "ja": "荷物を預けてもいいですか",
+      "en": "Can I leave my luggage?",
+      "zh": "可以寄存行李吗？",
+      "ko": "짐을 맡길 수 있나요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-053",
+    "categoryId": "emergency",
+    "tags": [
+      "emergency"
+    ],
+    "text": {
+      "ja": "助けてください",
+      "en": "Please help",
+      "zh": "请帮帮我",
+      "ko": "도와주세요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-054",
+    "categoryId": "emergency",
+    "tags": [
+      "emergency"
+    ],
+    "text": {
+      "ja": "具合が悪いです",
+      "en": "I feel sick",
+      "zh": "我不舒服",
+      "ko": "몸이 안 좋아요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-055",
+    "categoryId": "emergency",
+    "tags": [
+      "emergency"
+    ],
+    "text": {
+      "ja": "病院に行きたいです",
+      "en": "I want to go to a hospital",
+      "zh": "我想去医院",
+      "ko": "병원에 가고 싶어요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-056",
+    "categoryId": "emergency",
+    "tags": [
+      "emergency"
+    ],
+    "text": {
+      "ja": "警察を呼んでください",
+      "en": "Please call the police",
+      "zh": "请报警",
+      "ko": "경찰을 불러 주세요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-057",
+    "categoryId": "emergency",
+    "tags": [
+      "emergency"
+    ],
+    "text": {
+      "ja": "財布をなくしました",
+      "en": "I lost my wallet",
+      "zh": "我丢了钱包",
+      "ko": "지갑을 잃어버렸어요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-058",
+    "categoryId": "daily",
+    "tags": [
+      "daily"
+    ],
+    "text": {
+      "ja": "今日はいい天気ですね",
+      "en": "Nice weather today",
+      "zh": "今天天气很好",
+      "ko": "오늘 날씨가 좋네요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-059",
+    "categoryId": "daily",
+    "tags": [
+      "daily"
+    ],
+    "text": {
+      "ja": "写真を撮ってもらえますか",
+      "en": "Could you take a photo?",
+      "zh": "能帮我拍照吗？",
+      "ko": "사진 좀 찍어 주실래요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-060",
+    "categoryId": "daily",
+    "tags": [
+      "daily"
+    ],
+    "text": {
+      "ja": "これはどこで買えますか",
+      "en": "Where can I buy this?",
+      "zh": "这个在哪里买？",
+      "ko": "이건 어디에서 살 수 있나요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-061",
+    "categoryId": "daily",
+    "tags": [
+      "daily"
+    ],
+    "text": {
+      "ja": "トイレはどこですか",
+      "en": "Where is the restroom?",
+      "zh": "洗手间在哪里？",
+      "ko": "화장실이 어디예요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-062",
+    "categoryId": "daily",
+    "tags": [
+      "daily"
+    ],
+    "text": {
+      "ja": "もう一度お願いします",
+      "en": "One more time, please",
+      "zh": "请再说一次",
+      "ko": "한 번 더 부탁드려요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-063",
+    "categoryId": "daily",
+    "tags": [
+      "daily"
+    ],
+    "text": {
+      "ja": "私は観光客です",
+      "en": "I am a tourist",
+      "zh": "我是游客",
+      "ko": "저는 관광객입니다"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-064",
+    "categoryId": "daily",
+    "tags": [
+      "daily"
+    ],
+    "text": {
+      "ja": "地図がありますか",
+      "en": "Do you have a map?",
+      "zh": "有地图吗？",
+      "ko": "지도 있나요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-065",
+    "categoryId": "daily",
+    "tags": [
+      "daily"
+    ],
+    "text": {
+      "ja": "ここで待っていてください",
+      "en": "Please wait here",
+      "zh": "请在这里等",
+      "ko": "여기서 기다려 주세요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-066",
+    "categoryId": "daily",
+    "tags": [
+      "daily"
+    ],
+    "text": {
+      "ja": "今すぐ行きます",
+      "en": "I will go now",
+      "zh": "我马上过去",
+      "ko": "지금 갈게요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-067",
+    "categoryId": "daily",
+    "tags": [
+      "daily"
+    ],
+    "text": {
+      "ja": "少し待ちます",
+      "en": "I will wait a bit",
+      "zh": "我等一下",
+      "ko": "조금 기다릴게요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-068",
+    "categoryId": "dining",
+    "tags": [
+      "dining"
+    ],
+    "text": {
+      "ja": "アレルギーがあります",
+      "en": "I have an allergy",
+      "zh": "我有过敏",
+      "ko": "알레르기가 있습니다"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-069",
+    "categoryId": "dining",
+    "tags": [
+      "dining"
+    ],
+    "text": {
+      "ja": "辛さを控えめにできますか",
+      "en": "Can you make it less spicy?",
+      "zh": "可以少辣吗？",
+      "ko": "덜 맵게 해줄 수 있나요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-070",
+    "categoryId": "dining",
+    "tags": [
+      "dining"
+    ],
+    "text": {
+      "ja": "ベジタリアンです",
+      "en": "I am vegetarian",
+      "zh": "我是素食者",
+      "ko": "채식주의자예요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-071",
+    "categoryId": "dining",
+    "tags": [
+      "dining"
+    ],
+    "text": {
+      "ja": "水は有料ですか",
+      "en": "Is water free?",
+      "zh": "水是免费的么？",
+      "ko": "물은 무료인가요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-072",
+    "categoryId": "dining",
+    "tags": [
+      "dining"
+    ],
+    "text": {
+      "ja": "お箸をください",
+      "en": "Chopsticks, please",
+      "zh": "请给我筷子",
+      "ko": "젓가락 주세요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-073",
+    "categoryId": "shopping",
+    "tags": [
+      "shopping"
+    ],
+    "text": {
+      "ja": "領収書をください",
+      "en": "Please give me a receipt",
+      "zh": "请给我收据",
+      "ko": "영수증 주세요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-074",
+    "categoryId": "shopping",
+    "tags": [
+      "shopping"
+    ],
+    "text": {
+      "ja": "免税手続きがしたいです",
+      "en": "I want tax-free processing",
+      "zh": "我想办理免税",
+      "ko": "면세 처리하고 싶어요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-075",
+    "categoryId": "shopping",
+    "tags": [
+      "shopping"
+    ],
+    "text": {
+      "ja": "ポイントカードはありますか",
+      "en": "Do you have a point card?",
+      "zh": "有会员卡吗？",
+      "ko": "포인트 카드 있나요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-076",
+    "categoryId": "shopping",
+    "tags": [
+      "shopping"
+    ],
+    "text": {
+      "ja": "袋をください",
+      "en": "Can I have a bag?",
+      "zh": "请给我袋子",
+      "ko": "봉투 주세요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-077",
+    "categoryId": "shopping",
+    "tags": [
+      "shopping"
+    ],
+    "text": {
+      "ja": "試着室はどこですか",
+      "en": "Where is the fitting room?",
+      "zh": "试衣间在哪里？",
+      "ko": "피팅룸이 어디예요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-078",
+    "categoryId": "transport",
+    "tags": [
+      "transport"
+    ],
+    "text": {
+      "ja": "この電車は快速ですか",
+      "en": "Is this a rapid train?",
+      "zh": "这班是快车吗？",
+      "ko": "이 열차는 쾌속인가요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-079",
+    "categoryId": "transport",
+    "tags": [
+      "transport"
+    ],
+    "text": {
+      "ja": "空席はありますか",
+      "en": "Are there any seats?",
+      "zh": "有空位吗？",
+      "ko": "빈 좌석이 있나요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-080",
+    "categoryId": "transport",
+    "tags": [
+      "transport"
+    ],
+    "text": {
+      "ja": "定期券は買えますか",
+      "en": "Can I buy a pass?",
+      "zh": "可以买定期票吗？",
+      "ko": "정기권을 살 수 있나요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-081",
+    "categoryId": "transport",
+    "tags": [
+      "transport"
+    ],
+    "text": {
+      "ja": "出口はどこですか",
+      "en": "Where is the exit?",
+      "zh": "出口在哪里？",
+      "ko": "출구가 어디예요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-082",
+    "categoryId": "transport",
+    "tags": [
+      "transport"
+    ],
+    "text": {
+      "ja": "改札はどこですか",
+      "en": "Where are the ticket gates?",
+      "zh": "检票口在哪里？",
+      "ko": "개찰구가 어디예요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-083",
+    "categoryId": "hotel",
+    "tags": [
+      "hotel"
+    ],
+    "text": {
+      "ja": "朝食は何時からですか",
+      "en": "When is breakfast?",
+      "zh": "早餐几点开始？",
+      "ko": "아침식사는 몇 시부터예요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-084",
+    "categoryId": "hotel",
+    "tags": [
+      "hotel"
+    ],
+    "text": {
+      "ja": "ルームサービスはありますか",
+      "en": "Is there room service?",
+      "zh": "有客房服务吗？",
+      "ko": "룸서비스가 있나요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-085",
+    "categoryId": "hotel",
+    "tags": [
+      "hotel"
+    ],
+    "text": {
+      "ja": "タクシーを予約したいです",
+      "en": "I want to reserve a taxi",
+      "zh": "我想预约出租车",
+      "ko": "택시 예약하고 싶어요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-086",
+    "categoryId": "hotel",
+    "tags": [
+      "hotel"
+    ],
+    "text": {
+      "ja": "部屋が寒いです",
+      "en": "The room is cold",
+      "zh": "房间很冷",
+      "ko": "방이 추워요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-087",
+    "categoryId": "hotel",
+    "tags": [
+      "hotel"
+    ],
+    "text": {
+      "ja": "延泊できますか",
+      "en": "Can I extend my stay?",
+      "zh": "可以延住吗？",
+      "ko": "숙박을 연장할 수 있나요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-088",
+    "categoryId": "emergency",
+    "tags": [
+      "emergency"
+    ],
+    "text": {
+      "ja": "火事です",
+      "en": "There is a fire",
+      "zh": "着火了",
+      "ko": "불이 났어요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-089",
+    "categoryId": "emergency",
+    "tags": [
+      "emergency"
+    ],
+    "text": {
+      "ja": "救急車を呼んでください",
+      "en": "Please call an ambulance",
+      "zh": "请叫救护车",
+      "ko": "구급차를 불러 주세요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-090",
+    "categoryId": "emergency",
+    "tags": [
+      "emergency"
+    ],
+    "text": {
+      "ja": "パスポートをなくしました",
+      "en": "I lost my passport",
+      "zh": "我丢了护照",
+      "ko": "여권을 잃어버렸어요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-091",
+    "categoryId": "emergency",
+    "tags": [
+      "emergency"
+    ],
+    "text": {
+      "ja": "道に迷いました",
+      "en": "I am lost",
+      "zh": "我迷路了",
+      "ko": "길을 잃었어요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-092",
+    "categoryId": "emergency",
+    "tags": [
+      "emergency"
+    ],
+    "text": {
+      "ja": "とても痛いです",
+      "en": "It hurts a lot",
+      "zh": "很痛",
+      "ko": "많이 아파요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-093",
+    "categoryId": "directions",
+    "tags": [
+      "directions"
+    ],
+    "text": {
+      "ja": "近くにコンビニはありますか",
+      "en": "Is there a convenience store nearby?",
+      "zh": "附近有便利店吗？",
+      "ko": "근처에 편의점이 있나요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-094",
+    "categoryId": "directions",
+    "tags": [
+      "directions"
+    ],
+    "text": {
+      "ja": "次の角を右です",
+      "en": "Turn right at the next corner",
+      "zh": "下一个路口右转",
+      "ko": "다음 모퉁이에서 오른쪽으로 도세요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-095",
+    "categoryId": "directions",
+    "tags": [
+      "directions"
+    ],
+    "text": {
+      "ja": "信号のところで左です",
+      "en": "Turn left at the traffic light",
+      "zh": "红绿灯处左转",
+      "ko": "신호등에서 왼쪽으로 도세요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-096",
+    "categoryId": "directions",
+    "tags": [
+      "directions"
+    ],
+    "text": {
+      "ja": "徒歩で何分ですか",
+      "en": "How many minutes on foot?",
+      "zh": "走路要几分钟？",
+      "ko": "걸어서 몇 분인가요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-097",
+    "categoryId": "directions",
+    "tags": [
+      "directions"
+    ],
+    "text": {
+      "ja": "ここから遠いですか",
+      "en": "Is it far from here?",
+      "zh": "离这里远吗？",
+      "ko": "여기서 멀어요?"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-098",
+    "categoryId": "greeting",
+    "tags": [
+      "greeting"
+    ],
+    "text": {
+      "ja": "お久しぶりです",
+      "en": "Long time no see",
+      "zh": "好久不见",
+      "ko": "오랜만이에요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-099",
+    "categoryId": "greeting",
+    "tags": [
+      "greeting"
+    ],
+    "text": {
+      "ja": "ようこそ",
+      "en": "Welcome",
+      "zh": "欢迎",
+      "ko": "환영합니다"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  },
+  {
+    "id": "card-100",
+    "categoryId": "greeting",
+    "tags": [
+      "greeting"
+    ],
+    "text": {
+      "ja": "気をつけて",
+      "en": "Take care",
+      "zh": "请保重",
+      "ko": "조심하세요"
+    },
+    "replyPresets": [
+      "ok",
+      "yes",
+      "no",
+      "wait",
+      "custom"
+    ]
+  }
+]

--- a/data/categories.json
+++ b/data/categories.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "greeting",
+    "name_ja": "挨拶",
+    "name_en": "Greetings",
+    "sortOrder": 1
+  },
+  {
+    "id": "daily",
+    "name_ja": "日常会話",
+    "name_en": "Daily",
+    "sortOrder": 2
+  },
+  {
+    "id": "thanks",
+    "name_ja": "感謝",
+    "name_en": "Thanks",
+    "sortOrder": 3
+  },
+  {
+    "id": "apology",
+    "name_ja": "謝罪",
+    "name_en": "Apology",
+    "sortOrder": 4
+  },
+  {
+    "id": "directions",
+    "name_ja": "道案内",
+    "name_en": "Directions",
+    "sortOrder": 5
+  },
+  {
+    "id": "shopping",
+    "name_ja": "買い物",
+    "name_en": "Shopping",
+    "sortOrder": 6
+  },
+  {
+    "id": "dining",
+    "name_ja": "飲食",
+    "name_en": "Dining",
+    "sortOrder": 7
+  },
+  {
+    "id": "transport",
+    "name_ja": "交通",
+    "name_en": "Transport",
+    "sortOrder": 8
+  },
+  {
+    "id": "hotel",
+    "name_ja": "宿泊",
+    "name_en": "Hotel",
+    "sortOrder": 9
+  },
+  {
+    "id": "emergency",
+    "name_ja": "緊急",
+    "name_en": "Emergency",
+    "sortOrder": 10
+  }
+]

--- a/index.html
+++ b/index.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>翻訳カード</title>
+    <link rel="stylesheet" href="/assets/styles.css" />
+  </head>
+  <body>
+    <div id="app" class="app">
+      <header class="app-header">
+        <div class="brand">
+          <div class="brand-mark">翻</div>
+          <div>
+            <h1>翻訳カード</h1>
+            <p>Translation Card UI</p>
+          </div>
+        </div>
+        <nav class="nav">
+          <button class="nav-button" data-view="home">ホーム</button>
+          <button class="nav-button" data-view="history">履歴</button>
+        </nav>
+      </header>
+
+      <main class="app-main">
+        <section class="toolbar">
+          <div class="language-selector" id="languageSelector"></div>
+          <div class="search">
+            <input id="searchInput" type="search" placeholder="カードを検索" />
+          </div>
+        </section>
+
+        <section class="category-filter" id="categoryFilter"></section>
+
+        <section id="homeView" class="view view-active">
+          <div id="cardGrid" class="card-grid"></div>
+        </section>
+
+        <section id="detailView" class="view">
+          <button class="back-button" id="backButton">← 戻る</button>
+          <div id="detailCard" class="detail-card"></div>
+        </section>
+
+        <section id="historyView" class="view">
+          <h2>最近の履歴</h2>
+          <div id="historyList" class="history-list"></div>
+        </section>
+      </main>
+    </div>
+
+    <script src="/assets/app.js" type="module"></script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Replace the previous Vite + React + TypeScript scaffold with a pure HTML + JavaScript mock as requested to prioritize a runnable mock experience.
- Provide a highly designed, data-driven UI that can be used on iPad-sized viewports and easily inspected/extended without a build step.
- Ship a realistic dataset of ~100 cards focused on daily conversation and commonly used phrases, organized into categories for discoverability.
- Keep all state and data local so the mock works offline and persists user responses and history via `localStorage`.

### Description
- Removed the React/TypeScript app and added a static implementation with `index.html`, `assets/app.js`, and `assets/styles.css`, plus `data/cards.json` (100 cards) and `data/categories.json` for categories and metadata.
- Implemented SPA-like view switching, language selector (EN/ZH/KO), search, category filter, card grid, detail view with reply presets and custom memo entry, and a history view; replies and history persist using the keys documented in `README.md`.
- Added client-side features including `replyLabels`, reply presets (`ok`, `yes`, `no`, `wait`, `custom`), filtering, history capped to 20 entries, and helper functions to save/load from `localStorage`.
- Updated project docs and added `.gitignore` and a README describing how to run the static mock and how to extend data files.

### Testing
- Started a static server with `python -m http.server 5173`, which successfully served the app and JSON data files.
- Ran an automated Playwright script that loaded `http://127.0.0.1:5173` and produced a screenshot of the home view (`artifacts/translation-cards-home.png`) successfully.
- No unit tests were added in this PR and no npm-based test steps were required for the static mock.
- Manual interactions (loading pages, switching language, setting replies and memos) were exercised via the automated load/screenshot step and reported successful serving of assets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954b26b44e8832990e14ee97f59667a)