### PR TITLE
Add Pose Master v0.1 vanilla JS rhythm-combo prototype

### DIFF
--- a/pose-master/data.js
+++ b/pose-master/data.js
@@ -1,0 +1,45 @@
+const DEFAULT_FILES = {
+  poses: './poses.json',
+  rules: './rules.json'
+};
+
+async function fetchJson(path) {
+  const response = await fetch(path, { cache: 'no-store' });
+  if (!response.ok) {
+    throw new Error(`Failed to load ${path}: ${response.status}`);
+  }
+  return response.json();
+}
+
+function validateData(posesData, rulesData) {
+  if (!Array.isArray(posesData?.poses) || posesData.poses.length === 0) {
+    throw new Error('poses.json must contain a non-empty poses array.');
+  }
+
+  const poseMap = new Map();
+  for (const pose of posesData.poses) {
+    if (!pose.id || !pose.name || typeof pose.basePoint !== 'number' || !pose.lane) {
+      throw new Error('Each pose requires id, name, basePoint, and lane.');
+    }
+    poseMap.set(pose.id, pose);
+  }
+
+  if (typeof rulesData?.duration !== 'number' || typeof rulesData?.noteCount !== 'number') {
+    throw new Error('rules.json must provide numeric duration and noteCount.');
+  }
+
+  return {
+    poses: posesData.poses,
+    poseById: poseMap,
+    rules: rulesData
+  };
+}
+
+export async function loadGameConfig(paths = DEFAULT_FILES) {
+  const [posesData, rulesData] = await Promise.all([
+    fetchJson(paths.poses),
+    fetchJson(paths.rules)
+  ]);
+
+  return validateData(posesData, rulesData);
+}

