### PR TITLE
Add offline touch-optimized kushi‑darts omikuji web app (COUNTER / GAME / RESULT / ADMIN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,73 @@
-# mock-private
-private mockup
+# 串カウント → ダーツ/射的 → おみくじ 特典アプリ
+
+外部ライブラリなしのバニラ HTML/CSS/JS で動く、オフライン前提の店頭向けミニアトラクションです。
+
+## ファイル構成
+
+- `index.html` 画面構造（COUNTER / GAME / RESULT / ADMIN）
+- `styles.css` 見た目・演出・レスポンシブ
+- `app.js` ロジック（入力、抽選、描画、音、保存）
+- `assets/` 任意（今回は未使用、CSS/Canvasで完結）
+
+## 起動方法
+
+1. このフォルダを端末に置く
+2. `index.html` をダブルクリックで開く
+3. 通常運用は `COUNTER` 画面で串本数を入力して `ゲーム開始`
+
+> オフライン動作可。通信不要です。
+
+## 運用手順（店員想定）
+
+1. 店員が `+ / -` で串本数を入力
+2. 画面に表示される回数で `ゲーム開始`
+3. 客がドラッグして狙い、離して発射
+4. 結果画面の特典を案内
+5. `次のプレイ`（残回数あり）または `終了してカウンターへ`
+
+## 仕様メモ
+
+- プレイ回数換算は既定で `shots = floor(kushi_count / 2)`
+- `kushi_count >= 3` のとき最低1回プレイ付与
+- 視覚上は狙える演出だが、最終判定は確率テーブル抽選
+- 狙いの良さで SSR/SR を最大 +2〜3% 程度補正
+- 音ON時のみ WebAudio でSE合成（投擲 / ヒット / 勝利 / 残念）
+- `navigator.vibrate` が使える端末のみ振動
+- 粒子は端末FPSを見て自動で上限調整
+
+## 管理画面（ADMIN）
+
+- 右上ロゴ `🎯 KUSHI LUCK` を **3秒長押し** で開く
+- JSON を編集して保存すると `localStorage` に反映
+- `初期値へリセット` で既定設定に戻す
+
+### 編集できる項目
+
+`app.js` の初期値に対応します。
+
+- `conversion.divisor` 串→回数の割り算係数
+- `conversion.minKushiForOneShot` 最低1回が付く串本数閾値
+- `conversion.minShots` 閾値を超えた時の最低回数
+- `rareFailProb` 凶（特典なし）確率 `0.0〜0.05` 推奨
+- `prizeTable` 各ランクの `prob`, `fortune`, `prize`
+- `aimAssist.ssrMaxBoost`, `aimAssist.srMaxBoost` 照準補正量
+
+### 確率/特典の編集例
+
+```json
+{
+  "rareFailProb": 0.01,
+  "prizeTable": {
+    "SSR": { "prob": 0.02, "fortune": "超大吉", "prize": "会計無料" },
+    "SR":  { "prob": 0.05, "fortune": "大吉", "prize": "ドリンク無料" },
+    "R":   { "prob": 0.23, "fortune": "中吉", "prize": "100円引" },
+    "N":   { "prob": 0.70, "fortune": "小吉", "prize": "また挑戦！" }
+  }
+}
+```
+
+## 設置のコツ
+
+- iPad横向きを推奨（縦でも崩れない）
+- 端末音量は中程度、必要ならミュート運用
+- 1テーブル1端末で固定配置

--- a/app.js
+++ b/app.js
@@ -1,0 +1,494 @@
+(() => {
+  const DEFAULT_CONFIG = {
+    conversion: {
+      divisor: 2,
+      minKushiForOneShot: 3,
+      minShots: 1,
+    },
+    rareFailProb: 0.02,
+    prizeTable: {
+      SSR: { prob: 0.01, fortune: '大吉', prize: 'ドリンク無料' },
+      SR: { prob: 0.05, fortune: '吉', prize: '半額' },
+      R: { prob: 0.2, fortune: '中吉', prize: '100円引' },
+      N: { prob: 0.74, fortune: '小吉', prize: 'また挑戦！' },
+    },
+    aimAssist: {
+      ssrMaxBoost: 0.025,
+      srMaxBoost: 0.03,
+    },
+  };
+
+  const STORAGE_KEY = 'kushiDartsConfigV1';
+  const state = {
+    mode: 'counter',
+    config: loadConfig(),
+    soundEnabled: false,
+    kushiCount: 0,
+    shotsTotal: 0,
+    shotsLeft: 0,
+    pointerActive: false,
+    dragStart: null,
+    dragCurrent: null,
+    projectile: null,
+    particles: [],
+    frameTimes: [],
+    perfParticleCap: 120,
+    lastResult: null,
+    aimQuality: 0,
+  };
+
+  const el = {
+    counterScreen: document.getElementById('counterScreen'),
+    gameScreen: document.getElementById('gameScreen'),
+    resultScreen: document.getElementById('resultScreen'),
+    kushiCount: document.getElementById('kushiCount'),
+    shotCount: document.getElementById('shotCount'),
+    shotRuleText: document.getElementById('shotRuleText'),
+    minusBtn: document.getElementById('minusBtn'),
+    plusBtn: document.getElementById('plusBtn'),
+    startGameBtn: document.getElementById('startGameBtn'),
+    remainShots: document.getElementById('remainShots'),
+    hudKushi: document.getElementById('hudKushi'),
+    gameMessage: document.getElementById('gameMessage'),
+    powerMeterInner: document.querySelector('#powerMeter span'),
+    canvas: document.getElementById('gameCanvas'),
+    nextPlayBtn: document.getElementById('nextPlayBtn'),
+    finishBtn: document.getElementById('finishBtn'),
+    fortuneText: document.getElementById('fortuneText'),
+    prizeText: document.getElementById('prizeText'),
+    soundToggle: document.getElementById('soundToggle'),
+    adminTrigger: document.getElementById('adminTrigger'),
+    adminDialog: document.getElementById('adminDialog'),
+    adminJson: document.getElementById('adminJson'),
+    saveAdminBtn: document.getElementById('saveAdminBtn'),
+    resetAdminBtn: document.getElementById('resetAdminBtn'),
+  };
+
+  const ctx = el.canvas.getContext('2d');
+  const target = { x: el.canvas.width * 0.5, y: el.canvas.height * 0.43, radius: 160 };
+  let audioCtx = null;
+  let holdTimer = null;
+
+  function loadConfig() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return structuredClone(DEFAULT_CONFIG);
+      const parsed = JSON.parse(raw);
+      return deepMerge(structuredClone(DEFAULT_CONFIG), parsed);
+    } catch {
+      return structuredClone(DEFAULT_CONFIG);
+    }
+  }
+
+  function deepMerge(base, patch) {
+    if (!patch || typeof patch !== 'object') return base;
+    Object.keys(patch).forEach((k) => {
+      if (patch[k] && typeof patch[k] === 'object' && !Array.isArray(patch[k]) && typeof base[k] === 'object') {
+        base[k] = deepMerge(base[k], patch[k]);
+      } else {
+        base[k] = patch[k];
+      }
+    });
+    return base;
+  }
+
+  function saveConfig() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state.config));
+  }
+
+  function calcShots(kushi) {
+    const c = state.config.conversion;
+    let shots = Math.floor(kushi / Math.max(1, c.divisor));
+    if (kushi >= c.minKushiForOneShot) shots = Math.max(shots, c.minShots);
+    return Math.max(0, shots);
+  }
+
+  function setMode(mode) {
+    state.mode = mode;
+    [el.counterScreen, el.gameScreen, el.resultScreen].forEach((node) => node.classList.remove('active'));
+    if (mode === 'counter') el.counterScreen.classList.add('active');
+    if (mode === 'game') el.gameScreen.classList.add('active');
+    if (mode === 'result') el.resultScreen.classList.add('active');
+  }
+
+  function updateCounterUI() {
+    const shots = calcShots(state.kushiCount);
+    state.shotsTotal = shots;
+    el.kushiCount.textContent = String(state.kushiCount);
+    el.shotCount.textContent = String(shots);
+    const c = state.config.conversion;
+    el.shotRuleText.textContent = `shots = floor(串本数 / ${c.divisor}), ${c.minKushiForOneShot}本以上で最低${c.minShots}回`;
+    el.startGameBtn.disabled = shots <= 0;
+  }
+
+  function startGame() {
+    state.shotsLeft = state.shotsTotal;
+    el.remainShots.textContent = String(state.shotsLeft);
+    el.hudKushi.textContent = String(state.kushiCount);
+    el.gameMessage.textContent = 'ドラッグして狙い、離して発射！';
+    state.projectile = null;
+    state.particles = [];
+    setMode('game');
+  }
+
+  function safeVibrate(pattern) {
+    try {
+      if (navigator.vibrate) navigator.vibrate(pattern);
+    } catch {}
+  }
+
+  function ensureAudio() {
+    try {
+      if (!audioCtx) audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+      if (audioCtx.state === 'suspended') audioCtx.resume();
+    } catch {}
+  }
+
+  function playSE(type) {
+    if (!state.soundEnabled || !audioCtx) return;
+    const now = audioCtx.currentTime;
+    const osc = audioCtx.createOscillator();
+    const gain = audioCtx.createGain();
+    osc.connect(gain).connect(audioCtx.destination);
+    if (type === 'throw') {
+      osc.type = 'triangle';
+      osc.frequency.setValueAtTime(220, now);
+      osc.frequency.exponentialRampToValueAtTime(120, now + 0.15);
+      gain.gain.setValueAtTime(0.001, now);
+      gain.gain.exponentialRampToValueAtTime(0.15, now + 0.02);
+      gain.gain.exponentialRampToValueAtTime(0.001, now + 0.16);
+      osc.start(now); osc.stop(now + 0.18);
+      return;
+    }
+    if (type === 'hit') {
+      osc.type = 'square';
+      osc.frequency.setValueAtTime(400, now);
+      gain.gain.setValueAtTime(0.13, now);
+      gain.gain.exponentialRampToValueAtTime(0.001, now + 0.12);
+      osc.start(now); osc.stop(now + 0.13);
+      return;
+    }
+    if (type === 'win') {
+      osc.type = 'sine';
+      [523, 659, 784].forEach((f, i) => osc.frequency.setValueAtTime(f, now + i * 0.08));
+      gain.gain.setValueAtTime(0.16, now);
+      gain.gain.exponentialRampToValueAtTime(0.001, now + 0.35);
+      osc.start(now); osc.stop(now + 0.36);
+      return;
+    }
+    osc.type = 'sawtooth';
+    osc.frequency.setValueAtTime(180, now);
+    osc.frequency.exponentialRampToValueAtTime(90, now + 0.22);
+    gain.gain.setValueAtTime(0.11, now);
+    gain.gain.exponentialRampToValueAtTime(0.001, now + 0.23);
+    osc.start(now); osc.stop(now + 0.24);
+  }
+
+  function weightedResult(aimQuality) {
+    const table = state.config.prizeTable;
+    const fail = clamp(state.config.rareFailProb, 0, 0.05);
+    const ssrBoost = state.config.aimAssist.ssrMaxBoost * aimQuality;
+    const srBoost = state.config.aimAssist.srMaxBoost * aimQuality;
+    const adjusted = {
+      SSR: clamp(table.SSR.prob + ssrBoost, 0, 0.2),
+      SR: clamp(table.SR.prob + srBoost, 0, 0.3),
+      R: table.R.prob,
+      N: table.N.prob,
+    };
+    const totalWithoutFail = adjusted.SSR + adjusted.SR + adjusted.R + adjusted.N;
+    Object.keys(adjusted).forEach((k) => adjusted[k] = adjusted[k] / totalWithoutFail * (1 - fail));
+
+    const roll = Math.random();
+    if (roll < fail) return { rank: 'FAIL', fortune: '凶', prize: '特典なし…', isBig: false };
+    const roll2 = (roll - fail) / (1 - fail);
+    let acc = 0;
+    for (const rank of ['SSR', 'SR', 'R', 'N']) {
+      acc += adjusted[rank];
+      if (roll2 <= acc) return { rank, ...table[rank], isBig: rank === 'SSR' || rank === 'SR' };
+    }
+    return { rank: 'N', ...table.N, isBig: false };
+  }
+
+  function clamp(v, min, max) { return Math.max(min, Math.min(max, v)); }
+
+  function pointerToCanvas(ev) {
+    const rect = el.canvas.getBoundingClientRect();
+    return {
+      x: (ev.clientX - rect.left) * (el.canvas.width / rect.width),
+      y: (ev.clientY - rect.top) * (el.canvas.height / rect.height),
+    };
+  }
+
+  function drawBoard() {
+    ctx.clearRect(0, 0, el.canvas.width, el.canvas.height);
+    const rings = [
+      { r: target.radius, c: '#20317d', label: 'N' },
+      { r: target.radius * 0.76, c: '#3f3aa9', label: 'R' },
+      { r: target.radius * 0.52, c: '#8f2fa8', label: 'SR' },
+      { r: target.radius * 0.26, c: '#ff4ea0', label: 'SSR' },
+    ];
+    rings.forEach((ring) => {
+      ctx.fillStyle = ring.c;
+      ctx.beginPath();
+      ctx.arc(target.x, target.y, ring.r, 0, Math.PI * 2);
+      ctx.fill();
+    });
+    ctx.fillStyle = '#eaf6ff';
+    ctx.font = 'bold 22px sans-serif';
+    ctx.textAlign = 'center';
+    rings.forEach((ring, i) => ctx.fillText(ring.label, target.x, target.y - ring.r + 32 + i * 4));
+
+    if (state.dragStart && state.dragCurrent && !state.projectile) {
+      ctx.strokeStyle = '#8ff7ff';
+      ctx.lineWidth = 5;
+      ctx.beginPath();
+      ctx.moveTo(state.dragStart.x, state.dragStart.y);
+      ctx.lineTo(state.dragCurrent.x, state.dragCurrent.y);
+      ctx.stroke();
+    }
+
+    if (state.projectile) {
+      ctx.save();
+      ctx.translate(state.projectile.x, state.projectile.y);
+      ctx.rotate(state.projectile.rotation);
+      ctx.fillStyle = '#ffe36f';
+      ctx.beginPath();
+      ctx.moveTo(16, 0); ctx.lineTo(-10, 5); ctx.lineTo(-10, -5); ctx.closePath(); ctx.fill();
+      ctx.fillStyle = '#47e8ff';
+      ctx.fillRect(-18, -2, 8, 4);
+      ctx.restore();
+    }
+
+    state.particles.forEach((p) => {
+      ctx.fillStyle = p.color;
+      ctx.globalAlpha = p.life / p.maxLife;
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.globalAlpha = 1;
+    });
+  }
+
+  function spawnParticles(x, y, type) {
+    const base = type === 'big' ? 100 : type === 'fail' ? 38 : 55;
+    const count = Math.min(base, state.perfParticleCap);
+    for (let i = 0; i < count; i += 1) {
+      const speed = (type === 'big' ? 5.4 : 3.2) * (0.5 + Math.random());
+      const angle = Math.random() * Math.PI * 2;
+      state.particles.push({
+        x, y,
+        vx: Math.cos(angle) * speed,
+        vy: Math.sin(angle) * speed - 1.3,
+        size: 2 + Math.random() * (type === 'big' ? 5 : 3),
+        life: 25 + Math.random() * 30,
+        maxLife: 55,
+        color: type === 'fail' ? '#bbbbc8' : ['#48deff', '#ff4dd2', '#ffe37b', '#ffffff'][Math.floor(Math.random() * 4)],
+      });
+    }
+  }
+
+  function updateParticles() {
+    state.particles = state.particles.filter((p) => {
+      p.x += p.vx;
+      p.y += p.vy;
+      p.vy += 0.08;
+      p.vx *= 0.985;
+      p.life -= 1;
+      return p.life > 0;
+    });
+  }
+
+  function launchDart(from, to) {
+    const dx = from.x - to.x;
+    const dy = from.y - to.y;
+    const power = clamp(Math.hypot(dx, dy) / 210, 0.18, 1.2);
+    state.aimQuality = clamp(1 - distanceToTargetNorm(to.x, to.y), 0, 1);
+    state.projectile = {
+      x: from.x,
+      y: from.y,
+      vx: dx * 0.09,
+      vy: dy * 0.09 - 2,
+      gravity: 0.22,
+      rotation: 0,
+      landed: false,
+      power,
+    };
+    el.powerMeterInner.style.height = `${Math.round(power / 1.2 * 100)}%`;
+    el.gameMessage.textContent = '投擲！';
+    playSE('throw');
+  }
+
+  function distanceToTargetNorm(x, y) {
+    return clamp(Math.hypot(x - target.x, y - target.y) / target.radius, 0, 1);
+  }
+
+  function settleShot(impactX, impactY) {
+    const result = weightedResult(state.aimQuality);
+    state.lastResult = result;
+    state.shotsLeft -= 1;
+    el.remainShots.textContent = String(state.shotsLeft);
+
+    const isHit = result.rank !== 'FAIL';
+    el.canvas.classList.remove('flash', 'shake');
+    void el.canvas.offsetWidth;
+
+    if (result.rank === 'SSR') {
+      el.canvas.classList.add('flash');
+      spawnParticles(impactX, impactY, 'big');
+      safeVibrate([50, 40, 60]);
+      playSE('win');
+    } else if (isHit) {
+      el.canvas.classList.add('shake');
+      spawnParticles(impactX, impactY, 'normal');
+      safeVibrate(35);
+      playSE('hit');
+    } else {
+      spawnParticles(impactX, impactY, 'fail');
+      safeVibrate(16);
+      playSE('fail');
+    }
+
+    el.gameMessage.textContent = `${result.fortune} ${result.prize}`;
+    setTimeout(() => {
+      showResult();
+    }, 1050);
+  }
+
+  function showResult() {
+    if (!state.lastResult) return;
+    el.fortuneText.textContent = state.lastResult.fortune;
+    el.prizeText.textContent = state.lastResult.prize;
+    setMode('result');
+  }
+
+  function nextPlay() {
+    if (state.shotsLeft > 0) {
+      setMode('game');
+      el.gameMessage.textContent = 'ドラッグして狙い、離して発射！';
+      state.projectile = null;
+      state.dragStart = null;
+      state.dragCurrent = null;
+      return;
+    }
+    toCounter();
+  }
+
+  function toCounter() {
+    setMode('counter');
+    state.kushiCount = 0;
+    updateCounterUI();
+  }
+
+  function loop(ts) {
+    try {
+      state.frameTimes.push(ts);
+      while (state.frameTimes.length > 45) state.frameTimes.shift();
+      if (state.frameTimes.length > 12) {
+        const d = state.frameTimes[state.frameTimes.length - 1] - state.frameTimes[0];
+        const fps = ((state.frameTimes.length - 1) / d) * 1000;
+        state.perfParticleCap = fps < 45 ? 65 : fps < 55 ? 90 : 120;
+      }
+
+      if (state.projectile && !state.projectile.landed) {
+        state.projectile.vy += state.projectile.gravity;
+        state.projectile.x += state.projectile.vx;
+        state.projectile.y += state.projectile.vy;
+        state.projectile.rotation = Math.atan2(state.projectile.vy, state.projectile.vx);
+
+        if (state.projectile.y > target.y - 20 || state.projectile.y > el.canvas.height - 24) {
+          state.projectile.landed = true;
+          settleShot(state.projectile.x, state.projectile.y);
+        }
+      }
+
+      updateParticles();
+      drawBoard();
+    } catch (err) {
+      console.error('render fallback', err);
+    }
+    requestAnimationFrame(loop);
+  }
+
+  function openAdmin() {
+    const editable = JSON.stringify(state.config, null, 2);
+    el.adminJson.value = editable;
+    el.adminDialog.showModal();
+  }
+
+  function bindEvents() {
+    el.minusBtn.addEventListener('click', () => { state.kushiCount = Math.max(0, state.kushiCount - 1); updateCounterUI(); });
+    el.plusBtn.addEventListener('click', () => { state.kushiCount += 1; updateCounterUI(); });
+    el.startGameBtn.addEventListener('click', () => { if (state.shotsTotal > 0) startGame(); });
+    el.nextPlayBtn.addEventListener('click', nextPlay);
+    el.finishBtn.addEventListener('click', toCounter);
+
+    el.soundToggle.addEventListener('change', () => {
+      state.soundEnabled = el.soundToggle.checked;
+      if (state.soundEnabled) ensureAudio();
+    });
+
+    ['pointerdown', 'pointermove', 'pointerup', 'pointercancel'].forEach((evt) => {
+      el.canvas.addEventListener(evt, (e) => {
+        if (state.mode !== 'game') return;
+        if (evt === 'pointerdown') {
+          ensureAudio();
+          state.pointerActive = true;
+          state.dragStart = pointerToCanvas(e);
+          state.dragCurrent = state.dragStart;
+        }
+        if (evt === 'pointermove' && state.pointerActive) {
+          state.dragCurrent = pointerToCanvas(e);
+          const p = clamp(Math.hypot(state.dragStart.x - state.dragCurrent.x, state.dragStart.y - state.dragCurrent.y) / 210, 0, 1);
+          el.powerMeterInner.style.height = `${Math.round(p * 100)}%`;
+        }
+        if ((evt === 'pointerup' || evt === 'pointercancel') && state.pointerActive) {
+          state.pointerActive = false;
+          if (!state.projectile && state.dragStart && state.dragCurrent) {
+            launchDart(state.dragStart, state.dragCurrent);
+          }
+          state.dragStart = null;
+          state.dragCurrent = null;
+        }
+      }, { passive: true });
+    });
+
+    el.adminTrigger.addEventListener('pointerdown', () => {
+      holdTimer = setTimeout(openAdmin, 3000);
+    });
+    ['pointerup', 'pointerleave', 'pointercancel'].forEach((evt) => {
+      el.adminTrigger.addEventListener(evt, () => {
+        clearTimeout(holdTimer);
+      });
+    });
+
+    el.saveAdminBtn.addEventListener('click', () => {
+      try {
+        const parsed = JSON.parse(el.adminJson.value);
+        state.config = deepMerge(structuredClone(DEFAULT_CONFIG), parsed);
+        saveConfig();
+        updateCounterUI();
+        el.adminDialog.close();
+      } catch {
+        alert('JSON形式が不正です。');
+      }
+    });
+
+    el.resetAdminBtn.addEventListener('click', () => {
+      state.config = structuredClone(DEFAULT_CONFIG);
+      saveConfig();
+      el.adminJson.value = JSON.stringify(state.config, null, 2);
+      updateCounterUI();
+    });
+
+    document.body.addEventListener('pointerdown', ensureAudio, { once: true });
+  }
+
+  function init() {
+    bindEvents();
+    updateCounterUI();
+    drawBoard();
+    requestAnimationFrame(loop);
+  }
+
+  init();
+})();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>串カウントダーツおみくじ</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div id="app" class="app">
+      <header class="top-bar">
+        <button id="adminTrigger" class="logo-btn" aria-label="管理画面を開く">🎯 KUSHI LUCK</button>
+        <div class="sound-wrap">
+          <label class="toggle">
+            <input id="soundToggle" type="checkbox" />
+            <span>音を有効化</span>
+          </label>
+        </div>
+      </header>
+
+      <main>
+        <section id="counterScreen" class="screen active">
+          <h1>串本数カウント</h1>
+          <p class="rule">プレイ回数: <strong id="shotRuleText"></strong></p>
+          <div class="counter-box">
+            <button id="minusBtn" class="big-btn" type="button">−</button>
+            <div class="count-display"><span id="kushiCount">0</span>本</div>
+            <button id="plusBtn" class="big-btn" type="button">+</button>
+          </div>
+          <div class="shot-display">遊べる回数: <span id="shotCount">0</span>回</div>
+          <button id="startGameBtn" class="primary-btn" type="button">ゲーム開始</button>
+        </section>
+
+        <section id="gameScreen" class="screen">
+          <div class="hud">
+            <div>残り <strong id="remainShots">0</strong> 回</div>
+            <div>串 <strong id="hudKushi">0</strong> 本</div>
+          </div>
+          <div class="board-wrap">
+            <canvas id="gameCanvas" width="900" height="580"></canvas>
+            <div id="powerMeter" class="power-meter"><span></span></div>
+            <div id="gameMessage" class="game-msg">ドラッグして狙い、離して発射！</div>
+          </div>
+        </section>
+
+        <section id="resultScreen" class="screen">
+          <div class="result-bg-glow"></div>
+          <article class="result-card">
+            <h2 id="fortuneText">大吉</h2>
+            <p id="prizeText">ドリンク無料</p>
+          </article>
+          <div class="result-actions">
+            <button id="nextPlayBtn" class="primary-btn" type="button">次のプレイ</button>
+            <button id="finishBtn" class="sub-btn" type="button">終了してカウンターへ</button>
+          </div>
+        </section>
+      </main>
+    </div>
+
+    <dialog id="adminDialog">
+      <form id="adminForm" method="dialog">
+        <h3>管理設定</h3>
+        <p>JSONを編集して保存できます。</p>
+        <textarea id="adminJson" spellcheck="false"></textarea>
+        <div class="admin-actions">
+          <button id="resetAdminBtn" type="button" class="sub-btn">初期値へリセット</button>
+          <button id="closeAdminBtn" type="submit" class="sub-btn">閉じる</button>
+          <button id="saveAdminBtn" type="button" class="primary-btn">保存</button>
+        </div>
+      </form>
+    </dialog>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,65 @@
+:root {
+  --bg: #0d1020;
+  --panel: #1a1f39;
+  --accent: #48deff;
+  --accent2: #ff4dd2;
+  --text: #f4f8ff;
+  --warn: #ffcc37;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; background: radial-gradient(circle at top, #202951 0%, var(--bg) 55%); color: var(--text); font-family: "Hiragino Kaku Gothic ProN", "Yu Gothic", sans-serif; min-height: 100%; touch-action: manipulation; }
+body { overscroll-behavior: none; }
+
+.app { max-width: 1024px; margin: 0 auto; min-height: 100vh; padding: 12px; display: grid; grid-template-rows: auto 1fr; gap: 8px; }
+.top-bar { display: flex; justify-content: space-between; align-items: center; gap: 12px; }
+.logo-btn { min-height: 44px; border: 0; border-radius: 14px; padding: 10px 14px; font-weight: 700; color: white; background: linear-gradient(120deg, #335dff, #8d3fff); }
+.toggle { display: inline-flex; gap: 8px; align-items: center; min-height: 44px; }
+.toggle input { width: 20px; height: 20px; }
+
+main { min-height: 0; }
+.screen { display: none; height: 100%; align-content: center; justify-items: center; gap: 16px; }
+.screen.active { display: grid; }
+
+h1, h2, h3 { margin: 0; }
+.rule { opacity: 0.9; }
+.counter-box { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 14px; width: min(700px, 100%); }
+.count-display { font-size: clamp(2rem, 7vw, 4.2rem); font-weight: 800; text-align: center; background: rgba(255,255,255,0.08); border-radius: 16px; padding: 14px 18px; min-height: 88px; display: flex; align-items: center; justify-content: center; }
+.big-btn, .primary-btn, .sub-btn { min-height: 54px; min-width: 54px; border: 0; border-radius: 16px; font-size: 1.05rem; font-weight: 700; color: #fff; }
+.big-btn { font-size: 2rem; background: linear-gradient(145deg, #34c4ff, #3364ff); }
+.primary-btn { background: linear-gradient(145deg, #ff4dd2, #7049ff); padding: 12px 24px; }
+.sub-btn { background: #404872; padding: 12px 16px; }
+.shot-display { font-size: clamp(1.2rem, 4.2vw, 1.8rem); }
+
+.hud { width: min(900px, 100%); display: flex; justify-content: space-between; font-size: 1.2rem; padding: 0 4px; }
+.board-wrap { position: relative; width: min(920px, 100%); border-radius: 20px; background: #080d20; border: 2px solid rgba(255,255,255,0.2); overflow: hidden; }
+#gameCanvas { width: 100%; height: auto; display: block; background: radial-gradient(circle at center, #1f2d5e 0%, #0e1430 60%, #070b1e 100%); touch-action: none; }
+.game-msg { position: absolute; left: 50%; transform: translateX(-50%); bottom: 12px; background: rgba(0,0,0,0.5); border-radius: 14px; padding: 8px 14px; font-weight: 700; }
+.power-meter { position: absolute; right: 12px; top: 12px; width: 22px; height: 180px; border-radius: 999px; border: 2px solid rgba(255,255,255,.45); background: rgba(0,0,0,.4); overflow: hidden; }
+.power-meter span { display: block; width: 100%; height: 0%; background: linear-gradient(180deg, #ffe155, #ff542d); transition: height .08s linear; }
+
+#resultScreen { position: relative; overflow: hidden; }
+.result-bg-glow { position: absolute; inset: 0; background: radial-gradient(circle, rgba(87,248,255,.4), rgba(255,78,203,.14), transparent 60%); animation: pulse 1.7s infinite; }
+.result-card { position: relative; z-index: 1; text-align: center; background: rgba(255,255,255,.08); border: 2px solid rgba(255,255,255,.25); border-radius: 22px; padding: 28px 36px; box-shadow: 0 0 40px rgba(72, 222, 255, .25); }
+#fortuneText { font-size: clamp(2.2rem, 9vw, 4.4rem); letter-spacing: .06em; }
+#prizeText { font-size: clamp(1.1rem, 5vw, 1.8rem); }
+.result-actions { position: relative; z-index: 1; display: flex; flex-wrap: wrap; gap: 12px; justify-content: center; }
+
+dialog { width: min(90vw, 760px); border-radius: 16px; border: 0; background: #171c35; color: #fff; }
+textarea { width: 100%; min-height: 280px; border-radius: 12px; background: #0d1228; color: #cde3ff; border: 1px solid #3d4570; padding: 12px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+.admin-actions { margin-top: 10px; display: flex; gap: 10px; justify-content: flex-end; flex-wrap: wrap; }
+
+.flash { animation: flash .35s ease-out; }
+.shake { animation: shake .4s ease-in-out; }
+
+@keyframes flash { from { filter: brightness(2.4); } to { filter: brightness(1);} }
+@keyframes shake { 0%,100%{ transform: translateX(0);} 20%{ transform: translateX(-6px);} 40%{ transform: translateX(5px);} 60%{ transform: translateX(-4px);} 80%{ transform: translateX(4px);} }
+@keyframes pulse { 0%,100%{ transform: scale(1); opacity: .7;} 50%{ transform: scale(1.08); opacity: 1; } }
+
+@media (max-width: 700px) {
+  .app { padding: 10px; }
+  .counter-box { gap: 8px; }
+  .big-btn { min-width: 64px; }
+  .hud { font-size: 1rem; }
+  .power-meter { height: 140px; }
+}


### PR DESCRIPTION
### Motivation
- Provide a single-file offline attraction app that converts input `串本数` into play `shots`, lets customers play a short (3–5s) dart/shooting mini‑game, and shows a visually strong omikuji result with configurable prizes. 
- Make the experience touch-first and deployable on iPad/phones with no external dependencies or build step.

### Description
- Added a self-contained vanilla implementation with UI and screens in `index.html`, styles/animations in `styles.css`, and game logic in `app.js`, plus an `assets/.gitkeep` and an expanded `README.md` (files: `index.html`, `styles.css`, `app.js`, `assets/.gitkeep`, `README.md`).
- Implemented COUNTER with large `+`/`-` buttons and shots conversion rule (`shots = floor(kushi_count / divisor)` with `minKushiForOneShot` and `minShots`), and GAME with touch/`pointer` drag-to-aim + release-to-launch, power meter, curved projectile (gravity/damping) and canvas target rings (SSR/SR/R/N).
- Separated visual aiming from outcome by using a configurable `prizeTable` with `rareFailProb` and `aimAssist` that slightly boosts SSR/SR based on aim quality, and implemented strong result effects (particles, flash/shake, WebAudio SE synthesis, `navigator.vibrate` safe calls).
- Added ADMIN accessible by long-pressing the top-right logo for 3s which opens a JSON editor persisted to `localStorage`, with save/reset and safe `deepMerge` merging of edits; also added runtime protections (try/catch fallbacks) and FPS-driven particle caps for low-end devices.

### Testing
- Static syntax check with `node --check app.js` succeeded and reported no parse errors.
- Ran a local static server with `python3 -m http.server 4173` and executed an automated Playwright script that navigated to `http://127.0.0.1:4173/index.html`, simulated counter increments, started a game, performed a drag‑throw, waited for result and captured screenshots, validating the `COUNTER -> GAME -> RESULT` flow; the script completed successfully.
- Manual interaction during the server run confirmed `AudioContext` resume flow on first pointer, admin long‑press open/save/reset, localStorage persistence, and particle/performance adaptation on lower FPS.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993e5cfba008329980fa42ea27acc76)