### PR TITLE
iOS 18.6向け: 日本酒棚卸アプリ（SwiftUI + SwiftData）初期実装を追加

### DIFF
--- a/NihonshuInventory/Components/CardContainer.swift
+++ b/NihonshuInventory/Components/CardContainer.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct CardContainer<Content: View>: View {
+    let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .padding(Theme.Spacing.md)
+            .background(
+                RoundedRectangle(cornerRadius: Theme.CornerRadius.md, style: .continuous)
+                    .fill(Theme.Colors.paper.opacity(0.9))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: Theme.CornerRadius.md, style: .continuous)
+                    .stroke(Theme.DividerStyle.color, lineWidth: Theme.DividerStyle.height)
+            )
+            .shadow(color: Theme.Shadow.light, radius: Theme.Shadow.radius, x: 0, y: Theme.Shadow.y)
+    }
+}

--- a/NihonshuInventory/Components/PrimaryButton.swift
+++ b/NihonshuInventory/Components/PrimaryButton.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct PrimaryButton: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    let title: String
+    let action: () -> Void
+
+    @State private var isPressed = false
+
+    var body: some View {
+        Button(action: handleTap) {
+            Text(title)
+                .font(Theme.Typography.headline)
+                .foregroundStyle(Theme.Colors.paper)
+                .frame(maxWidth: .infinity, minHeight: 44)
+                .padding(.vertical, Theme.Spacing.xs)
+                .background(
+                    RoundedRectangle(cornerRadius: Theme.CornerRadius.sm, style: .continuous)
+                        .fill(Theme.Colors.accent)
+                )
+        }
+        .buttonStyle(.plain)
+        .scaleEffect(isPressed && !reduceMotion ? 0.98 : 1)
+        .animation(Motion.emphasizedSpring(reduceMotion: reduceMotion), value: isPressed)
+        .pressAction { isPressed = true } onRelease: { isPressed = false }
+    }
+
+    private func handleTap() {
+        let generator = UIImpactFeedbackGenerator(style: .soft)
+        generator.impactOccurred()
+        action()
+    }
+}
+
+private struct PressAction: ViewModifier {
+    let onPress: () -> Void
+    let onRelease: () -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { _ in onPress() }
+                    .onEnded { _ in onRelease() }
+            )
+    }
+}
+
+private extension View {
+    func pressAction(onPress: @escaping () -> Void, onRelease: @escaping () -> Void) -> some View {
+        modifier(PressAction(onPress: onPress, onRelease: onRelease))
+    }
+}

--- a/NihonshuInventory/Components/StatusStates.swift
+++ b/NihonshuInventory/Components/StatusStates.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct EmptyStateView: View {
+    let title: String
+    let message: String
+    let systemImage: String
+    let actionTitle: String?
+    let action: (() -> Void)?
+
+    var body: some View {
+        VStack(spacing: Theme.Spacing.md) {
+            Image(systemName: systemImage)
+                .font(.system(size: 42))
+                .foregroundStyle(Theme.Colors.accent)
+            Text(title)
+                .font(Theme.Typography.title)
+                .foregroundStyle(Theme.Colors.ink)
+            Text(message)
+                .font(Theme.Typography.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            if let actionTitle, let action {
+                PrimaryButton(title: actionTitle, action: action)
+                    .frame(maxWidth: 240)
+            }
+        }
+        .padding(Theme.Spacing.lg)
+        .frame(maxWidth: .infinity)
+    }
+}
+
+struct ErrorStateView: View {
+    let message: String
+
+    var body: some View {
+        VStack(spacing: Theme.Spacing.sm) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 36))
+                .foregroundStyle(.orange)
+            Text("エラー")
+                .font(Theme.Typography.headline)
+            Text(message)
+                .font(Theme.Typography.body)
+                .foregroundStyle(.secondary)
+        }
+        .padding(Theme.Spacing.lg)
+        .frame(maxWidth: .infinity)
+    }
+}
+
+struct LoadingStateView: View {
+    let message: String
+
+    var body: some View {
+        VStack(spacing: Theme.Spacing.sm) {
+            ProgressView()
+            Text(message)
+                .font(Theme.Typography.body)
+                .foregroundStyle(.secondary)
+        }
+        .padding(Theme.Spacing.lg)
+        .frame(maxWidth: .infinity)
+    }
+}

--- a/NihonshuInventory/DesignSystem/Backgrounds.swift
+++ b/NihonshuInventory/DesignSystem/Backgrounds.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct WashiBackground: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: gradientColors,
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            NoiseOverlay()
+        }
+        .ignoresSafeArea()
+    }
+
+    private var gradientColors: [Color] {
+        let base = Theme.Colors.paper
+        let tint = Theme.Colors.accent.opacity(colorScheme == .dark ? 0.12 : 0.08)
+        return [base, tint, base.opacity(0.98)]
+    }
+}
+
+struct NoiseOverlay: View {
+    var body: some View {
+        Canvas { context, size in
+            let dotSize: CGFloat = 1
+            let columns = Int(size.width / dotSize)
+            let rows = Int(size.height / dotSize)
+
+            for x in 0..<columns {
+                for y in 0..<rows {
+                    if Int.random(in: 0...22) == 0 {
+                        let rect = CGRect(
+                            x: CGFloat(x) * dotSize,
+                            y: CGFloat(y) * dotSize,
+                            width: dotSize,
+                            height: dotSize
+                        )
+                        context.fill(Path(rect), with: .color(.black.opacity(0.02)))
+                    }
+                }
+            }
+        }
+        .blendMode(.overlay)
+        .opacity(0.6)
+        .accessibilityHidden(true)
+    }
+}

--- a/NihonshuInventory/DesignSystem/Motion.swift
+++ b/NihonshuInventory/DesignSystem/Motion.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+enum Motion {
+    static func fadeScale(reduceMotion: Bool) -> AnyTransition {
+        if reduceMotion {
+            return .opacity
+        }
+        return .opacity.combined(with: .scale(scale: 0.98))
+    }
+
+    static func emphasizedSpring(reduceMotion: Bool) -> Animation {
+        if reduceMotion {
+            return .easeInOut(duration: 0.2)
+        }
+        return .spring(response: 0.32, dampingFraction: 0.85, blendDuration: 0.1)
+    }
+}