--- a/pose-master/game.js
+++ b/pose-master/game.js
@@ -1,0 +1,351 @@
+import { createScoringSystem } from './scoring.js';
+
+const KEY_BINDINGS = {
+  a: 'A',
+  s: 'B',
+  d: 'C',
+  f: 'D',
+  ' ': 'S'
+};
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function randomFrom(array) {
+  return array[Math.floor(Math.random() * array.length)];
+}
+
+function createNoteChart(poses, rules) {
+  const notes = [];
+  const startOffsetMs = 1600;
+  const playDurationMs = rules.duration * 1000;
+  const gapMs = (playDurationMs - startOffsetMs) / Math.max(rules.noteCount, 1);
+
+  for (let i = 0; i < rules.noteCount; i += 1) {
+    const pose = randomFrom(poses);
+    notes.push({
+      id: `note-${i}`,
+      poseId: pose.id,
+      lane: pose.lane,
+      timeMs: startOffsetMs + i * gapMs,
+      hit: false,
+      judged: false
+    });
+  }
+
+  return notes;
+}
+
+export class PoseMasterGame {
+  constructor({ root, config }) {
+    this.root = root;
+    this.config = config;
+    this.scoring = createScoringSystem(config.rules);
+
+    this.state = {
+      running: false,
+      startTs: 0,
+      nowMs: 0,
+      score: 0,
+      combo: 0,
+      maxCombo: 0,
+      fxLevel: 0,
+      streak: [],
+      lastInputId: null,
+      judgments: { perfect: 0, great: 0, good: 0, miss: 0 },
+      notes: [],
+      currentIndex: 0,
+      finalBonusAwarded: false
+    };
+
+    this.rafId = null;
+
+    this.cacheDom();
+    this.bindEvents();
+    this.reset();
+  }
+
+  cacheDom() {
+    this.dom = {
+      startButton: this.root.querySelector('[data-role="start"]'),
+      timer: this.root.querySelector('[data-role="timer"]'),
+      score: this.root.querySelector('[data-role="score"]'),
+      combo: this.root.querySelector('[data-role="combo"]'),
+      maxCombo: this.root.querySelector('[data-role="max-combo"]'),
+      fxLabel: this.root.querySelector('[data-role="fx-level"]'),
+      judge: this.root.querySelector('[data-role="judge"]'),
+      laneTrack: this.root.querySelector('[data-role="lane-track"]'),
+      notesLayer: this.root.querySelector('[data-role="notes"]'),
+      poseButtons: Array.from(this.root.querySelectorAll('[data-pose-id]')),
+      summary: this.root.querySelector('[data-role="summary"]')
+    };
+  }
+
+  bindEvents() {
+    this.dom.startButton.addEventListener('click', () => {
+      if (this.state.running) {
+        this.reset();
+      }
+      this.start();
+    });
+
+    this.dom.poseButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        this.handleInput(button.dataset.poseId);
+      });
+    });
+
+    window.addEventListener('keydown', (event) => {
+      const key = event.key.toLowerCase();
+      const mapped = KEY_BINDINGS[key];
+      if (!mapped) {
+        return;
+      }
+      event.preventDefault();
+      this.handleInput(mapped);
+    });
+  }
+
+  reset() {
+    cancelAnimationFrame(this.rafId);
+
+    this.state.running = false;
+    this.state.startTs = 0;
+    this.state.nowMs = 0;
+    this.state.score = 0;
+    this.state.combo = 0;
+    this.state.maxCombo = 0;
+    this.state.fxLevel = 0;
+    this.state.lastInputId = null;
+    this.state.currentIndex = 0;
+    this.state.finalBonusAwarded = false;
+    this.state.judgments = { perfect: 0, great: 0, good: 0, miss: 0 };
+    this.state.notes = createNoteChart(this.config.poses, this.config.rules);
+
+    this.renderNotes();
+    this.renderHud('READY');
+    this.setSummary('Press START to begin.');
+    this.dom.startButton.textContent = 'START';
+    this.root.classList.remove('is-running');
+  }
+
+  start() {
+    this.state.running = true;
+    this.state.startTs = performance.now();
+    this.dom.startButton.textContent = 'RESTART';
+    this.root.classList.add('is-running');
+    this.tick();
+  }
+
+  endGame() {
+    this.state.running = false;
+    this.root.classList.remove('is-running');
+
+    const bonus = this.scoring.computeFinishBonus({
+      remainingMs: 0,
+      lastInputId: this.state.lastInputId
+    });
+
+    if (bonus.hit && !this.state.finalBonusAwarded) {
+      this.state.finalBonusAwarded = true;
+      this.state.score += bonus.bonus;
+      this.setJudgeText(`${bonus.message} +${bonus.bonus}`);
+    }
+
+    const { perfect, great, good, miss } = this.state.judgments;
+    this.setSummary(
+      `Final Score ${this.state.score} | Max Combo ${this.state.maxCombo} | P:${perfect} G:${great} Go:${good} M:${miss}`
+    );
+    this.renderHud('END');
+  }
+
+  tick = () => {
+    if (!this.state.running) {
+      return;
+    }
+
+    const elapsed = performance.now() - this.state.startTs;
+    this.state.nowMs = elapsed;
+
+    this.judgeMisses();
+    this.renderNotes();
+    this.renderHud();
+
+    const totalMs = this.config.rules.duration * 1000;
+    if (elapsed >= totalMs) {
+      this.endGame();
+      return;
+    }
+
+    this.rafId = requestAnimationFrame(this.tick);
+  };
+
+  judgeMisses() {
+    const goodWindow = this.config.rules.timing.goodMs;
+
+    while (this.state.currentIndex < this.state.notes.length) {
+      const note = this.state.notes[this.state.currentIndex];
+      if (note.judged) {
+        this.state.currentIndex += 1;
+        continue;
+      }
+
+      if (this.state.nowMs - note.timeMs > goodWindow) {
+        note.judged = true;
+        note.hit = false;
+        this.applyMiss();
+        this.state.currentIndex += 1;
+      } else {
+        break;
+      }
+    }
+  }
+
+  handleInput(poseId) {
+    if (!this.state.running) {
+      return;
+    }
+
+    const goodWindow = this.config.rules.timing.goodMs;
+    const nextNote = this.findBestCandidate(poseId, goodWindow);
+
+    if (!nextNote) {
+      this.applyMiss('MISS');
+      return;
+    }
+
+    const deltaMs = this.state.nowMs - nextNote.timeMs;
+    nextNote.judged = true;
+    nextNote.hit = true;
+
+    const pose = this.config.poseById.get(poseId);
+    const result = this.scoring.computeHit({
+      pose,
+      deltaMs,
+      combo: this.state.combo
+    });
+
+    this.state.lastInputId = poseId;
+    this.state.judgments[result.timingKey] += 1;
+
+    if (result.timingKey === 'miss') {
+      this.applyMiss(result.timingLabel);
+      return;
+    }
+
+    this.state.combo += 1;
+    this.state.maxCombo = Math.max(this.state.maxCombo, this.state.combo);
+    this.state.fxLevel = result.fxLevel;
+    this.state.score += result.hitScore;
+
+    let bonusLabel = '';
+    if (result.sequenceBonus) {
+      this.state.score += result.sequenceBonus.bonus;
+      bonusLabel = ` + ${result.sequenceBonus.name} +${result.sequenceBonus.bonus}`;
+    }
+
+    this.setJudgeText(`${result.timingLabel} +${result.hitScore}${bonusLabel}`);
+
+    const remainingMs = this.config.rules.duration * 1000 - this.state.nowMs;
+    const finishBonus = this.scoring.computeFinishBonus({
+      remainingMs,
+      lastInputId: poseId
+    });
+
+    if (finishBonus.hit && !this.state.finalBonusAwarded) {
+      this.state.finalBonusAwarded = true;
+      this.state.score += finishBonus.bonus;
+      this.setJudgeText(`${result.timingLabel} +${result.hitScore} | ${finishBonus.message} +${finishBonus.bonus}`);
+    }
+  }
+
+  findBestCandidate(poseId, windowMs) {
+    let best = null;
+
+    for (let i = this.state.currentIndex; i < this.state.notes.length; i += 1) {
+      const note = this.state.notes[i];
+      if (note.judged || note.poseId !== poseId) {
+        continue;
+      }
+
+      const delta = Math.abs(this.state.nowMs - note.timeMs);
+      if (delta > windowMs) {
+        if (note.timeMs > this.state.nowMs + windowMs) {
+          break;
+        }
+        continue;
+      }
+
+      if (!best || delta < Math.abs(this.state.nowMs - best.timeMs)) {
+        best = note;
+      }
+    }
+
+    return best;
+  }
+
+  applyMiss(label = 'MISS') {
+    this.state.combo = 0;
+    this.state.fxLevel = this.scoring.getComboTier(0).fxLevel;
+    this.state.judgments.miss += 1;
+    this.setJudgeText(label);
+  }
+
+  setJudgeText(text) {
+    this.dom.judge.textContent = text;
+    this.dom.judge.classList.remove('pulse');
+    void this.dom.judge.offsetWidth;
+    this.dom.judge.classList.add('pulse');
+  }
+
+  setSummary(text) {
+    this.dom.summary.textContent = text;
+  }
+
+  renderHud(stateLabel) {
+    const durationMs = this.config.rules.duration * 1000;
+    const remainingMs = clamp(durationMs - this.state.nowMs, 0, durationMs);
+
+    this.dom.timer.textContent = `${(remainingMs / 1000).toFixed(1)}s`;
+    this.dom.score.textContent = String(this.state.score);
+    this.dom.combo.textContent = String(this.state.combo);
+    this.dom.maxCombo.textContent = String(this.state.maxCombo);
+    this.dom.fxLabel.textContent = `FX ${this.state.fxLevel}${stateLabel ? ` • ${stateLabel}` : ''}`;
+
+    this.root.style.setProperty('--fx-level', String(this.state.fxLevel));
+  }
+
+  renderNotes() {
+    const windowMs = 2200;
+    const timingNow = this.state.nowMs;
+
+    this.dom.notesLayer.innerHTML = '';
+
+    for (const note of this.state.notes) {
+      if (note.judged) {
+        continue;
+      }
+
+      const dt = note.timeMs - timingNow;
+      if (Math.abs(dt) > windowMs) {
+        continue;
+      }
+
+      const progress = 1 - (dt + windowMs) / (windowMs * 2);
+      const x = clamp(progress, 0, 1) * 100;
+
+      const node = document.createElement('div');
+      node.className = `note lane-${note.lane}`;
+      node.style.left = `${x}%`;
+      node.style.top = `${this.getLaneOffset(note.lane)}%`;
+      node.textContent = note.poseId;
+      this.dom.notesLayer.appendChild(node);
+    }
+  }
+
+  getLaneOffset(lane) {
+    const map = { A: 8, B: 28, C: 48, D: 68, S: 88 };
+    return map[lane] ?? 50;
+  }
+}

