### PR TITLE
Add responsive robots.txt FAQ mock site

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,264 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ローカルダイナー | robots.txt活用FAQと事例</title>
+    <meta
+      name="description"
+      content="飲食店サイト向けにrobots.txtの使い方やFAQ、ケーススタディ、AIに優しい文言例をまとめたモックサイト。"
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <nav class="nav">
+        <div class="logo">LOCAL DINER</div>
+        <button class="nav-toggle" aria-expanded="false" aria-controls="nav-menu">
+          <span class="sr-only">メニューを開く</span>
+          <span class="bar"></span>
+          <span class="bar"></span>
+          <span class="bar"></span>
+        </button>
+        <div id="nav-menu" class="nav-menu">
+          <a href="#about">店舗紹介</a>
+          <a href="#menu">商品紹介</a>
+          <a href="#robots">robots.txt</a>
+          <a href="#faq">FAQ</a>
+          <a href="#cases">事例</a>
+          <a href="#ai-copy">AI文言例</a>
+        </div>
+      </nav>
+      <div class="hero-content">
+        <p class="eyebrow">スマホベースのレスポンシブ構成</p>
+        <h1>飲食店サイトのための<br />robots.txtガイド</h1>
+        <p>
+          メニューや店舗情報を正しく届けながら、検索クローラーに配慮したサイト運営をサポート。
+          FAQ、ケーススタディ、AIに優しい文言例をまとめました。
+        </p>
+        <div class="hero-actions">
+          <a class="primary" href="#robots">使い方を見る</a>
+          <a class="secondary" href="#ai-copy">AI文言例へ</a>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section id="about" class="section">
+        <div class="section-header">
+          <h2>店舗紹介</h2>
+          <p>「LOCAL DINER」は季節素材を活かした料理と、街の人が集う心地よい空間が自慢のダイナーです。</p>
+        </div>
+        <div class="cards">
+          <article class="card">
+            <h3>朝食からディナーまで</h3>
+            <p>モーニングは自家製グラノーラ、ランチは日替わりプレート、夜はワインとタパスが人気。</p>
+          </article>
+          <article class="card">
+            <h3>アクセスと営業時間</h3>
+            <p>駅前徒歩3分。平日 8:00-21:00 / 土日祝 9:00-22:00。</p>
+          </article>
+          <article class="card">
+            <h3>デジタルメニュー</h3>
+            <p>オンライン予約・デジタルメニューを整備し、クローラーにも分かりやすい情報設計を採用。</p>
+          </article>
+        </div>
+      </section>
+
+      <section id="menu" class="section alt">
+        <div class="section-header">
+          <h2>商品紹介</h2>
+          <p>写真や価格、アレルゲン情報を整理し、AIと検索エンジンの両方に伝わるメニュー構成を意識。</p>
+        </div>
+        <div class="cards">
+          <article class="card">
+            <h3>シトラスチキンサラダ</h3>
+            <p>ジューシーなチキンと柑橘ドレッシング。1,180円 / たんぱく質20g。</p>
+          </article>
+          <article class="card">
+            <h3>季節野菜のグリルプレート</h3>
+            <p>契約農家の野菜をシンプルにグリル。1,480円 / ヴィーガン対応。</p>
+          </article>
+          <article class="card">
+            <h3>スモークサーモンベネディクト</h3>
+            <p>自家製ソースと半熟ポーチドエッグ。1,680円 / ブランチで人気。</p>
+          </article>
+        </div>
+      </section>
+
+      <section id="robots" class="section">
+        <div class="section-header">
+          <h2>robots.txtとは</h2>
+          <p>
+            robots.txtは検索クローラーに対してアクセスを制御するためのテキストファイルです。
+            食品写真や予約ページなど、公開範囲を明確にするのに役立ちます。
+          </p>
+        </div>
+        <div class="split">
+          <div>
+            <h3>基本構成</h3>
+            <p>サイト直下に設置し、ユーザーエージェントと許可/拒否パスを記述します。</p>
+            <pre><code>User-agent: *
+Disallow: /admin/
+Disallow: /draft-menu/
+Allow: /menu/
+Sitemap: https://localdiner.example.com/sitemap.xml</code></pre>
+          </div>
+          <div>
+            <h3>飲食店サイト向けのポイント</h3>
+            <ul>
+              <li>予約フォームの検証用URLは非公開に設定。</li>
+              <li>写真ギャラリーやメニューは許可し、来店動機につなげる。</li>
+              <li>更新頻度の高いメニューのURLをサイトマップに追加。</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section id="faq" class="section alt">
+        <div class="section-header">
+          <h2>robots.txt FAQ</h2>
+          <p>よくある質問をスマホで読みやすいカード形式にまとめました。</p>
+        </div>
+        <div class="faq">
+          <button class="faq-item" aria-expanded="false">
+            <span>Q. robot.txt と robots.txt の違いは？</span>
+            <span class="icon">+</span>
+          </button>
+          <div class="faq-panel">
+            <p>
+              正式名称は「robots.txt」です。ファイル名を誤るとクローラーに認識されないため、必ず複数形で作成します。
+            </p>
+          </div>
+
+          <button class="faq-item" aria-expanded="false">
+            <span>Q. メニュー画像をクロールさせたい場合は？</span>
+            <span class="icon">+</span>
+          </button>
+          <div class="faq-panel">
+            <p>
+              画像を置いているディレクトリをDisallowしないようにし、検索に出したい画像は公開パスにまとめます。
+            </p>
+          </div>
+
+          <button class="faq-item" aria-expanded="false">
+            <span>Q. 予約フォームを非公開にする意味は？</span>
+            <span class="icon">+</span>
+          </button>
+          <div class="faq-panel">
+            <p>
+              テスト用フォームや内部管理画面を非公開にすることで、検索結果に意図しないページが表示されるのを防げます。
+            </p>
+          </div>
+
+          <button class="faq-item" aria-expanded="false">
+            <span>Q. AIクローラーにも効く？</span>
+            <span class="icon">+</span>
+          </button>
+          <div class="faq-panel">
+            <p>
+              一部のAIクローラーはrobots.txtを参照します。明示的なAllow/Disallowに加えて、AI向け説明文を併記すると親切です。
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section id="cases" class="section">
+        <div class="section-header">
+          <h2>ケーススタディ</h2>
+          <p>飲食店のサイト運用を想定したロールモデルを紹介します。</p>
+        </div>
+        <div class="cases">
+          <article class="case">
+            <h3>ケース1：限定メニューの先行公開</h3>
+            <p>
+              SNSキャンペーン用の限定メニューは事前公開し、/campaign/ 配下のみAllow。検索結果には表示せず、
+              SNSからの流入に集中。
+            </p>
+            <ul>
+              <li>Disallow: /campaign/preview/</li>
+              <li>Allow: /campaign/</li>
+            </ul>
+          </article>
+          <article class="case">
+            <h3>ケース2：予約管理画面を保護</h3>
+            <p>
+              /booking/manage/ をDisallowし、一般ユーザー用の予約導線だけを検索に表示。FAQページを追加して離脱率を改善。
+            </p>
+            <ul>
+              <li>Disallow: /booking/manage/</li>
+              <li>Allow: /booking/</li>
+            </ul>
+          </article>
+          <article class="case">
+            <h3>ケース3：新店舗オープン告知</h3>
+            <p>
+              新店舗の紹介ページをサイトマップに登録し、店舗一覧ページを更新。AI検索にも伝わる要約文を追加して来店誘導。
+            </p>
+            <ul>
+              <li>Sitemap: /sitemap.xml</li>
+              <li>更新頻度: 週1回</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section id="ai-copy" class="section alt">
+        <div class="section-header">
+          <h2>AIに優しい文言例</h2>
+          <p>AI検索や音声アシスタントにも伝わりやすい、明確で具体的な文言を用意しました。</p>
+        </div>
+        <div class="copy-grid">
+          <article class="copy-card">
+            <h3>店舗概要</h3>
+            <p class="label">例文</p>
+            <p>
+              LOCAL DINERは東京都渋谷区にあるカジュアルダイナーです。朝8時から夜21時まで営業し、
+              朝食・ランチ・ディナーの全時間帯でメニューを提供しています。
+            </p>
+          </article>
+          <article class="copy-card">
+            <h3>メニュー紹介</h3>
+            <p class="label">例文</p>
+            <p>
+              シトラスチキンサラダは、国産鶏むね肉とオレンジドレッシングを合わせたたんぱく質豊富なサラダです。
+              価格は1,180円で、アレルゲンは卵・乳を含みません。
+            </p>
+          </article>
+          <article class="copy-card">
+            <h3>アクセス案内</h3>
+            <p class="label">例文</p>
+            <p>
+              最寄り駅は渋谷駅で、徒歩3分です。ベビーカーでの入店が可能で、テラス席はペット同伴OKです。
+            </p>
+          </article>
+        </div>
+        <div class="note">
+          <h4>robots.txtに添えるAI向け説明例</h4>
+          <pre><code># AIクローラー向けのお願い
+# 当店のメニュー情報は /menu/ に集約しています。
+# 画像や価格情報は /menu/ 配下のページをご参照ください。</code></pre>
+        </div>
+      </section>
+
+      <section class="section cta">
+        <div>
+          <h2>サイト構築の相談はこちら</h2>
+          <p>robots.txtやサイト情報設計の相談、メニュー更新フローの整備までサポートします。</p>
+        </div>
+        <a class="primary" href="mailto:hello@localdiner.example.com">問い合わせる</a>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>© 2024 LOCAL DINER. robots.txt活用ガイド。</p>
+      <div class="footer-links">
+        <a href="#faq">FAQ</a>
+        <a href="#cases">ケーススタディ</a>
+        <a href="#ai-copy">AI文言例</a>
+      </div>
+    </footer>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,27 @@
+const navToggle = document.querySelector('.nav-toggle');
+const navMenu = document.querySelector('.nav-menu');
+
+if (navToggle && navMenu) {
+  navToggle.addEventListener('click', () => {
+    const isOpen = navMenu.classList.toggle('open');
+    navToggle.setAttribute('aria-expanded', String(isOpen));
+  });
+}
+
+const faqItems = document.querySelectorAll('.faq-item');
+
+faqItems.forEach((item) => {
+  item.addEventListener('click', () => {
+    const panel = item.nextElementSibling;
+    const isExpanded = item.getAttribute('aria-expanded') === 'true';
+    item.setAttribute('aria-expanded', String(!isExpanded));
+
+    if (panel && panel.classList.contains('faq-panel')) {
+      panel.classList.toggle('open', !isExpanded);
+      const icon = item.querySelector('.icon');
+      if (icon) {
+        icon.textContent = isExpanded ? '+' : '−';
+      }
+    }
+  });
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,358 @@
+:root {
+  color-scheme: light;
+  --bg: #f8f7f4;
+  --primary: #2c3e50;
+  --accent: #f4a259;
+  --accent-dark: #e28413;
+  --text: #1f2933;
+  --muted: #5b6770;
+  --card: #ffffff;
+  --border: #e4e0d8;
+  --shadow: 0 12px 30px rgba(20, 24, 28, 0.08);
+  font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.hero {
+  background: linear-gradient(160deg, #fff6ec 0%, #fefbf6 50%, #f7f2ea 100%);
+  padding: 1.5rem 1.25rem 3rem;
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.logo {
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  font-size: 1rem;
+}
+
+.nav-toggle {
+  background: var(--card);
+  border: 1px solid var(--border);
+  padding: 0.5rem;
+  border-radius: 999px;
+  display: grid;
+  gap: 0.2rem;
+  cursor: pointer;
+}
+
+.nav-toggle .bar {
+  width: 20px;
+  height: 2px;
+  background: var(--text);
+  display: block;
+}
+
+.nav-menu {
+  display: none;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: var(--card);
+  border: 1px solid var(--border);
+  padding: 1rem;
+  border-radius: 16px;
+  position: absolute;
+  right: 1.25rem;
+  top: 4.2rem;
+  width: min(220px, 70vw);
+  box-shadow: var(--shadow);
+  z-index: 5;
+}
+
+.nav-menu a {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.nav-menu.open {
+  display: flex;
+}
+
+.hero-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--accent-dark);
+  font-weight: 700;
+  font-size: 0.7rem;
+}
+
+.hero h1 {
+  font-size: 2.1rem;
+  line-height: 1.2;
+}
+
+.hero p {
+  color: var(--muted);
+}
+
+.hero-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.primary,
+.secondary {
+  padding: 0.75rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.primary {
+  background: var(--accent);
+  color: #1a1a1a;
+  box-shadow: 0 8px 16px rgba(244, 162, 89, 0.35);
+}
+
+.secondary {
+  background: #fff;
+  border: 1px solid var(--border);
+}
+
+.section {
+  padding: 3rem 1.25rem;
+}
+
+.section.alt {
+  background: #fffaf3;
+}
+
+.section-header {
+  display: grid;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.section-header h2 {
+  font-size: 1.6rem;
+}
+
+.section-header p {
+  color: var(--muted);
+}
+
+.cards,
+.cases,
+.copy-grid {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.card,
+.case,
+.copy-card {
+  background: var(--card);
+  padding: 1.4rem;
+  border-radius: 20px;
+  box-shadow: var(--shadow);
+  border: 1px solid transparent;
+}
+
+.card h3,
+.case h3,
+.copy-card h3 {
+  margin-bottom: 0.6rem;
+  font-size: 1.15rem;
+}
+
+.card p,
+.case p,
+.copy-card p {
+  color: var(--muted);
+}
+
+.split {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.split ul {
+  padding-left: 1.1rem;
+  color: var(--muted);
+  display: grid;
+  gap: 0.4rem;
+}
+
+pre {
+  background: #1f2a37;
+  color: #f4f5f7;
+  padding: 1rem;
+  border-radius: 16px;
+  overflow-x: auto;
+  font-size: 0.85rem;
+}
+
+.faq {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.faq-item {
+  width: 100%;
+  text-align: left;
+  border: 1px solid var(--border);
+  background: var(--card);
+  padding: 1rem 1.2rem;
+  border-radius: 16px;
+  font-weight: 600;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  cursor: pointer;
+}
+
+.faq-panel {
+  display: none;
+  background: #fff;
+  border-radius: 0 0 16px 16px;
+  border: 1px solid var(--border);
+  border-top: none;
+  padding: 1rem 1.2rem;
+  margin-top: -0.7rem;
+}
+
+.faq-panel.open {
+  display: block;
+}
+
+.icon {
+  font-size: 1.4rem;
+  color: var(--accent-dark);
+}
+
+.cases ul {
+  padding-left: 1.2rem;
+  color: var(--muted);
+  margin-top: 0.6rem;
+}
+
+.copy-card .label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--accent-dark);
+  font-weight: 700;
+}
+
+.note {
+  margin-top: 2rem;
+  background: var(--card);
+  padding: 1.5rem;
+  border-radius: 20px;
+  box-shadow: var(--shadow);
+}
+
+.note h4 {
+  margin-bottom: 0.75rem;
+}
+
+.cta {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  align-items: flex-start;
+  background: #fff;
+  border-top: 1px solid var(--border);
+}
+
+.footer {
+  padding: 2rem 1.25rem 3rem;
+  background: #1b1f24;
+  color: #f3f4f6;
+  display: grid;
+  gap: 1rem;
+}
+
+.footer-links {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  font-size: 0.9rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (min-width: 768px) {
+  .hero {
+    padding: 2.5rem 3.5rem 4rem;
+  }
+
+  .nav-menu {
+    position: static;
+    display: flex;
+    flex-direction: row;
+    padding: 0;
+    border: none;
+    background: transparent;
+    box-shadow: none;
+    width: auto;
+  }
+
+  .nav-toggle {
+    display: none;
+  }
+
+  .hero-content {
+    max-width: 620px;
+  }
+
+  .section {
+    padding: 4rem 3.5rem;
+  }
+
+  .cards,
+  .cases,
+  .copy-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .split {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
+  }
+
+  .cta {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a mobile-first mock website for a restaurant that documents `robots.txt` usage, FAQ, case studies, and AI-friendly copy examples to guide site owners.
- Deliver a standalone demo with all related files colocated at the same level so the mock can be run locally for review.

### Description
- Add `index.html` containing sections for 店舗紹介, 商品紹介, `robots.txt` basics and example snippet, FAQ accordion, ケーススタディ, AI向け文言例, CTA, and footer for a complete demo site.
- Add `style.css` implementing a mobile-first responsive layout, card/grid styles, accessible navigation, and visual design tokens for consistent theming.
- Add `script.js` implementing the navigation toggle and FAQ accordion interactions, including `aria-expanded` management and icon updates for accessibility.
- Include an AI-oriented comment example intended to be appended to `robots.txt` to make intent clearer to text/AI crawlers and search agents.

### Testing
- started a local server with `python -m http.server 8000` and the server ran successfully for manual/automated rendering checks.
- ran a headless Playwright script to load `http://127.0.0.1:8000` and capture a full-page screenshot, which completed successfully and produced `artifacts/robots-site.png`.
- No automated unit tests were added for this static mock site.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969b47bcdc483298fd12c8067ca059c)