--- a/NihonshuInventory/DesignSystem/Theme.swift
+++ b/NihonshuInventory/DesignSystem/Theme.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+enum Theme {
+    enum Spacing {
+        static let xs: CGFloat = 8
+        static let sm: CGFloat = 12
+        static let md: CGFloat = 16
+        static let lg: CGFloat = 24
+    }
+
+    enum CornerRadius {
+        static let sm: CGFloat = 12
+        static let md: CGFloat = 16
+        static let lg: CGFloat = 24
+    }
+
+    enum Shadow {
+        static let light = Color.black.opacity(0.08)
+        static let radius: CGFloat = 10
+        static let y: CGFloat = 4
+    }
+
+    enum DividerStyle {
+        static let color = Color.primary.opacity(0.08)
+        static let height: CGFloat = 1
+    }
+
+    enum Typography {
+        static let title = Font.title2.weight(.semibold)
+        static let headline = Font.headline.weight(.semibold)
+        static let body = Font.body
+    }
+
+    enum Colors {
+        static let ink = Color(uiColor: UIColor { trait in
+            trait.userInterfaceStyle == .dark ? UIColor(white: 0.95, alpha: 1) : UIColor(white: 0.08, alpha: 1)
+        })
+        static let paper = Color(uiColor: UIColor { trait in
+            trait.userInterfaceStyle == .dark ? UIColor(white: 0.08, alpha: 1) : UIColor(red: 0.98, green: 0.97, blue: 0.94, alpha: 1)
+        })
+        static let accent = Color(uiColor: UIColor { trait in
+            trait.userInterfaceStyle == .dark ? UIColor(red: 0.35, green: 0.57, blue: 0.6, alpha: 1) : UIColor(red: 0.12, green: 0.35, blue: 0.42, alpha: 1)
+        })
+    }
+}

--- a/NihonshuInventory/Models/Sake.swift
+++ b/NihonshuInventory/Models/Sake.swift
@@ -1,0 +1,35 @@
+import Foundation
+import SwiftData
+
+@Model
+final class Sake {
+    var id: UUID
+    @Attribute(.unique) var name: String
+    var brewery: String?
+    var type: String?
+    var memo: String?
+    var createdAt: Date
+    var updatedAt: Date
+
+    @Relationship(inverse: \StockLot.sake)
+    var lots: [StockLot]
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        brewery: String? = nil,
+        type: String? = nil,
+        memo: String? = nil,
+        createdAt: Date = .now,
+        updatedAt: Date = .now
+    ) {
+        self.id = id
+        self.name = name
+        self.brewery = brewery
+        self.type = type
+        self.memo = memo
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.lots = []
+    }
+}

--- a/NihonshuInventory/Models/StockEvent.swift
+++ b/NihonshuInventory/Models/StockEvent.swift
@@ -1,0 +1,28 @@
+import Foundation
+import SwiftData
+
+@Model
+final class StockEvent {
+    var id: UUID
+    var lot: StockLot
+    var kind: String
+    var deltaMl: Int
+    var note: String?
+    var at: Date
+
+    init(
+        id: UUID = UUID(),
+        lot: StockLot,
+        kind: String,
+        deltaMl: Int,
+        note: String? = nil,
+        at: Date = .now
+    ) {
+        self.id = id
+        self.lot = lot
+        self.kind = kind
+        self.deltaMl = deltaMl
+        self.note = note
+        self.at = at
+    }
+}

--- a/NihonshuInventory/Models/StockLot.swift
+++ b/NihonshuInventory/Models/StockLot.swift
@@ -1,0 +1,35 @@
+import Foundation
+import SwiftData
+
+@Model
+final class StockLot {
+    var id: UUID
+    var sake: Sake
+    var location: String?
+    var bottleSizeMl: Int
+    var opened: Bool
+    var remainingMl: Int
+    var updatedAt: Date
+
+    @Relationship(deleteRule: .cascade, inverse: \StockEvent.lot)
+    var events: [StockEvent]
+
+    init(
+        id: UUID = UUID(),
+        sake: Sake,
+        location: String? = nil,
+        bottleSizeMl: Int,
+        opened: Bool,
+        remainingMl: Int,
+        updatedAt: Date = .now
+    ) {
+        self.id = id
+        self.sake = sake
+        self.location = location
+        self.bottleSizeMl = bottleSizeMl
+        self.opened = opened
+        self.remainingMl = max(0, min(remainingMl, bottleSizeMl))
+        self.updatedAt = updatedAt
+        self.events = []
+    }
+}

--- a/NihonshuInventory/NihonshuInventoryApp.swift
+++ b/NihonshuInventory/NihonshuInventoryApp.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+import SwiftData
+
+@main
+struct NihonshuInventoryApp: App {
+    var body: some Scene {
+        WindowGroup {
+            RootTabView()
+        }
+        .modelContainer(for: [Sake.self, StockLot.self, StockEvent.self])
+    }
+}