--- a/pose-master/index.html
+++ b/pose-master/index.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pose Master Prototype v0.1</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <main id="app" class="game-shell" style="--fx-level:0">
+      <header class="hud">
+        <h1>Pose Master <span>v0.1</span></h1>
+        <div class="stats">
+          <p>Time: <strong data-role="timer">60.0s</strong></p>
+          <p>Score: <strong data-role="score">0</strong></p>
+          <p>Combo: <strong data-role="combo">0</strong></p>
+          <p>Max Combo: <strong data-role="max-combo">0</strong></p>
+          <p><strong data-role="fx-level">FX 0 • READY</strong></p>
+        </div>
+      </header>
+
+      <section class="playfield">
+        <div class="lane-labels">
+          <span>A</span><span>B</span><span>C</span><span>D</span><span>S</span>
+        </div>
+        <div class="lane-track" data-role="lane-track">
+          <div class="hit-line">HIT</div>
+          <div class="notes" data-role="notes"></div>
+        </div>
+      </section>
+
+      <section class="feedback">
+        <h2 data-role="judge">READY</h2>
+        <p data-role="summary">Press START to begin.</p>
+      </section>
+
+      <section class="controls">
+        <button data-role="start" class="start">START</button>
+        <div class="pose-grid">
+          <button data-pose-id="A">A<br /><small>Front Double Biceps</small></button>
+          <button data-pose-id="B">B<br /><small>Side Chest</small></button>
+          <button data-pose-id="C">C<br /><small>Back Double Biceps</small></button>
+          <button data-pose-id="D">D<br /><small>Most Muscular</small></button>
+          <button data-pose-id="S">S<br /><small>Finish Pose</small></button>
+        </div>
+        <p class="hint">Keys: A / S / D / F / Space</p>
+      </section>
+      <p class="status" data-role="status">Booting...</p>
+    </main>
+
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/pose-master/main.js
+++ b/pose-master/main.js
@@ -1,0 +1,20 @@
+import { loadGameConfig } from './data.js';
+import { PoseMasterGame } from './game.js';
+
+async function bootstrap() {
+  const app = document.querySelector('#app');
+  const status = document.querySelector('[data-role="status"]');
+
+  try {
+    status.textContent = 'Loading data...';
+    const config = await loadGameConfig();
+    const game = new PoseMasterGame({ root: app, config });
+    window.poseMaster = game;
+    status.textContent = 'Ready. Data loaded from poses.json / rules.json';
+  } catch (error) {
+    console.error(error);
+    status.textContent = `Failed to start: ${error.message}`;
+  }
+}
+
+bootstrap();

