### PR TITLE
Add turnover rate dashboard mock (HTML + vanilla JS)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,267 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>回転率ダッシュボード（モック）</title>
+  <style>
+    :root {
+      color-scheme: light;
+      font-family: "Hiragino Kaku Gothic ProN", "Noto Sans JP", system-ui, sans-serif;
+      --bg: #f7f7f9;
+      --card: #ffffff;
+      --text: #1d1d1f;
+      --muted: #6b7280;
+      --accent: #1f6feb;
+      --accent-2: #f59e0b;
+      --border: #e5e7eb;
+    }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+    }
+    header {
+      padding: 32px 24px 8px;
+    }
+    header h1 {
+      margin: 0 0 8px;
+      font-size: 24px;
+    }
+    header p {
+      margin: 0;
+      color: var(--muted);
+    }
+    .container {
+      display: grid;
+      gap: 16px;
+      padding: 16px 24px 48px;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    }
+    .card {
+      background: var(--card);
+      border-radius: 16px;
+      border: 1px solid var(--border);
+      box-shadow: 0 10px 20px rgba(0, 0, 0, 0.04);
+      padding: 20px;
+    }
+    .card h2 {
+      margin-top: 0;
+      font-size: 18px;
+    }
+    .inputs {
+      display: grid;
+      gap: 12px;
+    }
+    label {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      font-size: 14px;
+      color: var(--muted);
+    }
+    input[type="number"] {
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 10px 12px;
+      font-size: 16px;
+    }
+    .metrics {
+      display: grid;
+      gap: 12px;
+    }
+    .metric {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 12px;
+      border-radius: 12px;
+      background: #f9fafb;
+      border: 1px solid var(--border);
+    }
+    .metric span {
+      font-weight: 600;
+    }
+    .chart {
+      display: grid;
+      gap: 16px;
+    }
+    .bar {
+      height: 18px;
+      border-radius: 999px;
+      background: #e5e7eb;
+      position: relative;
+      overflow: hidden;
+    }
+    .bar-fill {
+      height: 100%;
+      border-radius: inherit;
+      transition: width 0.4s ease;
+    }
+    .bar-label {
+      display: flex;
+      justify-content: space-between;
+      font-size: 14px;
+      color: var(--muted);
+      margin-bottom: 6px;
+    }
+    .hint {
+      font-size: 13px;
+      color: var(--muted);
+      line-height: 1.5;
+    }
+    .tag {
+      font-size: 12px;
+      padding: 4px 8px;
+      border-radius: 999px;
+      background: rgba(31, 111, 235, 0.1);
+      color: var(--accent);
+      font-weight: 600;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>回転率モックダッシュボード</h1>
+    <p>小規模飲食店向けの回転率可視化・試算ツールのイメージです。</p>
+  </header>
+
+  <main class="container">
+    <section class="card">
+      <h2>入力</h2>
+      <div class="inputs">
+        <label>
+          席数（席）
+          <input id="seats" type="number" min="1" value="18" />
+        </label>
+        <label>
+          営業時間（時間）
+          <input id="hours" type="number" min="1" step="0.5" value="8" />
+        </label>
+        <label>
+          平均滞在時間（分）
+          <input id="stay" type="number" min="10" step="5" value="55" />
+        </label>
+        <label>
+          来店人数（人）
+          <input id="guests" type="number" min="1" value="120" />
+        </label>
+      </div>
+      <p class="hint">
+        来店人数は実績値、席数・営業時間・平均滞在時間は目標値として入力すると
+        現在の回転率と理論上の回転率を比較できます。
+      </p>
+    </section>
+
+    <section class="card">
+      <h2>回転率の指標</h2>
+      <div class="metrics">
+        <div class="metric">
+          <div>
+            <div>実績回転率</div>
+            <small class="hint">来店人数 ÷ 席数</small>
+          </div>
+          <span id="actualTurnover">-</span>
+        </div>
+        <div class="metric">
+          <div>
+            <div>理論回転率</div>
+            <small class="hint">営業時間 ÷ 平均滞在時間</small>
+          </div>
+          <span id="idealTurnover">-</span>
+        </div>
+        <div class="metric">
+          <div>
+            <div>達成率</div>
+            <small class="hint">実績 ÷ 理論</small>
+          </div>
+          <span id="achievement">-</span>
+        </div>
+        <div class="metric">
+          <div>
+            <div>想定回転回数</div>
+            <small class="hint">理論回転率 × 席数</small>
+          </div>
+          <span id="totalCycles">-</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>回転率の可視化</h2>
+      <div class="chart">
+        <div>
+          <div class="bar-label">
+            <span>実績回転率</span>
+            <span class="tag" id="actualLabel">-</span>
+          </div>
+          <div class="bar">
+            <div class="bar-fill" id="actualBar" style="background: var(--accent); width: 0%;"></div>
+          </div>
+        </div>
+        <div>
+          <div class="bar-label">
+            <span>理論回転率</span>
+            <span class="tag" id="idealLabel">-</span>
+          </div>
+          <div class="bar">
+            <div class="bar-fill" id="idealBar" style="background: var(--accent-2); width: 0%;"></div>
+          </div>
+        </div>
+      </div>
+      <p class="hint">
+        実績回転率が理論回転率に近いほど、席の稼働が最適化されています。
+      </p>
+    </section>
+  </main>
+
+  <script>
+    const seatsInput = document.getElementById("seats");
+    const hoursInput = document.getElementById("hours");
+    const stayInput = document.getElementById("stay");
+    const guestsInput = document.getElementById("guests");
+
+    const actualTurnover = document.getElementById("actualTurnover");
+    const idealTurnover = document.getElementById("idealTurnover");
+    const achievement = document.getElementById("achievement");
+    const totalCycles = document.getElementById("totalCycles");
+
+    const actualLabel = document.getElementById("actualLabel");
+    const idealLabel = document.getElementById("idealLabel");
+    const actualBar = document.getElementById("actualBar");
+    const idealBar = document.getElementById("idealBar");
+
+    const formatNumber = (value) => Number.isFinite(value) ? value.toFixed(2) : "-";
+
+    const updateDashboard = () => {
+      const seats = Number(seatsInput.value);
+      const hours = Number(hoursInput.value);
+      const stayMinutes = Number(stayInput.value);
+      const guests = Number(guestsInput.value);
+
+      const actual = seats > 0 ? guests / seats : 0;
+      const ideal = stayMinutes > 0 ? (hours * 60) / stayMinutes : 0;
+      const ratio = ideal > 0 ? (actual / ideal) * 100 : 0;
+      const cycles = ideal * seats;
+
+      actualTurnover.textContent = `${formatNumber(actual)} 回`;
+      idealTurnover.textContent = `${formatNumber(ideal)} 回`;
+      achievement.textContent = `${formatNumber(ratio)} %`;
+      totalCycles.textContent = `${formatNumber(cycles)} 回/日`;
+
+      actualLabel.textContent = `${formatNumber(actual)} 回`;
+      idealLabel.textContent = `${formatNumber(ideal)} 回`;
+
+      const maxValue = Math.max(actual, ideal, 1);
+      actualBar.style.width = `${(actual / maxValue) * 100}%`;
+      idealBar.style.width = `${(ideal / maxValue) * 100}%`;
+    };
+
+    [seatsInput, hoursInput, stayInput, guestsInput].forEach((input) => {
+      input.addEventListener("input", updateDashboard);
+    });
+
+    updateDashboard();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a lightweight mock dashboard so small restaurant owners can visualize and experiment with seat turnover assumptions and results.
- Offer a single-file, static example that computes key turnover metrics from simple inputs for quick iteration and demonstration.

### Description
- Add a standalone `index.html` that contains input fields for seats/hours/average stay/guests, metric panels, and bar-style visualizations. 
- Implement interactive calculations in vanilla JavaScript via the `updateDashboard` function and attach live `input` listeners to update the UI.
- Include responsive CSS and small UI details (formatted labels, tags, and animated bar fills) for a presentable mockup.

### Testing
- Served the static page with `python -m http.server 8000` and confirmed the page could be loaded (succeeded). 
- Ran a Playwright (Python) script to load `index.html` and capture a screenshot `artifacts/turnover-dashboard.png` (succeeded).
- An earlier Node-based Playwright attempt failed due to using JS code in a Python runner (syntax error) (failed).
- No unit tests were added because this is a static HTML/JS mockup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965c1f100948329863e70fbf4e616cf)