### PR TITLE
Add inline log viewer for TeraTerm and tcpdump -x (vanilla HTML/JS/CSS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,64 @@
-# mock-private
-private mockup
+# 組み込み向けトレーサビリティWebモック
+
+バニラ HTML/CSS/JavaScript だけで動作する、オフライン向けの簡易トレーサビリティビューアです。localStorage と JSON で状態を保持し、抜粋ログを貼り付けて証跡として閲覧できます。
+
+## 特徴
+- **TeraTerm（時刻付きログ）**と**tcpdump -x（hexのみダンプ）**の inline 表示に対応
+- localStorage 保存 / JSON import/export 互換
+- 検索（部分一致）・該当行のみ表示・ハイライト・異常ワード抽出
+- 大規模ログ対策（先頭100行表示 + 全文表示切り替え）
+
+## 前提フォーマット
+### TeraTermログ（時刻あり）
+```
+[2026-02-07 13:21:01.123] UART RX: 0x02 0x10 0x00 0x01
+[2026-02-07 13:21:01.125] UART TX: ACK
+[2026-02-07 13:21:02.004] ERROR: timeout waiting response
+```
+
+### tcpdump -x（hexのみ）
+```
+14:32:01.123456 IP 192.168.0.10.5000 > 192.168.0.20.502: UDP, length 32
+        0x0000:  4500 003c 1c46 4000 4011 b861 c0a8 000a
+        0x0010:  c0a8 0014 1388 01f6 0028 0000 0210 0001
+```
+
+> **注意**: 本ツールは **tcpdump -x のhexダンプのみ**を対象とします。ASCII列（`-X` など）は扱いません。
+
+## 使い方
+1. `index.html` をブラウザで開く（オフライン動作）
+2. 左側で Step を選択
+3. 証跡をクリックしてログビューを表示
+4. 上部の検索や「異常ワード抽出」で絞り込み
+
+## 抜粋貼付方式（実機ログからの例）
+ローカルファイル自動読込は必須にせず、**抜粋貼付方式**で利用します。
+
+### TeraTerm 例
+```bash
+# 例: UART関連だけ抜粋して貼り付け
+grep -E 'UART|ERROR|RETRY|timeout' teraterm.log
+```
+
+### tcpdump 例
+```bash
+# 例: UDP 502番ポートのhexダンプを取得
+sudo tcpdump -i eth0 -x udp port 502
+```
+
+## データモデル拡張（evidences）
+```json
+{
+  "contentMode": "inline",
+  "inlineText": "...",
+  "format": "teraterm",
+  "tool": "TeraTerm",
+  "extractionHint": "grep -E 'UART|ERROR'"
+}
+```
+
+## ファイル構成
+- `index.html`
+- `styles.css`
+- `app.js`
+- `sample_data.json`

--- a/app.js
+++ b/app.js
@@ -1,0 +1,394 @@
+const STORAGE_KEY = "traceabilityMockData";
+const WARNING_SIZE = 200000;
+const PREVIEW_LINES = 100;
+const ABNORMAL_WORDS = ["timeout", "retrans", "error", "crc", "drop"];
+
+const state = {
+  data: null,
+  selectedStepId: null,
+  selectedEvidenceId: null,
+  searchText: "",
+  searchOnly: false,
+  showAllLines: false,
+  abnormalMode: false,
+};
+
+const elements = {
+  stepsList: document.getElementById("stepsList"),
+  evidenceList: document.getElementById("evidenceList"),
+  stepTitle: document.getElementById("stepTitle"),
+  stepDescription: document.getElementById("stepDescription"),
+  viewerMeta: document.getElementById("viewerMeta"),
+  logContainer: document.getElementById("logContainer"),
+  viewerFooter: document.getElementById("viewerFooter"),
+  searchInput: document.getElementById("searchInput"),
+  searchOnly: document.getElementById("searchOnly"),
+  toggleAllLines: document.getElementById("toggleAllLines"),
+  tcpdumpHeader: document.getElementById("tcpdumpHeader"),
+  storageStatus: document.getElementById("storageStatus"),
+  storageWarning: document.getElementById("storageWarning"),
+};
+
+function escapeHtml(text) {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+function highlightText(text, terms) {
+  if (!terms || terms.length === 0) {
+    return text;
+  }
+  const termList = Array.isArray(terms) ? terms : [terms];
+  const escapedTerms = termList.map((term) =>
+    term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  );
+  const regex = new RegExp(escapedTerms.join("|"), "gi");
+  return text.replace(regex, (match) => `<mark>${match}</mark>`);
+}
+
+function formatTeraTerm(line, searchTerms) {
+  let html = escapeHtml(line);
+  html = highlightText(html, searchTerms);
+  html = html.replace(/^(\[[^\]]+\])/, "<strong>$1</strong>");
+  html = html.replace(/\bERROR\b/gi, '<span class="severity">$&</span>');
+  html = html.replace(/\bWARN\b/gi, '<span class="warn">$&</span>');
+  html = html.replace(/\bRETRY\b/gi, '<span class="retry">$&</span>');
+  return html;
+}
+
+function formatTcpdump(line, searchTerms) {
+  let html = escapeHtml(line);
+  html = highlightText(html, searchTerms);
+  html = html.replace(/^(\s*0x[0-9a-fA-F]+:)/, '<span class="offset">$1</span>');
+  return html;
+}
+
+function parseTcpdumpHeader(lines) {
+  const headerIndex = lines.findIndex((line) => line.trim().length > 0);
+  const header = headerIndex >= 0 ? lines[headerIndex] : "";
+  if (!header) {
+    return { headerLine: "", length: null, headerIndex: -1 };
+  }
+  const lengthMatch = header.match(/length\s+(\d+)/i);
+  return {
+    headerLine: header,
+    length: lengthMatch ? lengthMatch[1] : null,
+    headerIndex,
+  };
+}
+
+function getSelectedStep() {
+  return state.data?.steps?.find((step) => step.id === state.selectedStepId) || null;
+}
+
+function getSelectedEvidence() {
+  const step = getSelectedStep();
+  return step?.evidences?.find((ev) => ev.id === state.selectedEvidenceId) || null;
+}
+
+function updateStorageStatus(saved) {
+  elements.storageStatus.textContent = saved
+    ? "localStorage: 保存済み"
+    : "localStorage: 未保存";
+}
+
+function saveToStorage() {
+  if (!state.data) {
+    return;
+  }
+  const payload = JSON.stringify(state.data);
+  localStorage.setItem(STORAGE_KEY, payload);
+  updateStorageStatus(true);
+  elements.storageWarning.classList.toggle("hidden", payload.length <= WARNING_SIZE);
+}
+
+function loadFromStorage() {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (!stored) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(stored);
+    updateStorageStatus(true);
+    return parsed;
+  } catch (error) {
+    console.error("Failed to parse storage", error);
+    return null;
+  }
+}
+
+async function loadSampleData() {
+  const response = await fetch("sample_data.json");
+  const data = await response.json();
+  state.data = data;
+  state.selectedStepId = data.steps?.[0]?.id || null;
+  state.selectedEvidenceId = data.steps?.[0]?.evidences?.[0]?.id || null;
+  saveToStorage();
+  renderAll();
+}
+
+function setData(data) {
+  state.data = data;
+  state.selectedStepId = data.steps?.[0]?.id || null;
+  state.selectedEvidenceId = data.steps?.[0]?.evidences?.[0]?.id || null;
+  saveToStorage();
+  renderAll();
+}
+
+function renderSteps() {
+  elements.stepsList.innerHTML = "";
+  if (!state.data?.steps) {
+    return;
+  }
+  state.data.steps.forEach((step) => {
+    const item = document.createElement("li");
+    item.textContent = step.title;
+    item.classList.toggle("active", step.id === state.selectedStepId);
+    item.addEventListener("click", () => {
+      state.selectedStepId = step.id;
+      state.selectedEvidenceId = step.evidences?.[0]?.id || null;
+      renderAll();
+    });
+    elements.stepsList.appendChild(item);
+  });
+}
+
+function renderStepDetails() {
+  const step = getSelectedStep();
+  if (!step) {
+    elements.stepTitle.textContent = "Step";
+    elements.stepDescription.textContent = "Stepを選択してください。";
+    elements.evidenceList.innerHTML = "";
+    return;
+  }
+  elements.stepTitle.textContent = step.title;
+  elements.stepDescription.textContent = step.description || "";
+  elements.evidenceList.innerHTML = "";
+  step.evidences?.forEach((ev) => {
+    const item = document.createElement("li");
+    item.innerHTML = `<strong>${ev.name}</strong><br><span class="muted">${ev.format} / ${ev.tool}</span>`;
+    item.classList.toggle("active", ev.id === state.selectedEvidenceId);
+    item.addEventListener("click", () => {
+      state.selectedEvidenceId = ev.id;
+      renderViewer();
+      renderStepDetails();
+    });
+    elements.evidenceList.appendChild(item);
+  });
+}
+
+function renderViewerMeta(evidence) {
+  if (!evidence) {
+    elements.viewerMeta.innerHTML = "";
+    return;
+  }
+  const lines = [
+    `type: ${evidence.type || "log"}`,
+    `contentMode: ${evidence.contentMode || "-"}`,
+    `format: ${evidence.format}`,
+    `tool: ${evidence.tool}`,
+    `relativePath: ${evidence.relativePath || "(inline)"}`,
+    `createdAt: ${evidence.createdAt || "-"}`,
+    `extractionHint: ${evidence.extractionHint || "-"}`,
+  ];
+  elements.viewerMeta.innerHTML = lines.map((line) => `<div>${escapeHtml(line)}</div>`).join("");
+}
+
+function filterLines(lines, searchTerms, onlyMatches) {
+  if (!searchTerms || searchTerms.length === 0) {
+    return lines;
+  }
+  const termList = Array.isArray(searchTerms) ? searchTerms : [searchTerms];
+  const normalized = termList.map((term) => term.toLowerCase());
+  if (!onlyMatches) {
+    return lines;
+  }
+  return lines.filter((line) =>
+    normalized.some((term) => line.toLowerCase().includes(term))
+  );
+}
+
+function renderLogLines(lines, evidence, searchTerms) {
+  elements.logContainer.innerHTML = "";
+  if (!lines.length) {
+    elements.logContainer.textContent = "ログがありません。";
+    return;
+  }
+
+  const formatLine = evidence.format === "teraterm" ? formatTeraTerm : formatTcpdump;
+  lines.forEach((line, index) => {
+    const lineEl = document.createElement("div");
+    lineEl.className = "log-line";
+    const numberEl = document.createElement("div");
+    numberEl.className = "line-number";
+    numberEl.textContent = String(index + 1).padStart(3, "0");
+    const contentEl = document.createElement("div");
+    contentEl.className = "log-content";
+    contentEl.innerHTML = formatLine(line, searchTerms);
+    lineEl.appendChild(numberEl);
+    lineEl.appendChild(contentEl);
+    elements.logContainer.appendChild(lineEl);
+  });
+}
+
+function renderViewerFooter(lines, totalLines) {
+  if (totalLines > lines.length) {
+    elements.viewerFooter.textContent = `表示中: ${lines.length} / ${totalLines} 行`;
+  } else {
+    elements.viewerFooter.textContent = `表示中: ${lines.length} 行`;
+  }
+}
+
+function renderTcpdumpHeader(lines) {
+  const { headerLine, length } = parseTcpdumpHeader(lines);
+  if (!headerLine) {
+    elements.tcpdumpHeader.classList.add("hidden");
+    elements.tcpdumpHeader.textContent = "";
+    return;
+  }
+  const lengthInfo = length ? `Length: ${length} bytes` : "Length: (unknown)";
+  elements.tcpdumpHeader.textContent = `${headerLine}\n${lengthInfo}`;
+  elements.tcpdumpHeader.classList.remove("hidden");
+}
+
+function renderViewer() {
+  const evidence = getSelectedEvidence();
+  renderViewerMeta(evidence);
+  elements.tcpdumpHeader.classList.add("hidden");
+  elements.toggleAllLines.classList.add("hidden");
+
+  if (!evidence) {
+    elements.logContainer.textContent = "証跡を選択してください。";
+    elements.viewerFooter.textContent = "";
+    return;
+  }
+
+  const inlineText = evidence.inlineText || "";
+  const allLines = inlineText.split(/\r?\n/);
+  const searchTerms = state.abnormalMode
+    ? ABNORMAL_WORDS
+    : state.searchText.trim()
+    ? [state.searchText.trim()]
+    : [];
+  const filteredLines = filterLines(allLines, searchTerms, state.searchOnly);
+  let linesToRender = filteredLines;
+  let renderLines = linesToRender;
+  let totalLines = filteredLines.length;
+
+  if (!state.showAllLines && filteredLines.length > PREVIEW_LINES) {
+    linesToRender = filteredLines.slice(0, PREVIEW_LINES);
+    elements.toggleAllLines.classList.remove("hidden");
+  }
+
+  elements.toggleAllLines.textContent = state.showAllLines ? "先頭100行" : "全文表示";
+
+  if (evidence.format === "tcpdump_x") {
+    const { headerLine } = parseTcpdumpHeader(allLines);
+    renderTcpdumpHeader(allLines);
+    let removed = false;
+    renderLines = linesToRender.filter((line) => {
+      if (!removed && line === headerLine) {
+        removed = true;
+        return false;
+      }
+      return true;
+    });
+    if (removed) {
+      totalLines = Math.max(totalLines - 1, 0);
+    }
+  }
+
+  renderLogLines(renderLines, evidence, searchTerms);
+  renderViewerFooter(renderLines, totalLines);
+}
+
+function renderAll() {
+  renderSteps();
+  renderStepDetails();
+  renderViewer();
+}
+
+function applyAbnormalExtract() {
+  const evidence = getSelectedEvidence();
+  if (!evidence) {
+    return;
+  }
+  state.searchText = "";
+  elements.searchInput.value = "";
+  state.abnormalMode = true;
+  state.searchOnly = true;
+  elements.searchOnly.checked = true;
+  renderViewer();
+}
+
+function setupEventListeners() {
+  document.getElementById("exportJson").addEventListener("click", () => {
+    if (!state.data) {
+      return;
+    }
+    const blob = new Blob([JSON.stringify(state.data, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "traceability_data.json";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  });
+
+  document.getElementById("importJson").addEventListener("change", async (event) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+    const text = await file.text();
+    try {
+      const parsed = JSON.parse(text);
+      setData(parsed);
+    } catch (error) {
+      alert("JSONの読み込みに失敗しました。");
+      console.error(error);
+    }
+  });
+
+  document.getElementById("resetSample").addEventListener("click", () => {
+    loadSampleData();
+  });
+
+  elements.searchInput.addEventListener("input", (event) => {
+    state.searchText = event.target.value;
+    state.abnormalMode = false;
+    renderViewer();
+  });
+
+  elements.searchOnly.addEventListener("change", (event) => {
+    state.searchOnly = event.target.checked;
+    renderViewer();
+  });
+
+  elements.toggleAllLines.addEventListener("click", () => {
+    state.showAllLines = !state.showAllLines;
+    renderViewer();
+  });
+
+  document.getElementById("abnormalExtract").addEventListener("click", () => {
+    applyAbnormalExtract();
+  });
+}
+
+async function init() {
+  const stored = loadFromStorage();
+  if (stored) {
+    setData(stored);
+  } else {
+    await loadSampleData();
+  }
+  setupEventListeners();
+}
+
+init();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>組み込み向けトレーサビリティWebモック</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="app-header">
+    <div>
+      <h1>組み込み向けトレーサビリティWebモック</h1>
+      <p class="subtitle">オフライン / localStorage 対応</p>
+    </div>
+    <div class="header-actions">
+      <button id="exportJson">JSONエクスポート</button>
+      <label class="file-button">
+        JSONインポート
+        <input type="file" id="importJson" accept="application/json" />
+      </label>
+      <button id="resetSample">サンプル読込</button>
+    </div>
+  </header>
+
+  <section class="status-bar">
+    <span id="storageStatus">localStorage: 未保存</span>
+    <span id="storageWarning" class="warning hidden">inlineText が大きいため localStorage へ保存できない可能性があります。</span>
+  </section>
+
+  <main class="layout">
+    <aside class="steps-panel">
+      <h2>Design詳細</h2>
+      <ul id="stepsList" class="steps-list"></ul>
+    </aside>
+
+    <section class="details-panel">
+      <div class="details-header">
+        <h2 id="stepTitle">Step</h2>
+        <p id="stepDescription" class="muted">Stepを選択してください。</p>
+      </div>
+      <div class="evidence-panel">
+        <h3>証跡</h3>
+        <ul id="evidenceList" class="evidence-list"></ul>
+      </div>
+    </section>
+
+    <section class="viewer-panel">
+      <div class="viewer-header">
+        <h2>ログビュー</h2>
+        <div class="viewer-meta" id="viewerMeta"></div>
+      </div>
+      <div class="viewer-toolbar">
+        <input type="text" id="searchInput" placeholder="検索 (部分一致)" />
+        <label class="toggle">
+          <input type="checkbox" id="searchOnly" />
+          該当行のみ表示
+        </label>
+        <button id="abnormalExtract">異常ワード抽出</button>
+        <button id="toggleAllLines">全文表示</button>
+      </div>
+      <div id="tcpdumpHeader" class="tcpdump-header hidden"></div>
+      <div class="log-container" id="logContainer"></div>
+      <div class="viewer-footer" id="viewerFooter"></div>
+    </section>
+  </main>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/sample_data.json
+++ b/sample_data.json
@@ -1,0 +1,46 @@
+{
+  "project": "Embedded Traceability Mock",
+  "updatedAt": "2026-02-07T13:30:00+09:00",
+  "steps": [
+    {
+      "id": "step-01",
+      "title": "UART通信 Failケース",
+      "description": "UARTの送受信でtimeoutとRETRYが発生したケース",
+      "designDetail": "UART RX/TX制御とACK待ち",
+      "evidences": [
+        {
+          "id": "ev-tt-01",
+          "name": "TeraTerm UARTログ",
+          "type": "log",
+          "format": "teraterm",
+          "tool": "TeraTerm",
+          "contentMode": "inline",
+          "relativePath": "logs/uart_fail.log",
+          "createdAt": "2026-02-07T13:21:02+09:00",
+          "extractionHint": "grep -E 'UART|ERROR|RETRY|timeout'",
+          "inlineText": "[2026-02-07 13:21:01.123] UART RX: 0x02 0x10 0x00 0x01\n[2026-02-07 13:21:01.125] UART TX: ACK\n[2026-02-07 13:21:01.450] UART RX: 0x02 0x10 0x00 0x02\n[2026-02-07 13:21:01.998] WARN: frame gap exceeded\n[2026-02-07 13:21:02.004] ERROR: timeout waiting response\n[2026-02-07 13:21:02.110] RETRY: count=1\n[2026-02-07 13:21:02.312] UART TX: 0x06 0x01 0x00 0x01\n[2026-02-07 13:21:02.789] ERROR: CRC mismatch\n[2026-02-07 13:21:03.102] RETRY: count=2\n[2026-02-07 13:21:03.450] UART RX: 0x02 0x10 0x00 0x01\n[2026-02-07 13:21:03.980] UART TX: ACK\n[2026-02-07 13:21:04.201] INFO: session recovered"
+        }
+      ]
+    },
+    {
+      "id": "step-02",
+      "title": "UDP通信 受信確認",
+      "description": "tcpdump -x のhexのみダンプでUDP payloadを確認",
+      "designDetail": "UDP通信とペイロード検証",
+      "evidences": [
+        {
+          "id": "ev-tcp-01",
+          "name": "tcpdump -x ダンプ",
+          "type": "log",
+          "format": "tcpdump_x",
+          "tool": "tcpdump",
+          "contentMode": "inline",
+          "relativePath": "logs/udp_dump.log",
+          "createdAt": "2026-02-07T14:32:02+09:00",
+          "extractionHint": "tcpdump -i eth0 -x udp port 502",
+          "inlineText": "14:32:01.123456 IP 192.168.0.10.5000 > 192.168.0.20.502: UDP, length 32\n        0x0000:  4500 003c 1c46 4000 4011 b861 c0a8 000a\n        0x0010:  c0a8 0014 1388 01f6 0028 0000 0210 0001\n        0x0020:  0000 0000 0000 0000\n14:32:02.004321 IP 192.168.0.10.5000 > 192.168.0.20.502: UDP, length 32\n        0x0000:  4500 003c 1c47 4000 4011 b860 c0a8 000a\n        0x0010:  c0a8 0014 1388 01f6 0028 0000 0210 0002\n        0x0020:  0000 0000 0000 0000"
+        }
+      ]
+    }
+  ]
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,254 @@
+:root {
+  color-scheme: light;
+  --bg: #f4f6f8;
+  --panel: #ffffff;
+  --border: #d9dee5;
+  --accent: #1e6bd6;
+  --danger: #c0392b;
+  --warning: #d35400;
+  --muted: #6b778c;
+  --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Meiryo", sans-serif;
+  background: var(--bg);
+  color: #1a1f2b;
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 24px;
+  background: var(--panel);
+  border-bottom: 1px solid var(--border);
+}
+
+.subtitle {
+  margin: 4px 0 0;
+  color: var(--muted);
+}
+
+.header-actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+button,
+.file-button {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 8px 14px;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+button.secondary {
+  background: #5c6f82;
+}
+
+.file-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.file-button input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.status-bar {
+  display: flex;
+  gap: 16px;
+  padding: 8px 24px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.warning {
+  color: var(--warning);
+  font-weight: 600;
+}
+
+.hidden {
+  display: none;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 240px 320px 1fr;
+  gap: 16px;
+  padding: 16px 24px 24px;
+}
+
+.steps-panel,
+.details-panel,
+.viewer-panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px;
+  min-height: 70vh;
+}
+
+.steps-list,
+.evidence-list {
+  list-style: none;
+  padding: 0;
+  margin: 12px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.steps-list li,
+.evidence-list li {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  cursor: pointer;
+}
+
+.steps-list li.active,
+.evidence-list li.active {
+  border-color: var(--accent);
+  background: #eef4ff;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.viewer-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.viewer-meta {
+  font-size: 12px;
+  color: var(--muted);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  text-align: right;
+}
+
+.viewer-toolbar {
+  margin: 12px 0;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.viewer-toolbar input[type="text"] {
+  flex: 1;
+  min-width: 180px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+}
+
+.toggle {
+  font-size: 13px;
+  color: var(--muted);
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.tcpdump-header {
+  background: #f8f8f8;
+  border: 1px dashed var(--border);
+  padding: 8px 12px;
+  font-family: var(--mono);
+  font-size: 13px;
+  margin-bottom: 8px;
+}
+
+.log-container {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: #111827;
+  color: #e5e7eb;
+  padding: 12px;
+  max-height: 52vh;
+  overflow: auto;
+  font-family: var(--mono);
+  font-size: 13px;
+}
+
+.log-line {
+  display: grid;
+  grid-template-columns: 46px 1fr;
+  gap: 12px;
+  padding: 2px 0;
+}
+
+.line-number {
+  color: #9ca3af;
+  text-align: right;
+  user-select: none;
+}
+
+.log-content strong {
+  color: #93c5fd;
+}
+
+.log-content .severity {
+  color: #f87171;
+  font-weight: 700;
+}
+
+.log-content .warn {
+  color: #fbbf24;
+  font-weight: 700;
+}
+
+.log-content .retry {
+  color: #60a5fa;
+  font-weight: 700;
+}
+
+.log-content .offset {
+  color: #34d399;
+  font-weight: 600;
+}
+
+.viewer-footer {
+  margin-top: 10px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+mark {
+  background: #fde047;
+  color: #111827;
+}
+
+@media (max-width: 1200px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .steps-panel,
+  .details-panel,
+  .viewer-panel {
+    min-height: auto;
+  }
+}


### PR DESCRIPTION
### Motivation
- Extend the existing offline traceability mock to display base↔UI communication traces inline for TeraTerm (timestamped) and tcpdump -x (hex-only) formats.  
- Meet strict constraints: vanilla HTML/CSS/JS only, no build tools or external CDNs, offline operation, and preserve localStorage + JSON import/export compatibility.  
- Provide lightweight regex-based parsing and UX features tailored to embedded troubleshooting (search, abnormal-word extraction, tcpdump length extraction, and large-log handling).  

### Description
- Added UI and assets: `index.html`, `styles.css`, `app.js`, `sample_data.json`, and updated `README.md`.  
- Data model extension: `evidences` may include `contentMode`, `inlineText`, `format` (`teraterm` | `tcpdump_x`), `tool`, and `extractionHint`, and these meta fields are shown in the viewer.  
- Implemented log viewer behaviors in `app.js`: regex-based parsing/formatting for `teraterm` (bold timestamps, highlighted ERROR/WARN/RETRY, hex preserved) and `tcpdump_x` (separate header line, extract `length` via regex, offset highlighting while preserving 16-byte boundaries).  
- UX features: monospace log area with line numbers, scrollable region, text search (partial match), "該当行のみ表示" toggle, highlight (`<mark>`), "異常ワード抽出" button (searches for timeout/retrans/error/CRC/drop), preview first 100 lines with "全文表示" toggle, and localStorage save with size warning when `inlineText` is large.  
- Maintains offline and paste-based workflow: sample data is stored inline in `sample_data.json`, import/export via JSON keeps compatibility, and local file auto-load is not required.  

### Testing
- Started a local static server with `python -m http.server 8000` and it started successfully.  
- Launched a Playwright script to load `http://127.0.0.1:8000/index.html` and captured a full-page screenshot, which completed successfully and produced an artifact.  
- Verified files were created and committed (`index.html`, `styles.css`, `app.js`, `sample_data.json`, `README.md`); automated checks above succeeded with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69872fb7c50c8329b1801d713307177e)