--- a/pose-master/poses.json
+++ b/pose-master/poses.json
@@ -1,0 +1,9 @@
+{
+  "poses": [
+    { "id": "A", "name": "Front Double Biceps", "basePoint": 100, "lane": "A" },
+    { "id": "B", "name": "Side Chest", "basePoint": 120, "lane": "B" },
+    { "id": "C", "name": "Back Double Biceps", "basePoint": 150, "lane": "C" },
+    { "id": "D", "name": "Most Muscular", "basePoint": 200, "lane": "D" },
+    { "id": "S", "name": "Finish Pose", "basePoint": 260, "lane": "S" }
+  ]
+}

--- a/pose-master/rules.json
+++ b/pose-master/rules.json
@@ -1,0 +1,38 @@
+{
+  "duration": 60,
+  "noteCount": 80,
+  "timing": {
+    "perfectMs": 60,
+    "greatMs": 110,
+    "goodMs": 170,
+    "labels": {
+      "perfect": "PERFECT",
+      "great": "GREAT",
+      "good": "GOOD",
+      "miss": "MISS"
+    },
+    "multipliers": {
+      "perfect": 1.2,
+      "great": 1,
+      "good": 0.75,
+      "miss": 0
+    }
+  },
+  "comboTiers": [
+    { "minCombo": 0, "multiplier": 1, "fxLevel": 0 },
+    { "minCombo": 5, "multiplier": 1.05, "fxLevel": 1 },
+    { "minCombo": 10, "multiplier": 1.1, "fxLevel": 2 },
+    { "minCombo": 20, "multiplier": 1.2, "fxLevel": 3 },
+    { "minCombo": 35, "multiplier": 1.35, "fxLevel": 4 }
+  ],
+  "sequenceBonuses": [
+    { "pattern": ["A", "B", "C"], "bonus": 300, "name": "Classic Flow" },
+    { "pattern": ["D", "D", "S"], "bonus": 500, "name": "Power Finish" },
+    { "pattern": ["A", "C", "D", "S"], "bonus": 700, "name": "Showstopper" }
+  ],
+  "finishBonus": {
+    "lastSec": 8,
+    "poseId": "S",
+    "bonus": 1000
+  }
+}