--- a/NihonshuInventory/Services/InventoryService.swift
+++ b/NihonshuInventory/Services/InventoryService.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+enum InventoryError: LocalizedError {
+    case emptyName
+    case duplicateSakeName
+    case invalidBottleSize
+    case invalidRemaining
+    case stockUnderflow
+    case stockOverflow
+    case sakeHasLots
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyName:
+            return "銘柄名を入力してください。"
+        case .duplicateSakeName:
+            return "同名の銘柄が既に存在します。"
+        case .invalidBottleSize:
+            return "容量は1以上で入力してください。"
+        case .invalidRemaining:
+            return "残量は0以上かつ容量以下で入力してください。"
+        case .stockUnderflow:
+            return "残量が不足しています。"
+        case .stockOverflow:
+            return "容量を超えるため更新できません。"
+        case .sakeHasLots:
+            return "在庫が紐づくため、この銘柄は削除できません。"
+        }
+    }
+}
+
+enum InventoryService {
+    static func validateSakeName(_ name: String, existingNames: [String], currentName: String? = nil) throws {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw InventoryError.emptyName }
+
+        let isDuplicate = existingNames.contains {
+            $0.caseInsensitiveCompare(trimmed) == .orderedSame &&
+            $0.caseInsensitiveCompare(currentName ?? "") != .orderedSame
+        }
+        if isDuplicate {
+            throw InventoryError.duplicateSakeName
+        }
+    }
+
+    static func validateLot(bottleSizeMl: Int, remainingMl: Int) throws {
+        guard bottleSizeMl > 0 else { throw InventoryError.invalidBottleSize }
+        guard (0...bottleSizeMl).contains(remainingMl) else {
+            throw InventoryError.invalidRemaining
+        }
+    }
+
+    static func applyIn(lot: StockLot, amountMl: Int, note: String?) throws {
+        guard lot.remainingMl + amountMl <= lot.bottleSizeMl else { throw InventoryError.stockOverflow }
+        lot.remainingMl += amountMl
+        lot.updatedAt = .now
+        lot.events.append(StockEvent(lot: lot, kind: "in", deltaMl: amountMl, note: note))
+    }
+
+    static func applyOut(lot: StockLot, amountMl: Int, note: String?) throws {
+        guard lot.remainingMl - amountMl >= 0 else { throw InventoryError.stockUnderflow }
+        lot.remainingMl -= amountMl
+        lot.updatedAt = .now
+        lot.events.append(StockEvent(lot: lot, kind: "out", deltaMl: -amountMl, note: note))
+    }
+
+    static func applyAdjust(lot: StockLot, to newRemainingMl: Int, note: String?) throws {
+        guard (0...lot.bottleSizeMl).contains(newRemainingMl) else { throw InventoryError.invalidRemaining }
+        let delta = newRemainingMl - lot.remainingMl
+        lot.remainingMl = newRemainingMl
+        lot.updatedAt = .now
+        lot.events.append(StockEvent(lot: lot, kind: "adjust", deltaMl: delta, note: note))
+    }
+
+    static func canDeleteSake(_ sake: Sake) -> Bool {
+        sake.lots.isEmpty
+    }
+}

--- a/NihonshuInventory/Utilities/Formatters.swift
+++ b/NihonshuInventory/Utilities/Formatters.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+enum AppFormatters {
+    static let dateTime: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ja_JP")
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        return formatter
+    }()
+}

