### PR TITLE
Add single-file “Manga Atlas” discovery UI mock

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,1311 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Manga Atlas — 横断探索モック</title>
+  <style>
+    /* =========================================================
+      Manga Atlas — Single-file UI Mock
+      - Structure-first CSS with tokens and section comments
+      - All data + logic lives below in JS
+    ========================================================== */
+
+    /* ---------- CSS Reset / Base ---------- */
+    *, *::before, *::after { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body {
+      font-family: system-ui, -apple-system, "Segoe UI", "Hiragino Kaku Gothic ProN", "Hiragino Sans", "Noto Sans JP", "Yu Gothic", "Meiryo", sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.5;
+      letter-spacing: 0.01em;
+      -webkit-font-smoothing: antialiased;
+      text-rendering: optimizeLegibility;
+    }
+    button, input, select, textarea { font: inherit; color: inherit; }
+    a { color: inherit; text-decoration: none; }
+
+    /* ---------- Theme Tokens ---------- */
+    :root {
+      --bg: #f7f7f8;
+      --panel: #ffffff;
+      --panel-2: #f0f1f3;
+      --panel-3: #e8eaee;
+      --text: #1b1d22;
+      --text-2: #5a5f69;
+      --text-3: #7a808b;
+      --border: #d8dbe2;
+      --hairline: rgba(0, 0, 0, 0.08);
+      --accent: #4b6bff;
+      --accent-2: rgba(75, 107, 255, 0.12);
+      --success: #2e7d32;
+      --warning: #8b8f96;
+      --muted: #b6bcc7;
+      --shadow: 0 8px 30px rgba(15, 23, 42, 0.08);
+      --radius-lg: 18px;
+      --radius-md: 12px;
+      --radius-sm: 10px;
+      --transition-fast: 0.12s ease;
+      --transition-mid: 0.22s ease;
+      --max-width: 1160px;
+    }
+    [data-theme="dark"] {
+      --bg: #0f1116;
+      --panel: #151820;
+      --panel-2: #1b1f2a;
+      --panel-3: #222733;
+      --text: #f2f4f8;
+      --text-2: #a6afbd;
+      --text-3: #7a8392;
+      --border: #2b3140;
+      --hairline: rgba(255, 255, 255, 0.08);
+      --accent: #7aa2ff;
+      --accent-2: rgba(122, 162, 255, 0.14);
+      --success: #8bd4a4;
+      --warning: #7d8795;
+      --muted: #3a4250;
+      --shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+    }
+
+    /* ---------- Layout ---------- */
+    .app {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+    }
+
+    .topbar {
+      position: sticky;
+      top: 0;
+      z-index: 50;
+      background: color-mix(in srgb, var(--panel) 92%, transparent);
+      backdrop-filter: blur(14px);
+      border-bottom: 1px solid var(--hairline);
+    }
+    .topbar-inner {
+      max-width: var(--max-width);
+      margin: 0 auto;
+      display: grid;
+      grid-template-columns: 1.1fr 1.8fr 1fr;
+      align-items: center;
+      gap: 24px;
+      padding: 18px 24px;
+    }
+    .brand {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+    .brand strong {
+      font-size: 17px;
+      font-weight: 700;
+      letter-spacing: 0.02em;
+    }
+    .brand span {
+      font-size: 12px;
+      color: var(--text-3);
+      letter-spacing: 0.08em;
+    }
+
+    .searchbar {
+      position: relative;
+      display: flex;
+      align-items: center;
+      background: var(--panel-2);
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      padding: 8px 14px 8px 14px;
+      gap: 12px;
+      transition: border var(--transition-fast), box-shadow var(--transition-fast);
+    }
+    .searchbar:focus-within {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px var(--accent-2);
+    }
+    .searchbar input {
+      width: 100%;
+      border: none;
+      background: transparent;
+      font-size: 14px;
+      outline: none;
+      color: var(--text);
+    }
+    .searchbar .kbd {
+      display: inline-flex;
+      gap: 6px;
+      align-items: center;
+      font-size: 11px;
+      color: var(--text-3);
+      background: var(--panel-3);
+      border-radius: 999px;
+      padding: 4px 10px;
+      border: 1px solid var(--border);
+    }
+
+    .top-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 8px;
+    }
+
+    .segmented {
+      display: inline-flex;
+      background: var(--panel-2);
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      overflow: hidden;
+    }
+    .segmented button {
+      border: none;
+      background: transparent;
+      padding: 6px 12px;
+      font-size: 12px;
+      color: var(--text-3);
+      cursor: pointer;
+      transition: background var(--transition-fast), color var(--transition-fast);
+    }
+    .segmented button.active {
+      background: var(--panel);
+      color: var(--text);
+      box-shadow: inset 0 0 0 1px var(--border);
+    }
+    .icon-btn {
+      border: 1px solid var(--border);
+      background: var(--panel-2);
+      padding: 6px 10px;
+      border-radius: 999px;
+      cursor: pointer;
+      color: var(--text-2);
+      font-size: 13px;
+      transition: transform var(--transition-fast), background var(--transition-fast), border var(--transition-fast);
+    }
+    .icon-btn:hover { transform: translateY(-1px); background: var(--panel); }
+    .icon-btn:active { transform: translateY(0); }
+
+    .main {
+      max-width: var(--max-width);
+      width: 100%;
+      margin: 0 auto;
+      display: grid;
+      grid-template-columns: 240px 1fr;
+      gap: 28px;
+      padding: 24px;
+      align-items: start;
+    }
+
+    /* ---------- Filter Rail ---------- */
+    .rail {
+      position: sticky;
+      top: 88px;
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
+    }
+    .rail-section {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      padding: 14px;
+      box-shadow: var(--shadow);
+    }
+    .rail-title {
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.14em;
+      color: var(--text-3);
+      margin-bottom: 10px;
+    }
+    .chip-group {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+    .chip {
+      border: 1px solid var(--border);
+      background: var(--panel-2);
+      border-radius: 999px;
+      padding: 6px 12px;
+      font-size: 12px;
+      color: var(--text-2);
+      cursor: pointer;
+      transition: transform var(--transition-fast), border var(--transition-fast), background var(--transition-fast), color var(--transition-fast);
+      user-select: none;
+    }
+    .chip:hover { transform: translateY(-1px); }
+    .chip.active {
+      background: var(--accent-2);
+      border-color: var(--accent);
+      color: var(--text);
+      box-shadow: 0 2px 10px rgba(76, 111, 255, 0.2);
+    }
+
+    .toggle {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 8px 12px;
+      border-radius: 12px;
+      border: 1px solid var(--border);
+      background: var(--panel-2);
+    }
+    .toggle button {
+      border: none;
+      background: var(--panel-3);
+      padding: 6px 12px;
+      border-radius: 999px;
+      cursor: pointer;
+      font-size: 12px;
+      color: var(--text-2);
+      transition: background var(--transition-fast), color var(--transition-fast);
+    }
+    .toggle button.active {
+      background: var(--accent-2);
+      color: var(--text);
+      box-shadow: inset 0 0 0 1px var(--accent);
+    }
+
+    /* ---------- Results ---------- */
+    .results {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+    .results-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 8px;
+    }
+    .results-header h2 {
+      font-size: 18px;
+      margin: 0;
+      font-weight: 650;
+    }
+    .results-header span {
+      color: var(--text-3);
+      font-size: 12px;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+      gap: 16px;
+    }
+    .list {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .card {
+      border: 1px solid var(--border);
+      background: var(--panel);
+      border-radius: var(--radius-lg);
+      padding: 16px;
+      box-shadow: var(--shadow);
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      cursor: pointer;
+      transition: transform var(--transition-fast), border var(--transition-fast), box-shadow var(--transition-fast);
+    }
+    .card:hover {
+      transform: translateY(-2px);
+      border-color: color-mix(in srgb, var(--accent) 60%, var(--border));
+      box-shadow: 0 14px 28px rgba(15, 23, 42, 0.12);
+    }
+    .card-header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 12px;
+    }
+    .card-title {
+      font-size: 17px;
+      font-weight: 650;
+      margin: 0;
+    }
+    .card-sub {
+      font-size: 12px;
+      color: var(--text-3);
+      margin-top: 4px;
+    }
+    .badge {
+      font-size: 12px;
+      padding: 4px 10px;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      background: var(--panel-2);
+      color: var(--text-2);
+    }
+
+    .meter {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-size: 12px;
+      color: var(--text-2);
+    }
+    .meter-bar {
+      flex: 1;
+      height: 6px;
+      background: var(--panel-3);
+      border-radius: 999px;
+      position: relative;
+      overflow: hidden;
+    }
+    .meter-bar span {
+      position: absolute;
+      left: 0;
+      top: 0;
+      bottom: 0;
+      background: linear-gradient(90deg, var(--accent), color-mix(in srgb, var(--accent) 50%, transparent));
+      border-radius: inherit;
+      transition: width var(--transition-mid);
+    }
+
+    .store-matrix {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+    .store-pill {
+      border-radius: 999px;
+      padding: 6px 10px;
+      font-size: 11px;
+      border: 1px solid var(--border);
+      background: var(--panel-2);
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      color: var(--text-2);
+    }
+    .store-pill.available {
+      border-color: color-mix(in srgb, var(--accent) 65%, var(--border));
+      background: color-mix(in srgb, var(--accent) 12%, var(--panel));
+      color: var(--text);
+    }
+    .store-pill.unknown {
+      border-color: var(--border);
+      color: var(--text-3);
+    }
+    .store-pill.not_listed {
+      border-color: transparent;
+      background: var(--panel-3);
+      color: var(--text-3);
+    }
+    .price {
+      font-weight: 600;
+      font-size: 10px;
+      color: var(--text-3);
+    }
+
+    /* ---------- Detail Drawer ---------- */
+    .drawer {
+      position: fixed;
+      right: 0;
+      top: 0;
+      height: 100vh;
+      width: min(420px, 92vw);
+      background: var(--panel);
+      border-left: 1px solid var(--border);
+      box-shadow: var(--shadow);
+      transform: translateX(100%);
+      transition: transform var(--transition-mid);
+      z-index: 60;
+      display: flex;
+      flex-direction: column;
+      padding: 20px;
+      gap: 16px;
+    }
+    .drawer.open { transform: translateX(0); }
+    .drawer-header {
+      display: flex;
+      align-items: start;
+      justify-content: space-between;
+      gap: 12px;
+    }
+    .drawer h3 {
+      margin: 0;
+      font-size: 20px;
+      font-weight: 700;
+    }
+    .drawer p {
+      margin: 0;
+      color: var(--text-2);
+      font-size: 14px;
+    }
+    .drawer-section {
+      border-top: 1px solid var(--border);
+      padding-top: 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    .drawer-section h4 {
+      font-size: 12px;
+      margin: 0;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--text-3);
+    }
+    .drawer-links {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    .drawer-links a {
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 10px 12px;
+      background: var(--panel-2);
+      font-size: 13px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      transition: border var(--transition-fast), transform var(--transition-fast);
+    }
+    .drawer-links a:hover { transform: translateX(2px); border-color: var(--accent); }
+
+    .drawer-footer {
+      margin-top: auto;
+      display: flex;
+      gap: 10px;
+    }
+    .primary-btn {
+      flex: 1;
+      border: none;
+      background: var(--accent);
+      color: #fff;
+      padding: 10px 14px;
+      border-radius: 12px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+    }
+    .primary-btn:hover { transform: translateY(-1px); box-shadow: 0 6px 16px rgba(76, 111, 255, 0.3); }
+    .ghost-btn {
+      border: 1px solid var(--border);
+      background: transparent;
+      color: var(--text-2);
+      padding: 10px 14px;
+      border-radius: 12px;
+      cursor: pointer;
+    }
+
+    /* ---------- Command Palette ---------- */
+    .palette-backdrop {
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.35);
+      display: none;
+      align-items: center;
+      justify-content: center;
+      z-index: 80;
+    }
+    .palette-backdrop.open { display: flex; }
+    .palette {
+      width: min(520px, 90vw);
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      box-shadow: var(--shadow);
+      padding: 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .palette input {
+      border: 1px solid var(--border);
+      background: var(--panel-2);
+      border-radius: 12px;
+      padding: 10px 12px;
+      font-size: 14px;
+      outline: none;
+    }
+    .palette-list {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      max-height: 280px;
+      overflow: auto;
+    }
+    .palette-item {
+      padding: 10px 12px;
+      border-radius: 12px;
+      background: var(--panel-2);
+      border: 1px solid transparent;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      cursor: pointer;
+    }
+    .palette-item:hover { border-color: var(--accent); }
+    .palette-item span { font-size: 12px; color: var(--text-3); }
+
+    /* ---------- Skeleton + Empty ---------- */
+    .skeleton {
+      border-radius: var(--radius-lg);
+      height: 160px;
+      background: linear-gradient(90deg, var(--panel-2), var(--panel-3), var(--panel-2));
+      background-size: 200% 100%;
+      animation: shimmer 1.2s ease infinite;
+    }
+    @keyframes shimmer {
+      0% { background-position: 0% 0; }
+      100% { background-position: -200% 0; }
+    }
+    .empty-state {
+      border: 1px dashed var(--border);
+      border-radius: var(--radius-md);
+      padding: 28px;
+      text-align: center;
+      color: var(--text-3);
+    }
+    .empty-state strong { color: var(--text); }
+
+    /* ---------- Footer ---------- */
+    footer {
+      margin-top: auto;
+      padding: 24px;
+      color: var(--text-3);
+      font-size: 12px;
+      border-top: 1px solid var(--hairline);
+    }
+    .footer-inner {
+      max-width: var(--max-width);
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    /* ---------- Focus + Motion ---------- */
+    :focus-visible {
+      outline: 2px solid color-mix(in srgb, var(--accent) 60%, transparent);
+      outline-offset: 2px;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; }
+    }
+
+    /* ---------- Responsive ---------- */
+    @media (max-width: 980px) {
+      .main { grid-template-columns: 1fr; }
+      .rail { position: static; }
+    }
+    @media (max-width: 720px) {
+      .topbar-inner { grid-template-columns: 1fr; gap: 12px; }
+      .top-actions { justify-content: flex-start; }
+      .drawer { width: 100%; height: 60vh; bottom: 0; top: auto; border-left: none; border-top: 1px solid var(--border); }
+      .drawer.open { transform: translateY(0); }
+      .drawer { transform: translateY(100%); }
+    }
+  </style>
+</head>
+<body>
+  <div class="app" id="app" data-theme="light">
+    <header class="topbar">
+      <div class="topbar-inner">
+        <div class="brand">
+          <strong>Manga Atlas</strong>
+          <span>横断探索モック</span>
+        </div>
+        <label class="searchbar" aria-label="Global search">
+          <input id="searchInput" type="text" placeholder="作品名・著者・巻数で検索（/ でフォーカス）" />
+          <span class="kbd">/</span>
+        </label>
+        <div class="top-actions">
+          <div class="segmented" role="tablist" aria-label="View toggle">
+            <button type="button" class="view-btn" data-view="grid">Grid</button>
+            <button type="button" class="view-btn" data-view="list">List</button>
+          </div>
+          <button type="button" class="icon-btn" id="themeToggle">Theme</button>
+          <button type="button" class="icon-btn" id="helpBtn">?</button>
+        </div>
+      </div>
+    </header>
+
+    <main class="main">
+      <aside class="rail" aria-label="Filters">
+        <section class="rail-section">
+          <div class="rail-title">Status</div>
+          <div class="chip-group" id="statusFilters"></div>
+        </section>
+        <section class="rail-section">
+          <div class="rail-title">Store</div>
+          <div class="chip-group" id="storeFilters"></div>
+        </section>
+        <section class="rail-section">
+          <div class="rail-title">Price display</div>
+          <div class="toggle">
+            <span>API-simulated only</span>
+            <div class="segmented">
+              <button type="button" class="price-scope" data-scope="api">Only</button>
+              <button type="button" class="price-scope" data-scope="all">All</button>
+            </div>
+          </div>
+        </section>
+        <section class="rail-section">
+          <div class="rail-title">Tone</div>
+          <div class="toggle">
+            <span>価格は参考</span>
+            <div class="segmented">
+              <button type="button" class="price-tone" data-tone="on">ON</button>
+              <button type="button" class="price-tone" data-tone="off">OFF</button>
+            </div>
+          </div>
+        </section>
+      </aside>
+
+      <section class="results">
+        <div class="results-header">
+          <div>
+            <h2>Discover</h2>
+            <span id="resultMeta">—</span>
+          </div>
+          <span id="resultHint">Cmd/Ctrl + K でコマンド</span>
+        </div>
+        <div id="resultsBody" class="grid"></div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="footer-inner">
+        <span>本ページは個人用モックです。</span>
+        <span>価格は参考表示（取得できる範囲の想定）。</span>
+        <span>最終的な販売状況は各ストアで確認。</span>
+      </div>
+    </footer>
+  </div>
+
+  <aside class="drawer" id="drawer" aria-hidden="true">
+    <div class="drawer-header">
+      <div>
+        <h3 id="drawerTitle">—</h3>
+        <p id="drawerSubtitle">—</p>
+      </div>
+      <button class="icon-btn" id="drawerClose">Close</button>
+    </div>
+    <div class="drawer-section">
+      <h4>Overview</h4>
+      <p id="drawerOverview">—</p>
+    </div>
+    <div class="drawer-section">
+      <h4>Store Links</h4>
+      <div class="drawer-links" id="drawerLinks"></div>
+    </div>
+    <div class="drawer-section">
+      <h4>Notes</h4>
+      <p>価格は一部ストアのAPI想定データのみ参考表示しています。最終的な販売状況・価格は各ストアでご確認ください。</p>
+    </div>
+    <div class="drawer-footer">
+      <button class="primary-btn" id="copyShare">Copy Share Text</button>
+      <button class="ghost-btn" id="drawerClear">Clear</button>
+    </div>
+  </aside>
+
+  <div class="palette-backdrop" id="paletteBackdrop">
+    <div class="palette">
+      <input id="paletteInput" type="text" placeholder="Type a command..." />
+      <div class="palette-list" id="paletteList"></div>
+    </div>
+  </div>
+
+  <script>
+    /* =========================================================
+      Data + State
+      - Data structure defined once, rendered into UI
+      - Extension points: add stores, add commands, add tags
+    ========================================================== */
+    const stores = [
+      { name: "Amazon Kindle", type: "api" },
+      { name: "楽天Kobo", type: "api" },
+      { name: "BookLive", type: "link" },
+      { name: "コミックシーモア", type: "link" },
+      { name: "DMMブックス", type: "link" },
+      { name: "ebookjapan", type: "link" },
+      { name: "honto", type: "link" }
+    ];
+
+    const data = [
+      {
+        id: 1,
+        title: "蒼のオーケストラ",
+        author: "阿久井 真",
+        volume: "1-11巻",
+        tags: ["青春", "音楽"],
+        synopsis: "音に居場所を求める少年が、オーケストラの緊張と余白の中で再び弓を取る。",
+        stores: [
+          { name: "Amazon Kindle", type: "api", availability: "available", price: 660, currency: "JPY", searchUrl: "https://example.com/search?q=ao-orchestra" },
+          { name: "楽天Kobo", type: "api", availability: "available", price: 638, currency: "JPY", searchUrl: "https://example.com/search?q=ao-orchestra" },
+          { name: "BookLive", type: "link", availability: "available", searchUrl: "https://example.com/search?q=ao-orchestra" },
+          { name: "コミックシーモア", type: "link", availability: "unknown", searchUrl: "https://example.com/search?q=ao-orchestra" },
+          { name: "DMMブックス", type: "link", availability: "not_listed", searchUrl: "https://example.com/search?q=ao-orchestra" },
+          { name: "ebookjapan", type: "link", availability: "available", searchUrl: "https://example.com/search?q=ao-orchestra" },
+          { name: "honto", type: "link", availability: "unknown", searchUrl: "https://example.com/search?q=ao-orchestra" }
+        ]
+      },
+      {
+        id: 2,
+        title: "夜明けのカーテンコール",
+        author: "高橋 みずき",
+        volume: "全6巻",
+        tags: ["舞台", "群像"],
+        synopsis: "舞台裏で交差する夢と現実。幕が上がる前の静寂が主役になる物語。",
+        stores: [
+          { name: "Amazon Kindle", type: "api", availability: "available", price: 580, currency: "JPY", searchUrl: "https://example.com/search?q=curtain-call" },
+          { name: "楽天Kobo", type: "api", availability: "unknown", price: 600, currency: "JPY", searchUrl: "https://example.com/search?q=curtain-call" },
+          { name: "BookLive", type: "link", availability: "available", searchUrl: "https://example.com/search?q=curtain-call" },
+          { name: "コミックシーモア", type: "link", availability: "available", searchUrl: "https://example.com/search?q=curtain-call" },
+          { name: "DMMブックス", type: "link", availability: "unknown", searchUrl: "https://example.com/search?q=curtain-call" },
+          { name: "ebookjapan", type: "link", availability: "not_listed", searchUrl: "https://example.com/search?q=curtain-call" },
+          { name: "honto", type: "link", availability: "available", searchUrl: "https://example.com/search?q=curtain-call" }
+        ]
+      },
+      {
+        id: 3,
+        title: "彗星リミット",
+        author: "伊吹 玲司",
+        volume: "1-9巻",
+        tags: ["SF", "バトル"],
+        synopsis: "彗星の接近とともに覚醒する能力者たちが、限界の先で選択を迫られる。",
+        stores: [
+          { name: "Amazon Kindle", type: "api", availability: "available", price: 720, currency: "JPY", searchUrl: "https://example.com/search?q=comet-limit" },
+          { name: "楽天Kobo", type: "api", availability: "available", price: 700, currency: "JPY", searchUrl: "https://example.com/search?q=comet-limit" },
+          { name: "BookLive", type: "link", availability: "unknown", searchUrl: "https://example.com/search?q=comet-limit" },
+          { name: "コミックシーモア", type: "link", availability: "available", searchUrl: "https://example.com/search?q=comet-limit" },
+          { name: "DMMブックス", type: "link", availability: "available", searchUrl: "https://example.com/search?q=comet-limit" },
+          { name: "ebookjapan", type: "link", availability: "unknown", searchUrl: "https://example.com/search?q=comet-limit" },
+          { name: "honto", type: "link", availability: "not_listed", searchUrl: "https://example.com/search?q=comet-limit" }
+        ]
+      },
+      {
+        id: 4,
+        title: "深層モノローグ",
+        author: "沢城 真白",
+        volume: "全4巻",
+        tags: ["サスペンス", "心理"],
+        synopsis: "言葉にできない感情を拾う探偵が、都市の沈黙を歩く。",
+        stores: [
+          { name: "Amazon Kindle", type: "api", availability: "unknown", price: 650, currency: "JPY", searchUrl: "https://example.com/search?q=deep-monologue" },
+          { name: "楽天Kobo", type: "api", availability: "available", price: 630, currency: "JPY", searchUrl: "https://example.com/search?q=deep-monologue" },
+          { name: "BookLive", type: "link", availability: "not_listed", searchUrl: "https://example.com/search?q=deep-monologue" },
+          { name: "コミックシーモア", type: "link", availability: "available", searchUrl: "https://example.com/search?q=deep-monologue" },
+          { name: "DMMブックス", type: "link", availability: "unknown", searchUrl: "https://example.com/search?q=deep-monologue" },
+          { name: "ebookjapan", type: "link", availability: "available", searchUrl: "https://example.com/search?q=deep-monologue" },
+          { name: "honto", type: "link", availability: "unknown", searchUrl: "https://example.com/search?q=deep-monologue" }
+        ]
+      },
+      {
+        id: 5,
+        title: "ねじれ坂の約束",
+        author: "白鳥 泉",
+        volume: "1-8巻",
+        tags: ["ラブストーリー", "日常"],
+        synopsis: "坂の上と下で出会う二人の距離。小さな約束が日々を変える。",
+        stores: [
+          { name: "Amazon Kindle", type: "api", availability: "available", price: 590, currency: "JPY", searchUrl: "https://example.com/search?q=nejire-saka" },
+          { name: "楽天Kobo", type: "api", availability: "available", price: 570, currency: "JPY", searchUrl: "https://example.com/search?q=nejire-saka" },
+          { name: "BookLive", type: "link", availability: "available", searchUrl: "https://example.com/search?q=nejire-saka" },
+          { name: "コミックシーモア", type: "link", availability: "available", searchUrl: "https://example.com/search?q=nejire-saka" },
+          { name: "DMMブックス", type: "link", availability: "available", searchUrl: "https://example.com/search?q=nejire-saka" },
+          { name: "ebookjapan", type: "link", availability: "unknown", searchUrl: "https://example.com/search?q=nejire-saka" },
+          { name: "honto", type: "link", availability: "unknown", searchUrl: "https://example.com/search?q=nejire-saka" }
+        ]
+      },
+      {
+        id: 6,
+        title: "灰色の航路",
+        author: "乾 航",
+        volume: "全5巻",
+        tags: ["冒険", "海洋"],
+        synopsis: "霧に覆われた海図を頼りに、失われた港を探す旅。",
+        stores: [
+          { name: "Amazon Kindle", type: "api", availability: "unknown", price: 640, currency: "JPY", searchUrl: "https://example.com/search?q=gray-route" },
+          { name: "楽天Kobo", type: "api", availability: "available", price: 620, currency: "JPY", searchUrl: "https://example.com/search?q=gray-route" },
+          { name: "BookLive", type: "link", availability: "unknown", searchUrl: "https://example.com/search?q=gray-route" },
+          { name: "コミックシーモア", type: "link", availability: "available", searchUrl: "https://example.com/search?q=gray-route" },
+          { name: "DMMブックス", type: "link", availability: "not_listed", searchUrl: "https://example.com/search?q=gray-route" },
+          { name: "ebookjapan", type: "link", availability: "available", searchUrl: "https://example.com/search?q=gray-route" },
+          { name: "honto", type: "link", availability: "available", searchUrl: "https://example.com/search?q=gray-route" }
+        ]
+      },
+      {
+        id: 7,
+        title: "雨粒ディスプレイ",
+        author: "相澤 海",
+        volume: "1-3巻",
+        tags: ["SF", "青春"],
+        synopsis: "雨粒に映る過去が見える少年が、夏の終わりに出会う別れ。",
+        stores: [
+          { name: "Amazon Kindle", type: "api", availability: "available", price: 610, currency: "JPY", searchUrl: "https://example.com/search?q=raindrop-display" },
+          { name: "楽天Kobo", type: "api", availability: "unknown", price: 600, currency: "JPY", searchUrl: "https://example.com/search?q=raindrop-display" },
+          { name: "BookLive", type: "link", availability: "available", searchUrl: "https://example.com/search?q=raindrop-display" },
+          { name: "コミックシーモア", type: "link", availability: "unknown", searchUrl: "https://example.com/search?q=raindrop-display" },
+          { name: "DMMブックス", type: "link", availability: "available", searchUrl: "https://example.com/search?q=raindrop-display" },
+          { name: "ebookjapan", type: "link", availability: "available", searchUrl: "https://example.com/search?q=raindrop-display" },
+          { name: "honto", type: "link", availability: "not_listed", searchUrl: "https://example.com/search?q=raindrop-display" }
+        ]
+      },
+      {
+        id: 8,
+        title: "千年書庫",
+        author: "花見 こよみ",
+        volume: "1-12巻",
+        tags: ["ファンタジー", "歴史"],
+        synopsis: "禁書の匂いが満ちる書庫で、司書が千年の記憶を紐解く。",
+        stores: [
+          { name: "Amazon Kindle", type: "api", availability: "available", price: 760, currency: "JPY", searchUrl: "https://example.com/search?q=millennium-archive" },
+          { name: "楽天Kobo", type: "api", availability: "available", price: 740, currency: "JPY", searchUrl: "https://example.com/search?q=millennium-archive" },
+          { name: "BookLive", type: "link", availability: "available", searchUrl: "https://example.com/search?q=millennium-archive" },
+          { name: "コミックシーモア", type: "link", availability: "available", searchUrl: "https://example.com/search?q=millennium-archive" },
+          { name: "DMMブックス", type: "link", availability: "unknown", searchUrl: "https://example.com/search?q=millennium-archive" },
+          { name: "ebookjapan", type: "link", availability: "available", searchUrl: "https://example.com/search?q=millennium-archive" },
+          { name: "honto", type: "link", availability: "unknown", searchUrl: "https://example.com/search?q=millennium-archive" }
+        ]
+      },
+      {
+        id: 9,
+        title: "平行線のレンズ",
+        author: "佐伯 碧",
+        volume: "全2巻",
+        tags: ["ドラマ", "写真"],
+        synopsis: "同じ被写体を違う角度で追う二人が、並行線の意味を知る。",
+        stores: [
+          { name: "Amazon Kindle", type: "api", availability: "unknown", price: 500, currency: "JPY", searchUrl: "https://example.com/search?q=parallel-lens" },
+          { name: "楽天Kobo", type: "api", availability: "available", price: 520, currency: "JPY", searchUrl: "https://example.com/search?q=parallel-lens" },
+          { name: "BookLive", type: "link", availability: "unknown", searchUrl: "https://example.com/search?q=parallel-lens" },
+          { name: "コミックシーモア", type: "link", availability: "available", searchUrl: "https://example.com/search?q=parallel-lens" },
+          { name: "DMMブックス", type: "link", availability: "available", searchUrl: "https://example.com/search?q=parallel-lens" },
+          { name: "ebookjapan", type: "link", availability: "not_listed", searchUrl: "https://example.com/search?q=parallel-lens" },
+          { name: "honto", type: "link", availability: "available", searchUrl: "https://example.com/search?q=parallel-lens" }
+        ]
+      },
+      {
+        id: 10,
+        title: "風待ちの庭",
+        author: "島田 渚",
+        volume: "1-7巻",
+        tags: ["ヒューマン", "日常"],
+        synopsis: "庭に吹く風が運ぶ記憶。静かな街で交差する小さな物語たち。",
+        stores: [
+          { name: "Amazon Kindle", type: "api", availability: "available", price: 610, currency: "JPY", searchUrl: "https://example.com/search?q=wind-garden" },
+          { name: "楽天Kobo", type: "api", availability: "unknown", price: 600, currency: "JPY", searchUrl: "https://example.com/search?q=wind-garden" },
+          { name: "BookLive", type: "link", availability: "available", searchUrl: "https://example.com/search?q=wind-garden" },
+          { name: "コミックシーモア", type: "link", availability: "unknown", searchUrl: "https://example.com/search?q=wind-garden" },
+          { name: "DMMブックス", type: "link", availability: "unknown", searchUrl: "https://example.com/search?q=wind-garden" },
+          { name: "ebookjapan", type: "link", availability: "available", searchUrl: "https://example.com/search?q=wind-garden" },
+          { name: "honto", type: "link", availability: "available", searchUrl: "https://example.com/search?q=wind-garden" }
+        ]
+      },
+      {
+        id: 11,
+        title: "白夜のパズル",
+        author: "森崎 凪",
+        volume: "全3巻",
+        tags: ["ミステリー", "頭脳"],
+        synopsis: "夜が明けない街で、謎だけが増えていく。解かれる順序が運命を変える。",
+        stores: [
+          { name: "Amazon Kindle", type: "api", availability: "available", price: 640, currency: "JPY", searchUrl: "https://example.com/search?q=white-night" },
+          { name: "楽天Kobo", type: "api", availability: "available", price: 620, currency: "JPY", searchUrl: "https://example.com/search?q=white-night" },
+          { name: "BookLive", type: "link", availability: "unknown", searchUrl: "https://example.com/search?q=white-night" },
+          { name: "コミックシーモア", type: "link", availability: "unknown", searchUrl: "https://example.com/search?q=white-night" },
+          { name: "DMMブックス", type: "link", availability: "available", searchUrl: "https://example.com/search?q=white-night" },
+          { name: "ebookjapan", type: "link", availability: "available", searchUrl: "https://example.com/search?q=white-night" },
+          { name: "honto", type: "link", availability: "available", searchUrl: "https://example.com/search?q=white-night" }
+        ]
+      },
+      {
+        id: 12,
+        title: "花筏アーカイブ",
+        author: "千尋 しずく",
+        volume: "1-10巻",
+        tags: ["幻想", "旅"],
+        synopsis: "川面に浮かぶ花筏を追って、失われた古都の記録を集める。",
+        stores: [
+          { name: "Amazon Kindle", type: "api", availability: "available", price: 690, currency: "JPY", searchUrl: "https://example.com/search?q=hana-ikada" },
+          { name: "楽天Kobo", type: "api", availability: "available", price: 670, currency: "JPY", searchUrl: "https://example.com/search?q=hana-ikada" },
+          { name: "BookLive", type: "link", availability: "available", searchUrl: "https://example.com/search?q=hana-ikada" },
+          { name: "コミックシーモア", type: "link", availability: "unknown", searchUrl: "https://example.com/search?q=hana-ikada" },
+          { name: "DMMブックス", type: "link", availability: "available", searchUrl: "https://example.com/search?q=hana-ikada" },
+          { name: "ebookjapan", type: "link", availability: "unknown", searchUrl: "https://example.com/search?q=hana-ikada" },
+          { name: "honto", type: "link", availability: "unknown", searchUrl: "https://example.com/search?q=hana-ikada" }
+        ]
+      }
+    ];
+
+    const state = {
+      search: "",
+      status: "all",
+      stores: new Set(),
+      priceScope: "api",
+      priceTone: "on",
+      view: "grid",
+      theme: "light",
+      selectedId: null,
+      paletteOpen: false
+    };
+
+    const elements = {
+      app: document.getElementById("app"),
+      searchInput: document.getElementById("searchInput"),
+      resultsBody: document.getElementById("resultsBody"),
+      resultMeta: document.getElementById("resultMeta"),
+      statusFilters: document.getElementById("statusFilters"),
+      storeFilters: document.getElementById("storeFilters"),
+      viewBtns: document.querySelectorAll(".view-btn"),
+      themeToggle: document.getElementById("themeToggle"),
+      priceScopes: document.querySelectorAll(".price-scope"),
+      priceTones: document.querySelectorAll(".price-tone"),
+      drawer: document.getElementById("drawer"),
+      drawerClose: document.getElementById("drawerClose"),
+      drawerClear: document.getElementById("drawerClear"),
+      drawerTitle: document.getElementById("drawerTitle"),
+      drawerSubtitle: document.getElementById("drawerSubtitle"),
+      drawerOverview: document.getElementById("drawerOverview"),
+      drawerLinks: document.getElementById("drawerLinks"),
+      copyShare: document.getElementById("copyShare"),
+      paletteBackdrop: document.getElementById("paletteBackdrop"),
+      paletteInput: document.getElementById("paletteInput"),
+      paletteList: document.getElementById("paletteList"),
+      helpBtn: document.getElementById("helpBtn")
+    };
+
+    const commands = [
+      { label: "Toggle Theme", action: () => toggleTheme() },
+      { label: "Toggle View", action: () => toggleView() },
+      { label: "Filter: Draft (Unknown)", action: () => setStatus("unknown") },
+      { label: "Filter: Available", action: () => setStatus("available") },
+      { label: "Filter: All", action: () => setStatus("all") },
+      { label: "Sort: Relevance", action: () => render() }
+    ];
+
+    /* ---------- Initialization ---------- */
+    const saved = JSON.parse(localStorage.getItem("manga-atlas-state") || "{}");
+    Object.assign(state, saved);
+    state.stores = new Set(saved.stores || []);
+    elements.app.dataset.theme = state.theme;
+
+    function saveState() {
+      const snapshot = {
+        ...state,
+        stores: Array.from(state.stores)
+      };
+      localStorage.setItem("manga-atlas-state", JSON.stringify(snapshot));
+    }
+
+    function setStatus(value) {
+      state.status = value;
+      render();
+    }
+
+    function toggleTheme() {
+      state.theme = state.theme === "light" ? "dark" : "light";
+      elements.app.dataset.theme = state.theme;
+      saveState();
+    }
+
+    function toggleView() {
+      state.view = state.view === "grid" ? "list" : "grid";
+      saveState();
+      render();
+    }
+
+    function formatPrice(price, currency) {
+      if (!price) return "";
+      return `${currency === "JPY" ? "¥" : ""}${price}`;
+    }
+
+    function availabilityCount(item) {
+      const total = item.stores.length;
+      const available = item.stores.filter((store) => store.availability === "available").length;
+      return { total, available };
+    }
+
+    function renderFilters() {
+      const statusOptions = [
+        { label: "All", value: "all" },
+        { label: "Available", value: "available" },
+        { label: "Partial", value: "partial" },
+        { label: "Unknown", value: "unknown" }
+      ];
+      elements.statusFilters.innerHTML = statusOptions.map((option) => {
+        const active = state.status === option.value ? "active" : "";
+        return `<div class="chip ${active}" data-status="${option.value}">${option.label}</div>`;
+      }).join("");
+
+      elements.storeFilters.innerHTML = stores.map((store) => {
+        const active = state.stores.has(store.name) ? "active" : "";
+        return `<div class="chip ${active}" data-store="${store.name}">${store.name}</div>`;
+      }).join("");
+
+      elements.priceScopes.forEach((btn) => {
+        btn.classList.toggle("active", btn.dataset.scope === state.priceScope);
+      });
+      elements.priceTones.forEach((btn) => {
+        btn.classList.toggle("active", btn.dataset.tone === state.priceTone);
+      });
+    }
+
+    function matchSearch(item) {
+      if (!state.search) return true;
+      const term = state.search.toLowerCase();
+      return [item.title, item.author, item.volume].some((field) => field.toLowerCase().includes(term));
+    }
+
+    function matchStatus(item) {
+      if (state.status === "all") return true;
+      const { available, total } = availabilityCount(item);
+      if (state.status === "available") return available === total;
+      if (state.status === "partial") return available > 0 && available < total;
+      if (state.status === "unknown") return available === 0;
+      return true;
+    }
+
+    function matchStores(item) {
+      if (!state.stores.size) return true;
+      return Array.from(state.stores).every((name) => {
+        const store = item.stores.find((s) => s.name === name);
+        return store && store.availability === "available";
+      });
+    }
+
+    function renderSkeleton() {
+      elements.resultsBody.innerHTML = Array.from({ length: 6 }).map(() => `<div class="skeleton"></div>`).join("");
+    }
+
+    function render() {
+      renderFilters();
+      const filtered = data.filter((item) => matchSearch(item) && matchStatus(item) && matchStores(item));
+      elements.resultsBody.className = state.view === "grid" ? "grid" : "list";
+      elements.viewBtns.forEach((btn) => btn.classList.toggle("active", btn.dataset.view === state.view));
+
+      if (!filtered.length) {
+        elements.resultsBody.innerHTML = `
+          <div class="empty-state">
+            <strong>結果が見つかりません。</strong><br />
+            フィルタを緩めるか、検索語を変更してください。<br />
+            <span>ショートカット: Cmd/Ctrl + K → Filter: All</span>
+          </div>
+        `;
+        elements.resultMeta.textContent = "0 items";
+        saveState();
+        return;
+      }
+
+      elements.resultsBody.innerHTML = filtered.map((item) => {
+        const { available, total } = availabilityCount(item);
+        const availabilityRate = Math.round((available / total) * 100);
+        const storesMarkup = item.stores.map((store) => {
+          const price = store.type === "api" && state.priceScope === "api" ? formatPrice(store.price, store.currency) : "";
+          const showPrice = state.priceTone === "off" ? price : price ? `≈${price}` : "";
+          const label = store.type === "api" ? `${store.name}` : store.name;
+          return `
+            <span class="store-pill ${store.availability}">
+              ${label}
+              ${showPrice ? `<span class="price">${showPrice}</span>` : ""}
+            </span>
+          `;
+        }).join("");
+
+        return `
+          <article class="card" data-id="${item.id}">
+            <div class="card-header">
+              <div>
+                <h3 class="card-title">${item.title}</h3>
+                <div class="card-sub">${item.author}</div>
+              </div>
+              <span class="badge">${item.volume}</span>
+            </div>
+            <div class="meter">
+              <div class="meter-bar"><span style="width:${availabilityRate}%;"></span></div>
+              <span>${available}/${total} stores</span>
+            </div>
+            <div class="store-matrix">${storesMarkup}</div>
+          </article>
+        `;
+      }).join("");
+
+      elements.resultMeta.textContent = `${filtered.length} items / ${data.length} total`;
+      saveState();
+    }
+
+    function openDrawer(item) {
+      state.selectedId = item.id;
+      elements.drawerTitle.textContent = item.title;
+      elements.drawerSubtitle.textContent = `${item.author} · ${item.volume}`;
+      elements.drawerOverview.textContent = item.synopsis;
+      elements.drawerLinks.innerHTML = item.stores.map((store) => {
+        const price = store.type === "api" && state.priceScope === "api" ? formatPrice(store.price, store.currency) : "";
+        const label = store.type === "api" && price ? `${store.name} · ≈${price}` : store.name;
+        return `<a href="${store.searchUrl}" target="_blank" rel="noopener">${label}<span>${store.availability}</span></a>`;
+      }).join("");
+      elements.drawer.classList.add("open");
+      elements.drawer.setAttribute("aria-hidden", "false");
+      saveState();
+    }
+
+    function closeDrawer() {
+      state.selectedId = null;
+      elements.drawer.classList.remove("open");
+      elements.drawer.setAttribute("aria-hidden", "true");
+      saveState();
+    }
+
+    function openPalette() {
+      state.paletteOpen = true;
+      elements.paletteBackdrop.classList.add("open");
+      elements.paletteInput.value = "";
+      renderPaletteList("");
+      elements.paletteInput.focus();
+    }
+
+    function closePalette() {
+      state.paletteOpen = false;
+      elements.paletteBackdrop.classList.remove("open");
+    }
+
+    function renderPaletteList(query) {
+      const lower = query.toLowerCase();
+      const filtered = commands.filter((cmd) => cmd.label.toLowerCase().includes(lower));
+      elements.paletteList.innerHTML = filtered.map((cmd) => `
+        <div class="palette-item" data-command="${cmd.label}">
+          ${cmd.label}
+          <span>Enter</span>
+        </div>
+      `).join("");
+    }
+
+    /* ---------- Event Binding ---------- */
+    elements.searchInput.addEventListener("input", (event) => {
+      state.search = event.target.value.trim();
+      render();
+    });
+
+    document.addEventListener("keydown", (event) => {
+      if (event.key === "/" && document.activeElement !== elements.searchInput) {
+        event.preventDefault();
+        elements.searchInput.focus();
+      }
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        openPalette();
+      }
+      if (event.key === "Escape") {
+        if (state.paletteOpen) {
+          closePalette();
+          return;
+        }
+        if (elements.drawer.classList.contains("open")) {
+          closeDrawer();
+          return;
+        }
+        elements.searchInput.value = "";
+        state.search = "";
+        render();
+      }
+    });
+
+    elements.statusFilters.addEventListener("click", (event) => {
+      const chip = event.target.closest(".chip");
+      if (!chip) return;
+      setStatus(chip.dataset.status);
+    });
+
+    elements.storeFilters.addEventListener("click", (event) => {
+      const chip = event.target.closest(".chip");
+      if (!chip) return;
+      const name = chip.dataset.store;
+      if (state.stores.has(name)) {
+        state.stores.delete(name);
+      } else {
+        state.stores.add(name);
+      }
+      render();
+    });
+
+    elements.resultsBody.addEventListener("click", (event) => {
+      const card = event.target.closest(".card");
+      if (!card) return;
+      const item = data.find((entry) => entry.id === Number(card.dataset.id));
+      if (item) openDrawer(item);
+    });
+
+    elements.drawerClose.addEventListener("click", closeDrawer);
+    elements.drawerClear.addEventListener("click", closeDrawer);
+
+    elements.viewBtns.forEach((btn) => {
+      btn.addEventListener("click", () => {
+        state.view = btn.dataset.view;
+        render();
+      });
+    });
+
+    elements.themeToggle.addEventListener("click", toggleTheme);
+
+    elements.priceScopes.forEach((btn) => {
+      btn.addEventListener("click", () => {
+        state.priceScope = btn.dataset.scope;
+        render();
+      });
+    });
+
+    elements.priceTones.forEach((btn) => {
+      btn.addEventListener("click", () => {
+        state.priceTone = btn.dataset.tone;
+        render();
+      });
+    });
+
+    elements.copyShare.addEventListener("click", async () => {
+      const item = data.find((entry) => entry.id === state.selectedId);
+      if (!item) return;
+      const linkLines = item.stores.map((store) => `${store.name}: ${store.searchUrl}`).join("\n");
+      const text = `${item.title} (${item.volume})\n${linkLines}`;
+      try {
+        await navigator.clipboard.writeText(text);
+        elements.copyShare.textContent = "Copied";
+        setTimeout(() => { elements.copyShare.textContent = "Copy Share Text"; }, 1400);
+      } catch (error) {
+        elements.copyShare.textContent = "Copy failed";
+      }
+    });
+
+    elements.paletteInput.addEventListener("input", (event) => {
+      renderPaletteList(event.target.value);
+    });
+
+    elements.paletteList.addEventListener("click", (event) => {
+      const item = event.target.closest(".palette-item");
+      if (!item) return;
+      const cmd = commands.find((command) => command.label === item.dataset.command);
+      if (cmd) cmd.action();
+      closePalette();
+    });
+
+    elements.paletteBackdrop.addEventListener("click", (event) => {
+      if (event.target === elements.paletteBackdrop) closePalette();
+    });
+
+    elements.helpBtn.addEventListener("click", () => {
+      alert("Shortcuts:\n/ focus search\nEsc clear or close\nCmd/Ctrl+K command palette");
+    });
+
+    // Skeleton show for 0.4s to add richness
+    renderSkeleton();
+    setTimeout(() => {
+      if (state.search) elements.searchInput.value = state.search;
+      render();
+      if (state.selectedId) {
+        const item = data.find((entry) => entry.id === state.selectedId);
+        if (item) openDrawer(item);
+      }
+    }, 400);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a polished, single-file mock of a cross-store manga discovery/inspection UI that emphasizes refined UX without real scraping or API calls.
- Surface a confident exploration experience (search, filters, command palette, detail drawer) using mock data so designers and front-end engineers can evaluate interaction quality.

### Description
- Add `index.html` as a single-file app containing all HTML/CSS/JS and a 12-item mock catalog following the required data schema, store types, and availability states.
- Implement top bar with global search (focus via `/`), view toggle, theme toggle (Light/Dark) and a Command Palette (open with `Cmd/Ctrl+K`) wired to commands like `Toggle Theme` and `Filter: Available`.
- Implement Filter Rail (status chips, store multi-select, price-scope and price-tone segmented controls), Results (rich cards with availability meter and store matrix), and a responsive Detail Drawer with `Copy Share Text` behavior; state persisted to `localStorage` (`theme`, `view`, `last filters`, `selected item`).
- Styling uses CSS variables for theming, system font stack, accessible focus rings, `prefers-reduced-motion` handling, and micro-interactions (fast transitions and drawer animation); JS is organized around a compact `state` object and render functions.

### Testing
- Served the static file with `python -m http.server` and opened it using a Playwright script (`playwright.sync_api`) to render the page and capture a full-page screenshot, which completed successfully and produced a screenshot artifact.
- No automated test failures were observed during the page render and screenshot capture.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b798aa75c83298cb1a68e99324319)