### PR TITLE
Add iOS 17+ SwiftUI MVVM app structure with actor repository and required screens

### DIFF
--- a/App.swift
+++ b/App.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+@main
+struct LocalHistoryApp: App {
+    @StateObject private var container = AppContainer()
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .environmentObject(container)
+                .task {
+                    await container.bootstrap()
+                }
+        }
+    }
+}
+
+@MainActor
+final class AppContainer: ObservableObject {
+    let settings = SettingsStore()
+    let logger = LogStore()
+    let repository: HistoryRepository
+
+    @Published var appViewModel: AppViewModel?
+
+    init() {
+        repository = HistoryRepository()
+    }
+
+    func bootstrap() async {
+        if appViewModel != nil { return }
+        let vm = AppViewModel(repository: repository, logger: logger, settings: settings)
+        appViewModel = vm
+        await vm.initialize()
+    }
+}

--- a/Models.swift
+++ b/Models.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+enum Role: String, CaseIterable, Codable, Identifiable {
+    case developer
+    case readonly
+    case admin
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .developer: "Developer"
+        case .readonly: "Read Only"
+        case .admin: "Admin"
+        }
+    }
+}
+
+struct AccessContext: Codable, Equatable {
+    var role: Role
+    var editLock: Bool
+
+    var canEdit: Bool {
+        !editLock && role != .readonly
+    }
+}
+
+struct HistoryRecord: Identifiable, Codable, Hashable {
+    var id: UUID
+    var title: String
+    var notes: String
+    var amount: Double
+    var createdAt: Date
+    var updatedAt: Date
+
+    init(id: UUID = UUID(), title: String, notes: String, amount: Double, createdAt: Date = .now, updatedAt: Date = .now) {
+        self.id = id
+        self.title = title
+        self.notes = notes
+        self.amount = amount
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
+struct HistoryDraft {
+    var title: String = ""
+    var notes: String = ""
+    var amount: Double = 0
+
+    var canSubmit: Bool {
+        !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    func buildRecord() -> HistoryRecord {
+        HistoryRecord(title: title, notes: notes, amount: amount)
+    }
+}
+
+struct DebugConfig: Codable, Equatable {
+    var simulateError: Bool = false
+    var simulateDelay: Bool = false
+    var delayMilliseconds: Int = 700
+}
+
+struct LogEntry: Identifiable, Codable {
+    var id: UUID = UUID()
+    var timestamp: Date = .now
+    var level: String
+    var message: String
+}
+
+enum AppError: LocalizedError {
+    case updateForbidden
+    case simulated
+    case notFound
+
+    var errorDescription: String? {
+        switch self {
+        case .updateForbidden: "現在のRBAC設定では更新できません。"
+        case .simulated: "Debugの疑似エラーが有効です。"
+        case .notFound: "対象の履歴が見つかりません。"
+        }
+    }
+}

--- a/Repositories.swift
+++ b/Repositories.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+actor HistoryRepository {
+    private struct Storage: Codable {
+        var records: [HistoryRecord]
+    }
+
+    private let fileName = "history.json"
+    private let backupFileName = "history.backup.json"
+
+    private var debugConfig = DebugConfig()
+    private var records: [HistoryRecord] = []
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init() {
+        encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+
+        decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+    }
+
+    func setDebugConfig(_ config: DebugConfig) {
+        debugConfig = config
+    }
+
+    func load() async throws -> [HistoryRecord] {
+        try await applyDebugBehaviors()
+        if let data = try readData(fileName: fileName) {
+            records = try decodeRecords(data)
+            return records.sorted { $0.createdAt > $1.createdAt }
+        }
+
+        if let backupData = try readData(fileName: backupFileName) {
+            records = try decodeRecords(backupData)
+            try persistCurrentState()
+            return records.sorted { $0.createdAt > $1.createdAt }
+        }
+
+        records = []
+        return []
+    }
+
+    func add(_ record: HistoryRecord, access: AccessContext) async throws -> [HistoryRecord] {
+        try ensureWritable(access)
+        try await applyDebugBehaviors()
+        records.insert(record, at: 0)
+        try persistCurrentState()
+        return records
+    }
+
+    func update(_ record: HistoryRecord, access: AccessContext) async throws -> [HistoryRecord] {
+        try ensureWritable(access)
+        try await applyDebugBehaviors()
+        guard let index = records.firstIndex(where: { $0.id == record.id }) else {
+            throw AppError.notFound
+        }
+        var updated = record
+        updated.updatedAt = .now
+        records[index] = updated
+        try persistCurrentState()
+        return records
+    }
+
+    func delete(id: UUID, access: AccessContext) async throws -> [HistoryRecord] {
+        try ensureWritable(access)
+        try await applyDebugBehaviors()
+        records.removeAll { $0.id == id }
+        try persistCurrentState()
+        return records
+    }
+
+    private func ensureWritable(_ access: AccessContext) throws {
+        guard access.canEdit else { throw AppError.updateForbidden }
+    }
+
+    private func applyDebugBehaviors() async throws {
+        if debugConfig.simulateDelay {
+            let ns = UInt64(max(0, debugConfig.delayMilliseconds)) * 1_000_000
+            try await Task.sleep(nanoseconds: ns)
+        }
+        if debugConfig.simulateError {
+            throw AppError.simulated
+        }
+    }
+
+    private func decodeRecords(_ data: Data) throws -> [HistoryRecord] {
+        let storage = try decoder.decode(Storage.self, from: data)
+        return storage.records
+    }
+
+    private func persistCurrentState() throws {
+        let data = try encoder.encode(Storage(records: records))
+        let mainURL = try fileURL(fileName)
+        let backupURL = try fileURL(backupFileName)
+
+        if FileManager.default.fileExists(atPath: mainURL.path) {
+            if FileManager.default.fileExists(atPath: backupURL.path) {
+                try FileManager.default.removeItem(at: backupURL)
+            }
+            try FileManager.default.copyItem(at: mainURL, to: backupURL)
+        }
+
+        try data.write(to: mainURL, options: [.atomic])
+    }
+
+    private func fileURL(_ name: String) throws -> URL {
+        guard let dir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        return dir.appendingPathComponent(name)
+    }
+
+    private func readData(fileName: String) throws -> Data? {
+        let url = try fileURL(fileName)
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        return try Data(contentsOf: url)
+    }
+}
+
+actor LogStore {
+    private(set) var entries: [LogEntry] = []
+    private let maxCount = 500
+
+    func push(level: String = "INFO", _ message: String) {
+        entries.append(LogEntry(level: level, message: message))
+        if entries.count > maxCount {
+            entries.removeFirst(entries.count - maxCount)
+        }
+    }
+
+    func list() -> [LogEntry] {
+        entries.sorted { $0.timestamp > $1.timestamp }
+    }
+}

--- a/ViewModels.swift
+++ b/ViewModels.swift
@@ -1,0 +1,119 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class SettingsStore: ObservableObject {
+    @AppStorage("settings.role") var roleRawValue: String = Role.developer.rawValue
+    @AppStorage("settings.editLock") var editLock: Bool = false
+
+    @AppStorage("debug.simulateError") var simulateError: Bool = false
+    @AppStorage("debug.simulateDelay") var simulateDelay: Bool = false
+    @AppStorage("debug.delayMS") var delayMS: Int = 700
+
+    var role: Role {
+        get { Role(rawValue: roleRawValue) ?? .developer }
+        set { roleRawValue = newValue.rawValue }
+    }
+
+    var accessContext: AccessContext {
+        AccessContext(role: role, editLock: editLock)
+    }
+
+    var debugConfig: DebugConfig {
+        DebugConfig(simulateError: simulateError, simulateDelay: simulateDelay, delayMilliseconds: delayMS)
+    }
+}
+
+@MainActor
+final class AppViewModel: ObservableObject {
+    @Published var records: [HistoryRecord] = []
+    @Published var selectedRecordID: UUID?
+    @Published var homeDraft = HistoryDraft()
+    @Published var latestErrorMessage: String?
+    @Published var logs: [LogEntry] = []
+
+    let settings: SettingsStore
+
+    private let repository: HistoryRepository
+    private let logger: LogStore
+
+    init(repository: HistoryRepository, logger: LogStore, settings: SettingsStore) {
+        self.repository = repository
+        self.logger = logger
+        self.settings = settings
+    }
+
+    func initialize() async {
+        await syncDebugConfig()
+        await loadRecords()
+    }
+
+    func syncDebugConfig() async {
+        await repository.setDebugConfig(settings.debugConfig)
+        await logger.push("DEBUG", "DebugConfig updated: error=\(settings.simulateError), delay=\(settings.simulateDelay), ms=\(settings.delayMS)")
+        await refreshLogs()
+    }
+
+    func loadRecords() async {
+        do {
+            records = try await repository.load()
+            await logger.push("INFO", "Loaded records: \(records.count)")
+            await refreshLogs()
+            if selectedRecord == nil {
+                selectedRecordID = records.first?.id
+            }
+        } catch {
+            await present(error)
+        }
+    }
+
+    var selectedRecord: HistoryRecord? {
+        records.first { $0.id == selectedRecordID }
+    }
+
+    func createFromDraft() async {
+        guard homeDraft.canSubmit else { return }
+        do {
+            let created = homeDraft.buildRecord()
+            records = try await repository.add(created, access: settings.accessContext)
+            selectedRecordID = created.id
+            homeDraft = HistoryDraft()
+            await logger.push("INFO", "Created record: \(created.id)")
+            await refreshLogs()
+        } catch {
+            await present(error)
+        }
+    }
+
+    func update(record: HistoryRecord) async {
+        do {
+            records = try await repository.update(record, access: settings.accessContext)
+            await logger.push("INFO", "Updated record: \(record.id)")
+            await refreshLogs()
+        } catch {
+            await present(error)
+        }
+    }
+
+    func deleteSelected() async {
+        guard let id = selectedRecordID else { return }
+        do {
+            records = try await repository.delete(id: id, access: settings.accessContext)
+            selectedRecordID = records.first?.id
+            await logger.push("INFO", "Deleted record: \(id)")
+            await refreshLogs()
+        } catch {
+            await present(error)
+        }
+    }
+
+    func refreshLogs() async {
+        logs = await logger.list()
+    }
+
+    private func present(_ error: Error) async {
+        latestErrorMessage = error.localizedDescription
+        await logger.push("ERROR", error.localizedDescription)
+        await refreshLogs()
+    }
+}

--- a/Views/HistoryViews.swift
+++ b/Views/HistoryViews.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+
+struct HistoryListView: View {
+    @ObservedObject var viewModel: AppViewModel
+
+    var body: some View {
+        List(selection: $viewModel.selectedRecordID) {
+            ForEach(viewModel.records) { record in
+                NavigationLink(value: record.id) {
+                    VStack(alignment: .leading) {
+                        Text(record.title).font(.headline)
+                        Text(record.updatedAt, style: .date).font(.caption)
+                    }
+                }
+            }
+        }
+        .navigationTitle("History")
+        .toolbar {
+            Button(role: .destructive) {
+                Task { await viewModel.deleteSelected() }
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+        .navigationDestination(for: UUID.self) { id in
+            if let record = viewModel.records.first(where: { $0.id == id }) {
+                HistoryDetailView(viewModel: viewModel, record: record)
+            } else {
+                Text("Not found")
+            }
+        }
+    }
+}
+
+struct HistoryDetailView: View {
+    @ObservedObject var viewModel: AppViewModel
+    let record: HistoryRecord
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(record.title).font(.title2).bold()
+            Text(record.notes)
+            Text("金額: \(record.amount.formatted())")
+            Text("作成: \(record.createdAt.formatted(date: .abbreviated, time: .shortened))")
+            Text("更新: \(record.updatedAt.formatted(date: .abbreviated, time: .shortened))")
+            NavigationLink("編集") {
+                HistoryEditView(viewModel: viewModel, record: record)
+            }
+            .buttonStyle(.borderedProminent)
+            Spacer()
+        }
+        .padding()
+        .navigationTitle("Detail")
+    }
+}
+
+struct HistoryEditView: View {
+    @ObservedObject var viewModel: AppViewModel
+    @EnvironmentObject private var settings: SettingsStore
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var title: String
+    @State private var notes: String
+    @State private var amount: Double
+
+    private let baseRecord: HistoryRecord
+
+    init(viewModel: AppViewModel, record: HistoryRecord) {
+        self.viewModel = viewModel
+        self.baseRecord = record
+        _title = State(initialValue: record.title)
+        _notes = State(initialValue: record.notes)
+        _amount = State(initialValue: record.amount)
+    }
+
+    var body: some View {
+        Form {
+            Section("編集") {
+                TextField("タイトル", text: $title)
+                TextField("メモ", text: $notes)
+                TextField("金額", value: $amount, format: .number)
+            }
+
+            Section {
+                Button("更新") {
+                    let updated = HistoryRecord(
+                        id: baseRecord.id,
+                        title: title,
+                        notes: notes,
+                        amount: amount,
+                        createdAt: baseRecord.createdAt,
+                        updatedAt: .now
+                    )
+                    Task {
+                        await viewModel.update(record: updated)
+                        dismiss()
+                    }
+                }
+                .disabled(!settings.accessContext.canEdit)
+            }
+
+            if !settings.accessContext.canEdit {
+                Text("RBAC / editLock により更新が禁止されています。")
+                    .foregroundStyle(.red)
+            }
+        }
+        .navigationTitle("Edit")
+    }
+}

--- a/Views/HomeView.swift
+++ b/Views/HomeView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+struct HomeView: View {
+    @ObservedObject var viewModel: AppViewModel
+
+    var body: some View {
+        GeometryReader { proxy in
+            let twoColumns = proxy.size.width > 700
+            ScrollView {
+                if twoColumns {
+                    HStack(alignment: .top, spacing: 16) {
+                        formSection
+                            .frame(maxWidth: .infinity)
+                        previewSection
+                            .frame(maxWidth: .infinity)
+                    }
+                    .padding()
+                } else {
+                    VStack(spacing: 16) {
+                        formSection
+                        previewSection
+                    }
+                    .padding()
+                }
+            }
+            .navigationTitle("Home")
+        }
+    }
+
+    private var formSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("入力フォーム").font(.headline)
+            TextField("タイトル", text: $viewModel.homeDraft.title)
+                .textFieldStyle(.roundedBorder)
+            TextField("メモ", text: $viewModel.homeDraft.notes, axis: .vertical)
+                .textFieldStyle(.roundedBorder)
+                .lineLimit(3, reservesSpace: true)
+            HStack {
+                Text("金額")
+                TextField("0", value: $viewModel.homeDraft.amount, format: .number)
+                    .keyboardType(.decimalPad)
+                    .textFieldStyle(.roundedBorder)
+            }
+            Button("保存") {
+                Task { await viewModel.createFromDraft() }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(!viewModel.homeDraft.canSubmit)
+
+            if let message = viewModel.latestErrorMessage {
+                Text(message)
+                    .foregroundStyle(.red)
+                    .font(.caption)
+            }
+        }
+        .padding()
+        .background(.thinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+    }
+
+    private var previewSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("プレビュー").font(.headline)
+            Text("タイトル: \(viewModel.homeDraft.title)")
+            Text("メモ: \(viewModel.homeDraft.notes)")
+            Text("金額: \(viewModel.homeDraft.amount.formatted())")
+            Divider()
+            Text("現在件数: \(viewModel.records.count)")
+                .font(.caption)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(.thinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+    }
+}

--- a/Views/RootView.swift
+++ b/Views/RootView.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+struct RootView: View {
+    @EnvironmentObject private var container: AppContainer
+
+    var body: some View {
+        Group {
+            if let vm = container.appViewModel {
+                AdaptiveRootNavigation(viewModel: vm)
+                    .environmentObject(container.settings)
+            } else {
+                ProgressView("初期化中...")
+            }
+        }
+    }
+}
+
+private struct AdaptiveRootNavigation: View {
+    @ObservedObject var viewModel: AppViewModel
+
+    @State private var path = NavigationPath()
+
+    var body: some View {
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            NavigationSplitView {
+                SidebarView(viewModel: viewModel)
+            } detail: {
+                HomeView(viewModel: viewModel)
+            }
+        } else {
+            NavigationStack(path: $path) {
+                SidebarView(viewModel: viewModel)
+                    .navigationDestination(for: Destination.self) { destination in
+                        switch destination {
+                        case .home: HomeView(viewModel: viewModel)
+                        case .historyList: HistoryListView(viewModel: viewModel)
+                        case .settings: SettingsView(viewModel: viewModel)
+                        case .debug: DebugView(viewModel: viewModel)
+                        }
+                    }
+            }
+            .environment(\.navigate, { path.append($0) })
+        }
+    }
+}
+
+enum Destination: Hashable {
+    case home
+    case historyList
+    case settings
+    case debug
+}
+
+private struct NavigateKey: EnvironmentKey {
+    static let defaultValue: (Destination) -> Void = { _ in }
+}
+
+extension EnvironmentValues {
+    var navigate: (Destination) -> Void {
+        get { self[NavigateKey.self] }
+        set { self[NavigateKey.self] = newValue }
+    }
+}
+
+private struct SidebarView: View {
+    @Environment(\.navigate) private var navigate
+
+    @ObservedObject var viewModel: AppViewModel
+
+    var body: some View {
+        List {
+            NavigationLink("Home") { HomeView(viewModel: viewModel) }
+            NavigationLink("History") { HistoryListView(viewModel: viewModel) }
+            NavigationLink("Settings") { SettingsView(viewModel: viewModel) }
+            NavigationLink("Debug") { DebugView(viewModel: viewModel) }
+
+            if UIDevice.current.userInterfaceIdiom != .pad {
+                Button("Open Home") { navigate(.home) }
+                Button("Open History") { navigate(.historyList) }
+                Button("Open Settings") { navigate(.settings) }
+                Button("Open Debug") { navigate(.debug) }
+            }
+        }
+        .listStyle(.sidebar)
+        .navigationTitle("Menu")
+    }
+}

--- a/Views/SettingsDebugViews.swift
+++ b/Views/SettingsDebugViews.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @ObservedObject var viewModel: AppViewModel
+    @EnvironmentObject private var settings: SettingsStore
+
+    var body: some View {
+        Form {
+            Section("RBAC") {
+                Picker("Role", selection: $settings.roleRawValue) {
+                    ForEach(Role.allCases) { role in
+                        Text(role.displayName).tag(role.rawValue)
+                    }
+                }
+                .onChange(of: settings.roleRawValue) { _, _ in
+                    Task { await viewModel.syncDebugConfig() }
+                }
+
+                Toggle("editLock", isOn: $settings.editLock)
+            }
+
+            Section {
+                Text("編集可否: \(settings.accessContext.canEdit ? "可能" : "禁止")")
+            }
+        }
+        .navigationTitle("Settings")
+    }
+}
+
+struct DebugView: View {
+    @ObservedObject var viewModel: AppViewModel
+    @EnvironmentObject private var settings: SettingsStore
+
+    var body: some View {
+        VStack {
+            Form {
+                Section("疑似挙動") {
+                    Toggle("疑似エラー", isOn: $settings.simulateError)
+                    Toggle("疑似遅延", isOn: $settings.simulateDelay)
+                    Stepper("遅延(ms): \(settings.delayMS)", value: $settings.delayMS, in: 0...5000, step: 100)
+                }
+                .onChange(of: settings.simulateError) { _, _ in
+                    Task { await viewModel.syncDebugConfig() }
+                }
+                .onChange(of: settings.simulateDelay) { _, _ in
+                    Task { await viewModel.syncDebugConfig() }
+                }
+                .onChange(of: settings.delayMS) { _, _ in
+                    Task { await viewModel.syncDebugConfig() }
+                }
+
+                Section("ログ (最大500)") {
+                    ForEach(viewModel.logs) { log in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("[\(log.level)] \(log.timestamp.formatted(date: .omitted, time: .standard))")
+                                .font(.caption)
+                            Text(log.message)
+                                .font(.caption2)
+                        }
+                    }
+                }
+            }
+        }
+        .task { await viewModel.refreshLogs() }
+        .navigationTitle("Debug")
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a complete, ready-to-paste SwiftUI app scaffold targeting iOS 17+/iPadOS 17+ that follows MVVM + `Repository(actor)` and implements the requested screens and behaviors. 
- Support local JSON persistence with backup/restore, RBAC (developer/readonly/admin) plus `editLock`, and a debug surface for simulated errors/delays. 
- Keep a lightweight, testable code layout so the sources can be dropped into an Xcode project and iterated on quickly.

### Description
- Added application entry and DI container in `App.swift` and a settings/log/repository surface in `ViewModels.swift` and `Repositories.swift`. 
- Implemented models in `Models.swift` including `Role`, `AccessContext`, `HistoryRecord`, `DebugConfig`, `LogEntry`, and `AppError`. 
- Implemented `HistoryRepository` as an `actor` with JSON persistence to device documents, backup-file restore, atomic write + backup rotation, RBAC checks (`ensureWritable`), and debug behaviors (`simulateError`/`simulateDelay`). 
- Implemented `LogStore` with max-500 rotation, `SettingsStore` using `@AppStorage`, `AppViewModel` for MVVM operations, and views `Views/RootView.swift`, `Views/HomeView.swift`, `Views/HistoryViews.swift`, and `Views/SettingsDebugViews.swift` including adaptive navigation (`NavigationSplitView` on iPad, `NavigationStack` on iPhone) and Home 1-/2-column layout switching by width.

### Testing
- Inspected and committed the new files using `git status --short` and a local commit, and created the PR metadata; the commit exists at `4a9570c`. 
- Printed file contents with `nl` to verify source generation and presence of all created files, which completed successfully. 
- Attempted to run `xcodebuild -version` to verify a build environment but it failed with `command not found` because Xcode is not available in this container, so no iOS build was performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984326278a4832992384d79ac72ad5e)