--- a/pose-master/scoring.js
+++ b/pose-master/scoring.js
@@ -1,0 +1,90 @@
+export function createScoringSystem(rules) {
+  let recentInputs = [];
+
+  function getTimingResult(absDeltaMs) {
+    if (absDeltaMs <= rules.timing.perfectMs) {
+      return 'perfect';
+    }
+    if (absDeltaMs <= rules.timing.greatMs) {
+      return 'great';
+    }
+    if (absDeltaMs <= rules.timing.goodMs) {
+      return 'good';
+    }
+    return 'miss';
+  }
+
+  function getComboTier(combo) {
+    let bestTier = rules.comboTiers[0];
+    for (const tier of rules.comboTiers) {
+      if (combo >= tier.minCombo) {
+        bestTier = tier;
+      }
+    }
+    return bestTier;
+  }
+
+  function checkSequenceBonus(inputId) {
+    recentInputs.push(inputId);
+
+    const maxPatternLength = Math.max(...rules.sequenceBonuses.map((item) => item.pattern.length), 1);
+    if (recentInputs.length > maxPatternLength) {
+      recentInputs = recentInputs.slice(-maxPatternLength);
+    }
+
+    for (const item of rules.sequenceBonuses) {
+      const { pattern, bonus, name } = item;
+      const tail = recentInputs.slice(-pattern.length);
+      const matched = tail.length === pattern.length && tail.every((id, index) => id === pattern[index]);
+      if (matched) {
+        return { bonus, name };
+      }
+    }
+
+    return null;
+  }
+
+  function computeHit({ pose, deltaMs, combo }) {
+    const absDeltaMs = Math.abs(deltaMs);
+    const timingKey = getTimingResult(absDeltaMs);
+    const timingLabel = rules.timing.labels[timingKey];
+    const timingMult = rules.timing.multipliers[timingKey];
+    const tier = getComboTier(combo);
+
+    const rawScore = pose.basePoint * timingMult * tier.multiplier;
+    const hitScore = Math.round(rawScore);
+
+    const sequence = timingKey === 'miss' ? null : checkSequenceBonus(pose.id);
+
+    return {
+      timingKey,
+      timingLabel,
+      timingMult,
+      fxLevel: tier.fxLevel,
+      comboMultiplier: tier.multiplier,
+      hitScore,
+      sequenceBonus: sequence
+    };
+  }
+
+  function computeFinishBonus({ remainingMs, lastInputId }) {
+    const inLastWindow = remainingMs <= rules.finishBonus.lastSec * 1000;
+    const matched = lastInputId === rules.finishBonus.poseId;
+
+    if (inLastWindow && matched) {
+      return {
+        hit: true,
+        bonus: rules.finishBonus.bonus,
+        message: 'FINISH BONUS'
+      };
+    }
+
+    return { hit: false, bonus: 0, message: '' };
+  }
+
+  return {
+    computeHit,
+    computeFinishBonus,
+    getComboTier
+  };
+}

