### PR TITLE
Add retro coin-pusher + horse race single-page game

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,468 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>レトロ競馬レースゲーム・プッシャー</title>
+  <style>
+    :root {
+      --bg: #0b0b16;
+      --panel: #1b1b2d;
+      --accent: #f7c948;
+      --accent-2: #ff6b6b;
+      --accent-3: #6ee7b7;
+      --text: #f8f9ff;
+      --track: #2b2b44;
+      --lane: #3a3a5e;
+    }
+
+    * {
+      box-sizing: border-box;
+      font-family: "Courier New", Courier, monospace;
+    }
+
+    body {
+      margin: 0;
+      background: linear-gradient(180deg, #05050b, var(--bg));
+      color: var(--text);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+    }
+
+    .cabinet {
+      width: min(960px, 100%);
+      background: var(--panel);
+      border: 4px solid #3f3f66;
+      border-radius: 18px;
+      padding: 24px;
+      box-shadow: 0 20px 50px rgba(0, 0, 0, 0.5);
+    }
+
+    header {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      border-bottom: 2px solid #3f3f66;
+      padding-bottom: 12px;
+    }
+
+    h1 {
+      font-size: 1.4rem;
+      margin: 0;
+      letter-spacing: 2px;
+      text-transform: uppercase;
+    }
+
+    .status {
+      display: flex;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+
+    .status-card {
+      background: #25253d;
+      padding: 8px 14px;
+      border-radius: 10px;
+      border: 2px solid #3f3f66;
+      min-width: 140px;
+    }
+
+    .status-card span {
+      display: block;
+      font-size: 0.8rem;
+      color: #c7c7dd;
+    }
+
+    .status-card strong {
+      font-size: 1.1rem;
+      color: var(--accent);
+    }
+
+    .layout {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(280px, 0.55fr);
+      gap: 20px;
+      margin-top: 20px;
+    }
+
+    .pusher-area,
+    .race-area {
+      background: #202038;
+      border-radius: 14px;
+      padding: 16px;
+      border: 2px solid #3f3f66;
+    }
+
+    .pusher-area {
+      position: relative;
+      min-height: 240px;
+      overflow: hidden;
+    }
+
+    .pusher-track {
+      position: absolute;
+      left: 16px;
+      right: 16px;
+      top: 40px;
+      height: 120px;
+      background: linear-gradient(90deg, #35355a, #2c2c49);
+      border-radius: 10px;
+      border: 2px solid #45456d;
+    }
+
+    .pusher {
+      position: absolute;
+      left: 16px;
+      right: 16px;
+      bottom: 30px;
+      height: 40px;
+      background: linear-gradient(90deg, #f7c948, #ff9f43);
+      border-radius: 10px;
+      border: 2px solid #f1b20f;
+      animation: pusher-move 1.2s ease-in-out infinite;
+    }
+
+    @keyframes pusher-move {
+      0%, 100% {
+        transform: translateY(0);
+      }
+      50% {
+        transform: translateY(-18px);
+      }
+    }
+
+    .coin {
+      position: absolute;
+      width: 26px;
+      height: 26px;
+      border-radius: 50%;
+      background: radial-gradient(circle at 30% 30%, #fff7d6, #f7c948 70%);
+      border: 2px solid #f1b20f;
+      box-shadow: 0 4px 10px rgba(0, 0, 0, 0.4);
+      opacity: 0;
+      animation: coin-drop 1.5s ease-in-out forwards;
+    }
+
+    @keyframes coin-drop {
+      0% {
+        transform: translate(0, -20px);
+        opacity: 0;
+      }
+      30% {
+        opacity: 1;
+      }
+      60% {
+        transform: translate(120px, 30px);
+      }
+      100% {
+        transform: translate(220px, 80px);
+        opacity: 0;
+      }
+    }
+
+    .race-area {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+
+    .track {
+      background: var(--track);
+      border-radius: 10px;
+      padding: 12px;
+      border: 2px solid #3f3f66;
+    }
+
+    .lane {
+      position: relative;
+      background: var(--lane);
+      height: 36px;
+      border-radius: 8px;
+      overflow: hidden;
+      margin-bottom: 10px;
+    }
+
+    .lane:last-child {
+      margin-bottom: 0;
+    }
+
+    .horse {
+      position: absolute;
+      left: 8px;
+      top: 50%;
+      transform: translateY(-50%);
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 0.85rem;
+      font-weight: bold;
+      color: #ffffff;
+    }
+
+    .horse-icon {
+      font-size: 1.2rem;
+    }
+
+    .finish {
+      position: absolute;
+      right: 20px;
+      top: 0;
+      bottom: 0;
+      width: 4px;
+      background: repeating-linear-gradient(
+        180deg,
+        #fff 0,
+        #fff 6px,
+        #000 6px,
+        #000 12px
+      );
+    }
+
+    .controls {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      margin-top: 12px;
+    }
+
+    button {
+      padding: 12px 16px;
+      border-radius: 10px;
+      border: none;
+      background: var(--accent);
+      color: #1a1a1a;
+      font-weight: bold;
+      cursor: pointer;
+      transition: transform 0.1s ease, box-shadow 0.2s ease;
+      box-shadow: 0 6px 12px rgba(0, 0, 0, 0.4);
+    }
+
+    button:hover {
+      transform: translateY(-1px);
+    }
+
+    button:disabled {
+      background: #555;
+      cursor: not-allowed;
+      transform: none;
+    }
+
+    .result {
+      background: #25253d;
+      border-radius: 10px;
+      padding: 12px;
+      border: 2px solid #3f3f66;
+      min-height: 80px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .result strong {
+      color: var(--accent-3);
+    }
+
+    .history {
+      font-size: 0.85rem;
+      color: #c7c7dd;
+      max-height: 120px;
+      overflow-y: auto;
+    }
+
+    .badge {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 999px;
+      background: #3f3f66;
+      font-size: 0.75rem;
+      color: #f7c948;
+      margin-left: 6px;
+    }
+
+    @media (max-width: 860px) {
+      .layout {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="cabinet">
+    <header>
+      <h1>Retro Turf Pusher Derby</h1>
+      <div class="status">
+        <div class="status-card">
+          <span>クレジット</span>
+          <strong id="creditCount">3</strong>
+        </div>
+        <div class="status-card">
+          <span>投入コイン</span>
+          <strong id="coinCount">0</strong>
+        </div>
+        <div class="status-card">
+          <span>ラウンド</span>
+          <strong id="roundCount">0</strong>
+        </div>
+      </div>
+    </header>
+
+    <div class="layout">
+      <section class="pusher-area">
+        <h2>コインプッシャー</h2>
+        <p>コイン投入でプッシャーが動き、レースがスタート！</p>
+        <div class="pusher-track"></div>
+        <div class="pusher"></div>
+      </section>
+
+      <section class="race-area">
+        <h2>レトロ競馬レース</h2>
+        <div class="track" id="track">
+          <div class="lane" data-horse="1">
+            <div class="finish"></div>
+            <div class="horse" id="horse-1"><span class="horse-icon">🐎</span>サンダー</div>
+          </div>
+          <div class="lane" data-horse="2">
+            <div class="finish"></div>
+            <div class="horse" id="horse-2"><span class="horse-icon">🐴</span>ミルキー</div>
+          </div>
+          <div class="lane" data-horse="3">
+            <div class="finish"></div>
+            <div class="horse" id="horse-3"><span class="horse-icon">🏇</span>ブレイズ</div>
+          </div>
+          <div class="lane" data-horse="4">
+            <div class="finish"></div>
+            <div class="horse" id="horse-4"><span class="horse-icon">🐎</span>シャドウ</div>
+          </div>
+          <div class="lane" data-horse="5">
+            <div class="finish"></div>
+            <div class="horse" id="horse-5"><span class="horse-icon">🐴</span>スター</div>
+          </div>
+        </div>
+
+        <div class="controls">
+          <button id="insertButton">コイン投入</button>
+          <button id="resetButton">クレジット補充</button>
+        </div>
+
+        <div class="result">
+          <div>結果: <strong id="resultText">準備中</strong></div>
+          <div class="history" id="history"></div>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <script>
+    const creditCount = document.getElementById("creditCount");
+    const coinCount = document.getElementById("coinCount");
+    const roundCount = document.getElementById("roundCount");
+    const insertButton = document.getElementById("insertButton");
+    const resetButton = document.getElementById("resetButton");
+    const resultText = document.getElementById("resultText");
+    const history = document.getElementById("history");
+    const pusherArea = document.querySelector(".pusher-area");
+
+    const horses = [
+      { id: 1, name: "サンダー" },
+      { id: 2, name: "ミルキー" },
+      { id: 3, name: "ブレイズ" },
+      { id: 4, name: "シャドウ" },
+      { id: 5, name: "スター" },
+    ];
+
+    let credits = 3;
+    let insertedCoins = 0;
+    let round = 0;
+    let raceInProgress = false;
+
+    const resetRacePositions = () => {
+      horses.forEach((horse) => {
+        const horseEl = document.getElementById(`horse-${horse.id}`);
+        horseEl.style.left = "8px";
+      });
+    };
+
+    const updateStatus = () => {
+      creditCount.textContent = credits;
+      coinCount.textContent = insertedCoins;
+      roundCount.textContent = round;
+      insertButton.disabled = credits <= 0 || raceInProgress;
+    };
+
+    const addHistory = (text) => {
+      const entry = document.createElement("div");
+      entry.textContent = text;
+      history.prepend(entry);
+    };
+
+    const createCoin = () => {
+      const coin = document.createElement("div");
+      coin.className = "coin";
+      coin.style.left = `${20 + Math.random() * 80}px`;
+      coin.style.top = `${20 + Math.random() * 20}px`;
+      pusherArea.appendChild(coin);
+      setTimeout(() => coin.remove(), 1600);
+    };
+
+    const startRace = () => {
+      raceInProgress = true;
+      updateStatus();
+      resultText.textContent = "レース中…";
+
+      const finishLine = document.querySelector(".lane").clientWidth - 60;
+      const positions = horses.map(() => 8);
+      const speeds = horses.map(() => 0);
+
+      const raceInterval = setInterval(() => {
+        horses.forEach((horse, index) => {
+          const boost = Math.random() * 6 + 2;
+          speeds[index] = Math.max(1, speeds[index] * 0.6 + boost);
+          positions[index] += speeds[index];
+          const horseEl = document.getElementById(`horse-${horse.id}`);
+          horseEl.style.left = `${Math.min(positions[index], finishLine)}px`;
+        });
+
+        const winnerIndex = positions.findIndex((pos) => pos >= finishLine);
+        if (winnerIndex !== -1) {
+          clearInterval(raceInterval);
+          const winner = horses[winnerIndex];
+          resultText.innerHTML = `${winner.name} <span class="badge">優勝</span>`;
+          addHistory(`Round ${round}: ${winner.name} 勝利`);
+          raceInProgress = false;
+          updateStatus();
+        }
+      }, 120);
+    };
+
+    insertButton.addEventListener("click", () => {
+      if (raceInProgress || credits <= 0) {
+        return;
+      }
+      credits -= 1;
+      insertedCoins += 1;
+      round += 1;
+      createCoin();
+      resetRacePositions();
+      updateStatus();
+      setTimeout(startRace, 500);
+    });
+
+    resetButton.addEventListener("click", () => {
+      credits = 3;
+      insertedCoins = 0;
+      round = 0;
+      history.textContent = "";
+      resultText.textContent = "準備中";
+      resetRacePositions();
+      updateStatus();
+    });
+
+    updateStatus();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a self-contained retro-styled coin pusher + horse racing mini-game implemented with only HTML/CSS/JavaScript.
- Create a playful cabinet UI that supports coin insertion, a pusher animation, a randomized race simulation, and result/history display.
- Keep the implementation single-file and dependency-free for easy embedding and testing.

### Description
- Add `index.html` which contains the full UI, CSS styling, and vanilla JS game logic in a single page.
- Implement coin insertion animation and credit/round tracking with `createCoin()`, `credits`, and UI bindings.
- Implement a simple race simulation driven by randomized speed boosts and DOM movement of horse elements, with winner detection and result history via `startRace()` and `addHistory()`.
- Include responsive layout and visual polish (cabinet frame, pusher animation, finish line badges) using CSS only.

### Testing
- Started a local static server with `python -m http.server 8000` to serve the page, which successfully started and served `index.html` during verification.
- Attempted automated UI validation via Playwright to load the page and capture a screenshot, but the Playwright runs failed (first attempt timed out and the subsequent attempt crashed the headless browser with a SIGSEGV), so the automated screenshot test did not succeed.
- No additional automated unit tests were added for this static HTML/CSS/JS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69866a4d14e48329a3c56b9a5e4eaa16)