--- a/NihonshuInventory/Views/InventoryListView.swift
+++ b/NihonshuInventory/Views/InventoryListView.swift
@@ -1,0 +1,125 @@
+import SwiftUI
+import SwiftData
+
+struct InventoryListView: View {
+    enum SortMode: String, CaseIterable, Identifiable {
+        case updatedDesc = "更新日↓"
+        case sakeAsc = "銘柄A-Z"
+
+        var id: String { rawValue }
+    }
+
+    @Environment(\.modelContext) private var modelContext
+    @Query private var lots: [StockLot]
+
+    @State private var searchText = ""
+    @State private var selectedOpened: Bool?
+    @State private var selectedLocation = "すべて"
+    @State private var sortMode: SortMode = .updatedDesc
+    @State private var showLotForm = false
+
+    init() {
+        _lots = Query(sort: [SortDescriptor(\StockLot.updatedAt, order: .reverse)])
+    }
+
+    private var locations: [String] {
+        let values = lots.compactMap { $0.location?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        return ["すべて"] + Array(Set(values)).sorted()
+    }
+
+    private var filteredLots: [StockLot] {
+        lots
+            .filter { lot in
+                if let opened = selectedOpened, lot.opened != opened { return false }
+                if selectedLocation != "すべて", lot.location != selectedLocation { return false }
+                if searchText.isEmpty { return true }
+                let key = searchText.lowercased()
+                return lot.sake.name.lowercased().contains(key)
+                    || (lot.sake.brewery?.lowercased().contains(key) ?? false)
+                    || (lot.location?.lowercased().contains(key) ?? false)
+            }
+            .sorted { lhs, rhs in
+                switch sortMode {
+                case .updatedDesc:
+                    return lhs.updatedAt > rhs.updatedAt
+                case .sakeAsc:
+                    return lhs.sake.name.localizedStandardCompare(rhs.sake.name) == .orderedAscending
+                }
+            }
+    }
+
+    var body: some View {
+        List {
+            Section {
+                Picker("開栓", selection: $selectedOpened) {
+                    Text("すべて").tag(Optional<Bool>.none)
+                    Text("未開栓").tag(Optional(false))
+                    Text("開栓済み").tag(Optional(true))
+                }
+                .pickerStyle(.segmented)
+
+                Picker("保管場所", selection: $selectedLocation) {
+                    ForEach(locations, id: \.self) { location in
+                        Text(location).tag(location)
+                    }
+                }
+
+                Picker("並び順", selection: $sortMode) {
+                    ForEach(SortMode.allCases) { mode in
+                        Text(mode.rawValue).tag(mode)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+
+            if filteredLots.isEmpty {
+                ContentUnavailableView(
+                    "在庫がありません",
+                    systemImage: "shippingbox",
+                    description: Text("右上の追加ボタンから在庫を作成してください。")
+                )
+            } else {
+                ForEach(filteredLots) { lot in
+                    NavigationLink {
+                        StockLotDetailView(lot: lot)
+                    } label: {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(lot.sake.name)
+                                .font(.headline)
+                            Text("場所: \(lot.location ?? "未設定")")
+                            Text("残量: \(lot.remainingMl) / \(lot.bottleSizeMl) ml")
+                            Text(lot.opened ? "開栓済み" : "未開栓")
+                            Text("更新: \(AppFormatters.dateTime.string(from: lot.updatedAt))")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .onDelete(perform: deleteLots)
+            }
+        }
+        .navigationTitle("日本酒棚卸")
+        .searchable(text: $searchText, prompt: "銘柄・蔵元・場所で検索")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    showLotForm = true
+                } label: {
+                    Label("在庫追加", systemImage: "plus")
+                }
+            }
+        }
+        .sheet(isPresented: $showLotForm) {
+            NavigationStack {
+                StockLotFormView()
+            }
+        }
+    }
+
+    private func deleteLots(offsets: IndexSet) {
+        for index in offsets {
+            modelContext.delete(filteredLots[index])
+        }
+    }
+}

--- a/NihonshuInventory/Views/InventoryListView.swift
+++ b/NihonshuInventory/Views/InventoryListView.swift
@@ -10,7 +10,9 @@ struct InventoryListView: View {
     }
 
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Query private var lots: [StockLot]
+    @Namespace private var cardNamespace
 
     @State private var searchText = ""
     @State private var selectedOpened: Bool?
@@ -50,54 +52,74 @@ struct InventoryListView: View {
     }
 
     var body: some View {
-        List {
-            Section {
-                Picker("開栓", selection: $selectedOpened) {
-                    Text("すべて").tag(Optional<Bool>.none)
-                    Text("未開栓").tag(Optional(false))
-                    Text("開栓済み").tag(Optional(true))
-                }
-                .pickerStyle(.segmented)
+        ZStack {
+            WashiBackground()
 
-                Picker("保管場所", selection: $selectedLocation) {
-                    ForEach(locations, id: \.self) { location in
-                        Text(location).tag(location)
+            List {
+                Section {
+                    Picker("開栓", selection: $selectedOpened) {
+                        Text("すべて").tag(Optional<Bool>.none)
+                        Text("未開栓").tag(Optional(false))
+                        Text("開栓済み").tag(Optional(true))
                     }
-                }
+                    .pickerStyle(.segmented)
 
-                Picker("並び順", selection: $sortMode) {
-                    ForEach(SortMode.allCases) { mode in
-                        Text(mode.rawValue).tag(mode)
-                    }
-                }
-                .pickerStyle(.segmented)
-            }
-
-            if filteredLots.isEmpty {
-                ContentUnavailableView(
-                    "在庫がありません",
-                    systemImage: "shippingbox",
-                    description: Text("右上の追加ボタンから在庫を作成してください。")
-                )
-            } else {
-                ForEach(filteredLots) { lot in
-                    NavigationLink {
-                        StockLotDetailView(lot: lot)
-                    } label: {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(lot.sake.name)
-                                .font(.headline)
-                            Text("場所: \(lot.location ?? "未設定")")
-                            Text("残量: \(lot.remainingMl) / \(lot.bottleSizeMl) ml")
-                            Text(lot.opened ? "開栓済み" : "未開栓")
-                            Text("更新: \(AppFormatters.dateTime.string(from: lot.updatedAt))")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
+                    Picker("保管場所", selection: $selectedLocation) {
+                        ForEach(locations, id: \.self) { location in
+                            Text(location).tag(location)
                         }
                     }
+
+                    Picker("並び順", selection: $sortMode) {
+                        ForEach(SortMode.allCases) { mode in
+                            Text(mode.rawValue).tag(mode)
+                        }
+                    }
+                    .pickerStyle(.segmented)
                 }
-                .onDelete(perform: deleteLots)
+
+                if filteredLots.isEmpty {
+                    EmptyStateView(
+                        title: "在庫がありません",
+                        message: "右上の追加ボタンから在庫を作成してください。",
+                        systemImage: "shippingbox",
+                        actionTitle: "在庫を追加",
+                        action: { showLotForm = true }
+                    )
+                    .listRowSeparator(.hidden)
+                } else {
+                    ForEach(filteredLots) { lot in
+                        NavigationLink {
+                            StockLotDetailView(lot: lot, namespace: cardNamespace)
+                        } label: {
+                            CardContainer {
+                                VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+                                    Text(lot.sake.name)
+                                        .font(Theme.Typography.headline)
+                                        .foregroundStyle(Theme.Colors.ink)
+                                        .matchedGeometryEffect(id: "title-\(lot.id)", in: cardNamespace)
+                                    Text("場所: \(lot.location ?? "未設定")")
+                                        .font(Theme.Typography.body)
+                                    Text("残量: \(lot.remainingMl) / \(lot.bottleSizeMl) ml")
+                                        .font(Theme.Typography.body)
+                                    Text(lot.opened ? "開栓済み" : "未開栓")
+                                        .font(Theme.Typography.body)
+                                        .foregroundStyle(.secondary)
+                                    Text("更新: \(AppFormatters.dateTime.string(from: lot.updatedAt))")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                        .listRowSeparator(.hidden)
+                        .listRowBackground(Color.clear)
+                        .transition(Motion.fadeScale(reduceMotion: reduceMotion).combined(with: .move(edge: .bottom)))
+                    }
+                    .onDelete(perform: deleteLots)
+                }
             }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
         }
         .navigationTitle("日本酒棚卸")
         .searchable(text: $searchText, prompt: "銘柄・蔵元・場所で検索")
@@ -110,6 +132,7 @@ struct InventoryListView: View {
                 }
             }
         }
+        .animation(Motion.emphasizedSpring(reduceMotion: reduceMotion), value: filteredLots)
         .sheet(isPresented: $showLotForm) {
             NavigationStack {
                 StockLotFormView()

--- a/NihonshuInventory/Views/RootTabView.swift
+++ b/NihonshuInventory/Views/RootTabView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct RootTabView: View {
+    var body: some View {
+        TabView {
+            NavigationStack {
+                InventoryListView()
+            }
+            .tabItem {
+                Label("在庫", systemImage: "shippingbox")
+            }
+
+            NavigationStack {
+                SakeManagementView()
+            }
+            .tabItem {
+                Label("銘柄", systemImage: "wineglass")
+            }
+        }
+    }
+}

--- a/NihonshuInventory/Views/RootTabView.swift
+++ b/NihonshuInventory/Views/RootTabView.swift
@@ -17,5 +17,6 @@ struct RootTabView: View {
                 Label("銘柄", systemImage: "wineglass")
             }
         }
+        .tint(Theme.Colors.accent)
     }
 }

--- a/NihonshuInventory/Views/SakeFormView.swift
+++ b/NihonshuInventory/Views/SakeFormView.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+import SwiftData
+
+struct SakeFormView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \Sake.name) private var allSakes: [Sake]
+
+    let sake: Sake?
+
+    @State private var name = ""
+    @State private var brewery = ""
+    @State private var type = ""
+    @State private var memo = ""
+    @State private var errorMessage: String?
+
+    init(sake: Sake? = nil) {
+        self.sake = sake
+        _name = State(initialValue: sake?.name ?? "")
+        _brewery = State(initialValue: sake?.brewery ?? "")
+        _type = State(initialValue: sake?.type ?? "")
+        _memo = State(initialValue: sake?.memo ?? "")
+    }
+
+    var body: some View {
+        Form {
+            Section("基本情報") {
+                TextField("銘柄名（必須）", text: $name)
+                TextField("蔵元", text: $brewery)
+                TextField("タイプ", text: $type)
+                TextField("メモ", text: $memo, axis: .vertical)
+                    .lineLimit(3...6)
+            }
+        }
+        .navigationTitle(sake == nil ? "銘柄追加" : "銘柄編集")
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("キャンセル") { dismiss() }
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("保存") { saveSake() }
+            }
+        }
+        .alert("エラー", isPresented: Binding(
+            get: { errorMessage != nil },
+            set: { _ in errorMessage = nil }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    private func saveSake() {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let allNames = allSakes.map(\.name)
+
+        do {
+            try InventoryService.validateSakeName(trimmedName, existingNames: allNames, currentName: sake?.name)
+
+            if let sake {
+                sake.name = trimmedName
+                sake.brewery = normalizedOrNil(brewery)
+                sake.type = normalizedOrNil(type)
+                sake.memo = normalizedOrNil(memo)
+                sake.updatedAt = .now
+            } else {
+                let newSake = Sake(
+                    name: trimmedName,
+                    brewery: normalizedOrNil(brewery),
+                    type: normalizedOrNil(type),
+                    memo: normalizedOrNil(memo)
+                )
+                modelContext.insert(newSake)
+            }
+
+            try modelContext.save()
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func normalizedOrNil(_ text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/NihonshuInventory/Views/SakeFormView.swift
+++ b/NihonshuInventory/Views/SakeFormView.swift
@@ -23,14 +23,19 @@ struct SakeFormView: View {
     }
 
     var body: some View {
-        Form {
-            Section("基本情報") {
-                TextField("銘柄名（必須）", text: $name)
-                TextField("蔵元", text: $brewery)
-                TextField("タイプ", text: $type)
-                TextField("メモ", text: $memo, axis: .vertical)
-                    .lineLimit(3...6)
+        ZStack {
+            WashiBackground()
+
+            Form {
+                Section("基本情報") {
+                    TextField("銘柄名（必須）", text: $name)
+                    TextField("蔵元", text: $brewery)
+                    TextField("タイプ", text: $type)
+                    TextField("メモ", text: $memo, axis: .vertical)
+                        .lineLimit(3...6)
+                }
             }
+            .scrollContentBackground(.hidden)
         }
         .navigationTitle(sake == nil ? "銘柄追加" : "銘柄編集")
         .toolbar {

--- a/NihonshuInventory/Views/SakeManagementView.swift
+++ b/NihonshuInventory/Views/SakeManagementView.swift
@@ -3,6 +3,7 @@ import SwiftData
 
 struct SakeManagementView: View {
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Query(sort: \Sake.updatedAt, order: .reverse) private var sakes: [Sake]
 
     @State private var showCreate = false
@@ -10,32 +11,47 @@ struct SakeManagementView: View {
     @State private var errorMessage: String?
 
     var body: some View {
-        List {
-            if sakes.isEmpty {
-                ContentUnavailableView(
-                    "銘柄がありません",
-                    systemImage: "wineglass",
-                    description: Text("右上の追加ボタンから銘柄を登録してください。")
-                )
-            } else {
-                ForEach(sakes) { sake in
-                    Button {
-                        editingSake = sake
-                    } label: {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(sake.name)
-                                .font(.headline)
-                                .foregroundStyle(.primary)
-                            Text("蔵元: \(sake.brewery ?? "未設定")")
-                                .foregroundStyle(.secondary)
-                            Text("更新: \(AppFormatters.dateTime.string(from: sake.updatedAt))")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
+        ZStack {
+            WashiBackground()
+
+            List {
+                if sakes.isEmpty {
+                    EmptyStateView(
+                        title: "銘柄がありません",
+                        message: "右上の追加ボタンから銘柄を登録してください。",
+                        systemImage: "wineglass",
+                        actionTitle: "銘柄を追加",
+                        action: { showCreate = true }
+                    )
+                    .listRowSeparator(.hidden)
+                } else {
+                    ForEach(sakes) { sake in
+                        Button {
+                            editingSake = sake
+                        } label: {
+                            CardContainer {
+                                VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+                                    Text(sake.name)
+                                        .font(Theme.Typography.headline)
+                                        .foregroundStyle(Theme.Colors.ink)
+                                    Text("蔵元: \(sake.brewery ?? "未設定")")
+                                        .font(Theme.Typography.body)
+                                        .foregroundStyle(.secondary)
+                                    Text("更新: \(AppFormatters.dateTime.string(from: sake.updatedAt))")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
                         }
+                        .listRowSeparator(.hidden)
+                        .listRowBackground(Color.clear)
+                        .transition(Motion.fadeScale(reduceMotion: reduceMotion).combined(with: .move(edge: .bottom)))
                     }
+                    .onDelete(perform: deleteSake)
                 }
-                .onDelete(perform: deleteSake)
             }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
         }
         .navigationTitle("銘柄管理")
         .toolbar {
@@ -47,6 +63,7 @@ struct SakeManagementView: View {
                 }
             }
         }
+        .animation(Motion.emphasizedSpring(reduceMotion: reduceMotion), value: sakes.count)
         .sheet(isPresented: $showCreate) {
             NavigationStack {
                 SakeFormView()

--- a/NihonshuInventory/Views/SakeManagementView.swift
+++ b/NihonshuInventory/Views/SakeManagementView.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+import SwiftData
+
+struct SakeManagementView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \Sake.updatedAt, order: .reverse) private var sakes: [Sake]
+
+    @State private var showCreate = false
+    @State private var editingSake: Sake?
+    @State private var errorMessage: String?
+
+    var body: some View {
+        List {
+            if sakes.isEmpty {
+                ContentUnavailableView(
+                    "銘柄がありません",
+                    systemImage: "wineglass",
+                    description: Text("右上の追加ボタンから銘柄を登録してください。")
+                )
+            } else {
+                ForEach(sakes) { sake in
+                    Button {
+                        editingSake = sake
+                    } label: {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(sake.name)
+                                .font(.headline)
+                                .foregroundStyle(.primary)
+                            Text("蔵元: \(sake.brewery ?? "未設定")")
+                                .foregroundStyle(.secondary)
+                            Text("更新: \(AppFormatters.dateTime.string(from: sake.updatedAt))")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .onDelete(perform: deleteSake)
+            }
+        }
+        .navigationTitle("銘柄管理")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    showCreate = true
+                } label: {
+                    Label("追加", systemImage: "plus")
+                }
+            }
+        }
+        .sheet(isPresented: $showCreate) {
+            NavigationStack {
+                SakeFormView()
+            }
+        }
+        .sheet(item: $editingSake) { sake in
+            NavigationStack {
+                SakeFormView(sake: sake)
+            }
+        }
+        .alert("エラー", isPresented: Binding(
+            get: { errorMessage != nil },
+            set: { _ in errorMessage = nil }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    private func deleteSake(offsets: IndexSet) {
+        for index in offsets {
+            let target = sakes[index]
+            guard InventoryService.canDeleteSake(target) else {
+                errorMessage = InventoryError.sakeHasLots.localizedDescription
+                return
+            }
+            modelContext.delete(target)
+        }
+    }
+}

--- a/NihonshuInventory/Views/StockLotDetailView.swift
+++ b/NihonshuInventory/Views/StockLotDetailView.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+import SwiftData
+
+struct StockLotDetailView: View {
+    enum ActionKind: String, CaseIterable, Identifiable {
+        case `in` = "入庫"
+        case out = "提供"
+        case adjust = "棚卸調整"
+
+        var id: String { rawValue }
+    }
+
+    @Environment(\.modelContext) private var modelContext
+    @State private var amount = ""
+    @State private var note = ""
+    @State private var actionKind: ActionKind = .out
+    @State private var errorMessage: String?
+
+    let lot: StockLot
+
+    private var sortedEvents: [StockEvent] {
+        lot.events.sorted { $0.at > $1.at }
+    }
+
+    var body: some View {
+        Form {
+            Section("基本情報") {
+                LabeledContent("銘柄", value: lot.sake.name)
+                LabeledContent("場所", value: lot.location ?? "未設定")
+                LabeledContent("状態", value: lot.opened ? "開栓済み" : "未開栓")
+                LabeledContent("容量", value: "\(lot.bottleSizeMl)ml")
+                LabeledContent("残量", value: "\(lot.remainingMl)ml")
+                LabeledContent("更新", value: AppFormatters.dateTime.string(from: lot.updatedAt))
+            }
+
+            Section("在庫操作") {
+                Picker("操作", selection: $actionKind) {
+                    ForEach(ActionKind.allCases) { kind in
+                        Text(kind.rawValue).tag(kind)
+                    }
+                }
+
+                TextField(actionKind == .adjust ? "調整後残量(ml)" : "数量(ml)", text: $amount)
+                    .keyboardType(.numberPad)
+
+                TextField("メモ", text: $note)
+
+                Button("実行") {
+                    applyAction()
+                }
+            }
+
+            Section("履歴") {
+                if sortedEvents.isEmpty {
+                    Text("履歴はまだありません。")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(sortedEvents) { event in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("\(event.kind) \(event.deltaMl >= 0 ? "+" : "")\(event.deltaMl)ml")
+                                .font(.headline)
+                            if let note = event.note, !note.isEmpty {
+                                Text(note)
+                            }
+                            Text(AppFormatters.dateTime.string(from: event.at))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("在庫詳細")
+        .alert("エラー", isPresented: Binding(
+            get: { errorMessage != nil },
+            set: { _ in errorMessage = nil }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    private func applyAction() {
+        guard let value = Int(amount), value >= 0 else {
+            errorMessage = "数量は0以上の整数で入力してください。"
+            return
+        }
+
+        do {
+            switch actionKind {
+            case .in:
+                try InventoryService.applyIn(lot: lot, amountMl: value, note: noteOrNil)
+            case .out:
+                try InventoryService.applyOut(lot: lot, amountMl: value, note: noteOrNil)
+            case .adjust:
+                try InventoryService.applyAdjust(lot: lot, to: value, note: noteOrNil)
+            }
+            try modelContext.save()
+            amount = ""
+            note = ""
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private var noteOrNil: String? {
+        let trimmed = note.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/NihonshuInventory/Views/StockLotDetailView.swift
+++ b/NihonshuInventory/Views/StockLotDetailView.swift
@@ -11,66 +11,101 @@ struct StockLotDetailView: View {
     }
 
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var amount = ""
     @State private var note = ""
     @State private var actionKind: ActionKind = .out
     @State private var errorMessage: String?
 
     let lot: StockLot
+    let namespace: Namespace.ID?
 
     private var sortedEvents: [StockEvent] {
         lot.events.sorted { $0.at > $1.at }
     }
 
     var body: some View {
-        Form {
-            Section("基本情報") {
-                LabeledContent("銘柄", value: lot.sake.name)
-                LabeledContent("場所", value: lot.location ?? "未設定")
-                LabeledContent("状態", value: lot.opened ? "開栓済み" : "未開栓")
-                LabeledContent("容量", value: "\(lot.bottleSizeMl)ml")
-                LabeledContent("残量", value: "\(lot.remainingMl)ml")
-                LabeledContent("更新", value: AppFormatters.dateTime.string(from: lot.updatedAt))
-            }
+        ZStack {
+            WashiBackground()
 
-            Section("在庫操作") {
-                Picker("操作", selection: $actionKind) {
-                    ForEach(ActionKind.allCases) { kind in
-                        Text(kind.rawValue).tag(kind)
+            ScrollView {
+                VStack(spacing: Theme.Spacing.md) {
+                    CardContainer {
+                        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+                            titleView
+                            Divider()
+                                .overlay(Theme.DividerStyle.color)
+                            LabeledContent("場所", value: lot.location ?? "未設定")
+                            LabeledContent("状態", value: lot.opened ? "開栓済み" : "未開栓")
+                            LabeledContent("容量", value: "\(lot.bottleSizeMl)ml")
+                            LabeledContent("残量", value: "\(lot.remainingMl)ml")
+                            LabeledContent("更新", value: AppFormatters.dateTime.string(from: lot.updatedAt))
+                        }
+                        .font(Theme.Typography.body)
                     }
-                }
 
-                TextField(actionKind == .adjust ? "調整後残量(ml)" : "数量(ml)", text: $amount)
-                    .keyboardType(.numberPad)
-
-                TextField("メモ", text: $note)
-
-                Button("実行") {
-                    applyAction()
-                }
-            }
-
-            Section("履歴") {
-                if sortedEvents.isEmpty {
-                    Text("履歴はまだありません。")
-                        .foregroundStyle(.secondary)
-                } else {
-                    ForEach(sortedEvents) { event in
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("\(event.kind) \(event.deltaMl >= 0 ? "+" : "")\(event.deltaMl)ml")
-                                .font(.headline)
-                            if let note = event.note, !note.isEmpty {
-                                Text(note)
+                    CardContainer {
+                        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                            Text("在庫操作")
+                                .font(Theme.Typography.headline)
+                                .foregroundStyle(Theme.Colors.ink)
+                            Picker("操作", selection: $actionKind) {
+                                ForEach(ActionKind.allCases) { kind in
+                                    Text(kind.rawValue).tag(kind)
+                                }
                             }
-                            Text(AppFormatters.dateTime.string(from: event.at))
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
+
+                            TextField(actionKind == .adjust ? "調整後残量(ml)" : "数量(ml)", text: $amount)
+                                .keyboardType(.numberPad)
+                                .textFieldStyle(.roundedBorder)
+
+                            TextField("メモ", text: $note)
+                                .textFieldStyle(.roundedBorder)
+
+                            PrimaryButton(title: "実行") {
+                                applyAction()
+                            }
+                        }
+                    }
+
+                    CardContainer {
+                        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                            Text("履歴")
+                                .font(Theme.Typography.headline)
+                                .foregroundStyle(Theme.Colors.ink)
+
+                            if sortedEvents.isEmpty {
+                                Text("履歴はまだありません。")
+                                    .foregroundStyle(.secondary)
+                            } else {
+                                ForEach(sortedEvents) { event in
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text("\(event.kind) \(event.deltaMl >= 0 ? "+" : "")\(event.deltaMl)ml")
+                                            .font(Theme.Typography.headline)
+                                        if let note = event.note, !note.isEmpty {
+                                            Text(note)
+                                                .font(Theme.Typography.body)
+                                        }
+                                        Text(AppFormatters.dateTime.string(from: event.at))
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                    .padding(.vertical, Theme.Spacing.xs)
+                                    if event.id != sortedEvents.last?.id {
+                                        Divider()
+                                            .overlay(Theme.DividerStyle.color)
+                                    }
+                                }
+                            }
                         }
                     }
                 }
+                .padding(Theme.Spacing.md)
             }
+            .scrollIndicators(.hidden)
         }
         .navigationTitle("在庫詳細")
+        .animation(Motion.emphasizedSpring(reduceMotion: reduceMotion), value: lot.remainingMl)
         .alert("エラー", isPresented: Binding(
             get: { errorMessage != nil },
             set: { _ in errorMessage = nil }
@@ -78,6 +113,20 @@ struct StockLotDetailView: View {
             Button("OK", role: .cancel) {}
         } message: {
             Text(errorMessage ?? "")
+        }
+    }
+
+    @ViewBuilder
+    private var titleView: some View {
+        if let namespace {
+            Text(lot.sake.name)
+                .font(Theme.Typography.title)
+                .foregroundStyle(Theme.Colors.ink)
+                .matchedGeometryEffect(id: "title-\(lot.id)", in: namespace)
+        } else {
+            Text(lot.sake.name)
+                .font(Theme.Typography.title)
+                .foregroundStyle(Theme.Colors.ink)
         }
     }
 

--- a/NihonshuInventory/Views/StockLotFormView.swift
+++ b/NihonshuInventory/Views/StockLotFormView.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+import SwiftData
+
+struct StockLotFormView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \Sake.name) private var sakes: [Sake]
+
+    @State private var selectedSake: Sake?
+    @State private var bottleSizeMl = "720"
+    @State private var location = ""
+    @State private var opened = false
+    @State private var remainingMl = "720"
+
+    @State private var showCreateSake = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        Form {
+            Section("銘柄") {
+                if sakes.isEmpty {
+                    Text("先に銘柄を作成してください。")
+                } else {
+                    Picker("銘柄", selection: $selectedSake) {
+                        Text("選択してください").tag(Optional<Sake>.none)
+                        ForEach(sakes) { sake in
+                            Text(sake.name).tag(Optional(sake))
+                        }
+                    }
+                }
+                Button("銘柄を新規作成") {
+                    showCreateSake = true
+                }
+            }
+
+            Section("在庫情報") {
+                TextField("容量(ml)", text: $bottleSizeMl)
+                    .keyboardType(.numberPad)
+                TextField("保管場所", text: $location)
+                Toggle("開栓済み", isOn: $opened)
+                TextField("残量(ml)", text: $remainingMl)
+                    .keyboardType(.numberPad)
+            }
+        }
+        .navigationTitle("在庫追加")
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("キャンセル") { dismiss() }
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("保存") { saveLot() }
+            }
+        }
+        .sheet(isPresented: $showCreateSake) {
+            NavigationStack {
+                SakeFormView()
+            }
+        }
+        .onAppear {
+            if selectedSake == nil { selectedSake = sakes.first }
+        }
+        .alert("エラー", isPresented: Binding(
+            get: { errorMessage != nil },
+            set: { _ in errorMessage = nil }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    private func saveLot() {
+        guard let selectedSake else {
+            errorMessage = "銘柄を選択してください。"
+            return
+        }
+        guard let size = Int(bottleSizeMl), let remaining = Int(remainingMl) else {
+            errorMessage = "容量と残量は整数で入力してください。"
+            return
+        }
+
+        do {
+            try InventoryService.validateLot(bottleSizeMl: size, remainingMl: remaining)
+            let lot = StockLot(
+                sake: selectedSake,
+                location: normalizedLocation,
+                bottleSizeMl: size,
+                opened: opened,
+                remainingMl: remaining
+            )
+            modelContext.insert(lot)
+            try modelContext.save()
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private var normalizedLocation: String? {
+        let trimmed = location.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/NihonshuInventory/Views/StockLotFormView.swift
+++ b/NihonshuInventory/Views/StockLotFormView.swift
@@ -16,31 +16,36 @@ struct StockLotFormView: View {
     @State private var errorMessage: String?
 
     var body: some View {
-        Form {
-            Section("銘柄") {
-                if sakes.isEmpty {
-                    Text("先に銘柄を作成してください。")
-                } else {
-                    Picker("銘柄", selection: $selectedSake) {
-                        Text("選択してください").tag(Optional<Sake>.none)
-                        ForEach(sakes) { sake in
-                            Text(sake.name).tag(Optional(sake))
+        ZStack {
+            WashiBackground()
+
+            Form {
+                Section("銘柄") {
+                    if sakes.isEmpty {
+                        Text("先に銘柄を作成してください。")
+                    } else {
+                        Picker("銘柄", selection: $selectedSake) {
+                            Text("選択してください").tag(Optional<Sake>.none)
+                            ForEach(sakes) { sake in
+                                Text(sake.name).tag(Optional(sake))
+                            }
                         }
                     }
+                    Button("銘柄を新規作成") {
+                        showCreateSake = true
+                    }
                 }
-                Button("銘柄を新規作成") {
-                    showCreateSake = true
-                }
-            }
 
-            Section("在庫情報") {
-                TextField("容量(ml)", text: $bottleSizeMl)
-                    .keyboardType(.numberPad)
-                TextField("保管場所", text: $location)
-                Toggle("開栓済み", isOn: $opened)
-                TextField("残量(ml)", text: $remainingMl)
-                    .keyboardType(.numberPad)
+                Section("在庫情報") {
+                    TextField("容量(ml)", text: $bottleSizeMl)
+                        .keyboardType(.numberPad)
+                    TextField("保管場所", text: $location)
+                    Toggle("開栓済み", isOn: $opened)
+                    TextField("残量(ml)", text: $remainingMl)
+                        .keyboardType(.numberPad)
+                }
             }
+            .scrollContentBackground(.hidden)
         }
         .navigationTitle("在庫追加")
         .toolbar {

--- a/NihonshuInventoryTests/InventoryServiceTests.swift
+++ b/NihonshuInventoryTests/InventoryServiceTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import NihonshuInventory
+
+final class InventoryServiceTests: XCTestCase {
+    func testApplyOutReducesRemainingAndCreatesEvent() throws {
+        let sake = Sake(name: "テスト酒")
+        let lot = StockLot(sake: sake, bottleSizeMl: 720, opened: true, remainingMl: 500)
+
+        try InventoryService.applyOut(lot: lot, amountMl: 120, note: "試飲")
+
+        XCTAssertEqual(lot.remainingMl, 380)
+        XCTAssertEqual(lot.events.count, 1)
+        XCTAssertEqual(lot.events.first?.kind, "out")
+        XCTAssertEqual(lot.events.first?.deltaMl, -120)
+    }
+
+    func testApplyAdjustSetsRemainingAndRecordsDelta() throws {
+        let sake = Sake(name: "テスト酒")
+        let lot = StockLot(sake: sake, bottleSizeMl: 1800, opened: false, remainingMl: 1600)
+
+        try InventoryService.applyAdjust(lot: lot, to: 1500, note: "棚卸")
+
+        XCTAssertEqual(lot.remainingMl, 1500)
+        XCTAssertEqual(lot.events.first?.kind, "adjust")
+        XCTAssertEqual(lot.events.first?.deltaMl, -100)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
-# mock-private
-private mockup
+# 日本酒棚卸（iOS 18.6+ / オフライン）
+
+SwiftUI + SwiftData で作成した、ローカル保存専用の日本酒在庫管理アプリです。
+
+## 機能
+- 在庫一覧（検索 / 開栓フィルタ / 保管場所フィルタ / 並び替え）
+- 在庫詳細（入庫・提供・棚卸調整）
+- 増減履歴（StockEvent）
+- 銘柄管理（Sake の作成・編集・削除）
+  - 同名チェック（重複禁止）
+  - 在庫が紐づく銘柄は削除不可
+- 在庫追加フォーム（銘柄選択、容量、場所、開栓状態、残量）
+
+## ディレクトリ構成
+- `NihonshuInventory/Models`: SwiftDataモデル
+- `NihonshuInventory/Services`: 在庫更新ロジックとバリデーション
+- `NihonshuInventory/Views`: 画面
+- `NihonshuInventory/Utilities`: フォーマッタ
+- `NihonshuInventoryTests`: ユニットテスト
+
+## Xcodeで実行する手順
+1. Xcode 16 以降で iOS App プロジェクト `NihonshuInventory` を新規作成（SwiftUI / SwiftData）。
+2. Deployment Target を **iOS 18.6** に設定。
+3. このリポジトリの `NihonshuInventory/` 配下ファイルをプロジェクトに追加。
+4. テストターゲットへ `NihonshuInventoryTests/InventoryServiceTests.swift` を追加。
+5. 実機または iOS 18.6+ シミュレータで Run。
+
+> 注: このリポジトリには `.xcodeproj` は含めていません。既存プロジェクトへ取り込みやすいよう、ファイル分割したソースのみを配置しています。


### PR DESCRIPTION
### Motivation
- オフライン専用でローカル保存のみ動作する、iOS 18.6+ 向けの日本酒在庫管理アプリを最小実装で用意するため。 
- 在庫の現在値と増減履歴を `SwiftData` で永続化し、UIは `SwiftUI` / `NavigationStack` で実装する要件を満たすため。 
- 銘柄重複禁止や残量レンジ検証などのバリデーションを組み込み、安全に運用できる状態を目指すため。 

### Description
- SwiftData モデルを追加し、`Sake`（銘柄、`@Attribute(.unique)` で重複抑止）、`StockLot`（在庫単位）、`StockEvent`（増減履歴）とそれぞれの関連を定義しました。 
- 在庫更新ロジックとバリデーションを `InventoryService` に集約し、`applyIn`/`applyOut`/`applyAdjust` 実装および銘柄名・在庫入力の検証を追加しました。 
- UI を `SwiftUI` で実装し、`RootTabView`（タブ構成）、`InventoryListView`（検索・フィルタ・ソート・一覧）、`StockLotDetailView`（残量表示＋操作＋履歴）、`StockLotFormView`（在庫追加フォーム）、`SakeManagementView`/`SakeFormView`（銘柄CRUD）を追加しました。 
- `NihonshuInventoryApp` で `modelContainer` を注入し、日付フォーマット用の `AppFormatters` と日本語 README、及び `XCTest` によるユニットテスト（`NihonshuInventoryTests/InventoryServiceTests.swift`）を追加しました。 

### Testing
- 自動テストとして `NihonshuInventoryTests/InventoryServiceTests.swift` に `testApplyOutReducesRemainingAndCreatesEvent` と `testApplyAdjustSetsRemainingAndRecordsDelta` の2つのテストを追加しています。 
- リポジトリ直下で `swift test` を実行しましたが、`Package.swift` が存在しないため実行に失敗し（Xcode プロジェクト前提の構成）、テストは実行されていません。 
- 実機/シミュレータでの動作確認とテスト実行は Xcode 上でプロジェクトにファイルを取り込んだうえで `Product → Test` を実行してください。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69842f45020c8329a248d0598bcd7d9a)