--- a/pose-master/styles.css
+++ b/pose-master/styles.css
@@ -1,0 +1,194 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #23274f, #0a0b16 58%);
+  color: #f6f6f8;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.game-shell {
+  width: min(980px, 100%);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  background: rgba(10, 12, 26, 0.84);
+  backdrop-filter: blur(8px);
+  padding: 18px;
+  display: grid;
+  gap: 14px;
+  box-shadow: 0 0 calc(12px + var(--fx-level) * 8px) rgba(122, 85, 255, 0.3);
+}
+
+.hud {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: start;
+}
+
+.hud h1 {
+  margin: 0;
+}
+
+.hud h1 span {
+  font-size: 0.8rem;
+  color: #b9b7ff;
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(3, auto);
+  gap: 4px 14px;
+}
+
+.stats p {
+  margin: 0;
+  font-size: 0.92rem;
+}
+
+.playfield {
+  display: grid;
+  gap: 6px;
+}
+
+.lane-labels {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  color: #b9c4ff;
+  letter-spacing: 0.08em;
+}
+
+.lane-track {
+  position: relative;
+  height: 280px;
+  background: linear-gradient(180deg, rgba(30, 35, 67, 0.8), rgba(12, 14, 28, 0.9));
+  border-radius: 12px;
+  border: 1px solid rgba(153, 167, 255, 0.35);
+  overflow: hidden;
+}
+
+.lane-track::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(
+      rgba(255, 255, 255, 0.08) 1px,
+      transparent 1px
+    ),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.06) 1px, transparent 1px);
+  background-size: 100% 20%, 20% 100%;
+}
+
+.hit-line {
+  position: absolute;
+  left: 50%;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  transform: translateX(-50%);
+  background: linear-gradient(#fff, #8ec5ff, #fff);
+  box-shadow: 0 0 14px rgba(94, 168, 255, 0.85);
+  text-align: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #ddf0ff;
+}
+
+.notes {
+  position: absolute;
+  inset: 0;
+}
+
+.note {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.85);
+  color: #f4f7ff;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  box-shadow: 0 0 calc(8px + var(--fx-level) * 3px) rgba(130, 200, 255, 0.6);
+}
+
+.lane-A { background: #5a72ff; }
+.lane-B { background: #b570ff; }
+.lane-C { background: #00a9d6; }
+.lane-D { background: #ff6f90; }
+.lane-S { background: #ffba35; color: #111; }
+
+.feedback {
+  text-align: center;
+}
+
+.feedback h2 {
+  margin: 0;
+  font-size: 2rem;
+  letter-spacing: 0.12em;
+}
+
+.feedback h2.pulse {
+  animation: pulse 170ms ease-out;
+}
+
+@keyframes pulse {
+  from { transform: scale(1.12); filter: brightness(1.8); }
+  to { transform: scale(1); filter: brightness(1); }
+}
+
+.controls {
+  display: grid;
+  gap: 10px;
+}
+
+button {
+  border: 0;
+  border-radius: 10px;
+  background: #2f3466;
+  color: #fff;
+  padding: 10px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.start {
+  background: linear-gradient(135deg, #22b3ff, #6b66ff);
+}
+
+.pose-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 8px;
+}
+
+.pose-grid button {
+  min-height: 76px;
+}
+
+.pose-grid small {
+  opacity: 0.9;
+  font-weight: 500;
+}
+
+.hint,
+.status {
+  margin: 0;
+  color: #c4c8ef;
+  font-size: 0.9rem;
+}
+
+.is-running .lane-track {
+  box-shadow: inset 0 0 calc(12px + var(--fx-level) * 9px) rgba(126, 179, 255, 0.45);
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight, data-driven single-page prototype for a rhythm/combo scoring game implemented in plain HTML/CSS/vanilla ES modules. 
- Allow designers to tune gameplay by editing `poses.json` and `rules.json` without rebuilding the app. 
- Ship a simple, modular codebase that demonstrates timing-based judgments, combo tiers, sequence bonuses and a finish bonus.

### Description
- Add a new `/pose-master` app with `index.html`, `styles.css`, `main.js`, `data.js`, `game.js`, `scoring.js`, `poses.json`, and `rules.json` implementing the UI, game loop and scoring pipeline. 
- Implement data loading and validation in `data.js` so the game reads `poses.json` and `rules.json` at runtime and exposes `poseById` and rules to the game. 
- Implement the core loop and input handling in `game.js` using `performance.now()` for timing, note chart generation, scrolling notes, hit/miss judgement, combo tracking, FX-level state and UI updates; add keyboard (`A/S/D/F/Space`) and button inputs. 
- Implement scoring in `scoring.js` with timing windows (PERFECT/GREAT/GOOD/MISS), combo-tier multipliers, sequence bonuses and finish bonus, and remove a prior pattern-dedup guard so sequence bonuses are evaluated straightforwardly per matched pattern. 

### Testing
- JSON validation: ran `python -m json.tool pose-master/poses.json` and `python -m json.tool pose-master/rules.json`, both succeeded. 
- Static check: ran `node --check` on `pose-master/main.js`, `pose-master/data.js`, `pose-master/game.js`, and `pose-master/scoring.js`, all succeeded. 
- Manual browser smoke test: served the folder with `python -m http.server 4173` and performed an automated smoke navigation + screenshot via Playwright to ensure the page loads and the gameplay loop runs, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c3a240f8083298bc274716d237195)