### PR TITLE
Add static lead-generation landing page with 3-step estimate form

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,172 @@
+(() => {
+  const form = document.getElementById("estimateForm");
+  const steps = Array.from(document.querySelectorAll(".step"));
+  const prevBtn = document.getElementById("prevBtn");
+  const nextBtn = document.getElementById("nextBtn");
+  const submitBtn = document.getElementById("submitBtn");
+  const progressBar = document.getElementById("progressBar");
+  const progressText = document.getElementById("progressText");
+  const result = document.getElementById("result");
+  const estimateRange = document.getElementById("estimateRange");
+  const estimateSummary = document.getElementById("estimateSummary");
+
+  const fieldIds = ["workType", "scale", "buildingAge", "timing", "contact"];
+  const storageKey = "estimateFormData";
+
+  const basePrices = {
+    外壁: { min: 45, max: 70 },
+    屋根: { min: 40, max: 65 },
+    水回り: { min: 35, max: 55 },
+    内装: { min: 30, max: 50 },
+    増改築: { min: 80, max: 130 },
+  };
+
+  const scaleFactor = { 小: 0.9, 中: 1.2, 大: 1.6 };
+
+  let currentStep = 1;
+
+  function saveData() {
+    const data = fieldIds.reduce((acc, id) => {
+      const element = document.getElementById(id);
+      acc[id] = element ? element.value : "";
+      return acc;
+    }, {});
+    localStorage.setItem(storageKey, JSON.stringify(data));
+  }
+
+  function loadData() {
+    const raw = localStorage.getItem(storageKey);
+    if (!raw) return;
+
+    try {
+      const parsed = JSON.parse(raw);
+      fieldIds.forEach((id) => {
+        const el = document.getElementById(id);
+        if (el && typeof parsed[id] === "string") {
+          el.value = parsed[id];
+        }
+      });
+    } catch {
+      localStorage.removeItem(storageKey);
+    }
+  }
+
+  function ageFactor(age) {
+    if (age <= 10) return 1;
+    if (age <= 20) return 1.12;
+    if (age <= 30) return 1.25;
+    return 1.4;
+  }
+
+  function clearErrors() {
+    ["errorStep1", "errorStep2", "errorStep3"].forEach((id) => {
+      const node = document.getElementById(id);
+      if (node) node.textContent = "";
+    });
+  }
+
+  function validateStep(step) {
+    clearErrors();
+
+    if (step === 1) {
+      const workType = document.getElementById("workType").value;
+      if (!workType) {
+        document.getElementById("errorStep1").textContent = "工事タイプを選択してください。";
+        return false;
+      }
+      return true;
+    }
+
+    if (step === 2) {
+      const scale = document.getElementById("scale").value;
+      const buildingAge = Number(document.getElementById("buildingAge").value);
+      if (!scale) {
+        document.getElementById("errorStep2").textContent = "工事規模を選択してください。";
+        return false;
+      }
+      if (!Number.isFinite(buildingAge) || buildingAge < 0 || buildingAge > 120) {
+        document.getElementById("errorStep2").textContent = "築年数は0〜120の範囲で入力してください。";
+        return false;
+      }
+      return true;
+    }
+
+    const timing = document.getElementById("timing").value;
+    const contact = document.getElementById("contact").value.trim();
+    if (!timing) {
+      document.getElementById("errorStep3").textContent = "希望時期を選択してください。";
+      return false;
+    }
+    if (contact.length < 6) {
+      document.getElementById("errorStep3").textContent = "連絡先を正しく入力してください。";
+      return false;
+    }
+    return true;
+  }
+
+  function updateStepUI() {
+    steps.forEach((stepEl, index) => {
+      const stepNo = index + 1;
+      const active = stepNo === currentStep;
+      stepEl.hidden = !active;
+      stepEl.classList.toggle("is-active", active);
+    });
+
+    prevBtn.disabled = currentStep === 1;
+    nextBtn.hidden = currentStep === steps.length;
+    submitBtn.hidden = currentStep !== steps.length;
+
+    const progressPercent = (currentStep / steps.length) * 100;
+    progressBar.style.width = `${progressPercent}%`;
+    progressText.textContent = `Step ${currentStep} / ${steps.length}`;
+  }
+
+  function calculateEstimate() {
+    const workType = document.getElementById("workType").value;
+    const scale = document.getElementById("scale").value;
+    const buildingAge = Number(document.getElementById("buildingAge").value);
+    const timing = document.getElementById("timing").value;
+
+    const base = basePrices[workType];
+    const factor = (scaleFactor[scale] || 1) * ageFactor(buildingAge);
+    const min = Math.round(base.min * factor);
+    const max = Math.round(base.max * factor);
+
+    estimateRange.textContent = `${min}〜${max}万円`;
+    estimateSummary.textContent = `${workType}・${scale}規模・築${buildingAge}年を想定した概算です。希望時期は「${timing}」として受付しました。`; 
+    result.hidden = false;
+    result.scrollIntoView({ behavior: "smooth", block: "start" });
+
+    const finalCta = document.getElementById("final-cta");
+    finalCta.classList.add("highlight");
+    setTimeout(() => finalCta.classList.remove("highlight"), 1800);
+  }
+
+  prevBtn.addEventListener("click", () => {
+    if (currentStep > 1) {
+      currentStep -= 1;
+      updateStepUI();
+      clearErrors();
+    }
+  });
+
+  nextBtn.addEventListener("click", () => {
+    if (!validateStep(currentStep)) return;
+    saveData();
+    currentStep += 1;
+    updateStepUI();
+  });
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    if (!validateStep(currentStep)) return;
+    saveData();
+    calculateEstimate();
+  });
+
+  form.addEventListener("input", saveData);
+  form.addEventListener("change", saveData);
+
+  loadData();
+  updateStepUI();
+})();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,223 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="地元密着の建築工事会社。無料現地調査・概算見積を30秒で。雨漏り、外壁、屋根、水回り、内装、増改築まで迅速対応。" />
+    <title>無料現地調査・概算見積 | 地元密着の建築工事会社</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#estimate">概算フォームへスキップ</a>
+
+    <header class="site-header" aria-label="ページ上部">
+      <div class="container header-inner">
+        <p class="brand">まちの建築工事サポート</p>
+        <a class="header-phone" href="tel:0312345678" aria-label="電話で相談 03-1234-5678">📞 03-1234-5678</a>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero" aria-labelledby="hero-title">
+        <div class="container hero-grid">
+          <div>
+            <p class="pill">地域密着・最短2日で訪問</p>
+            <h1 id="hero-title">無料現地調査で、<br />失敗しない工事計画を。</h1>
+            <p class="hero-lead">
+              雨漏り修繕から増改築まで。現地確認のうえ、わかりやすい概算見積をご案内します。
+              しつこい営業は一切なし。
+            </p>
+            <div class="hero-cta" role="group" aria-label="お問い合わせ方法">
+              <a class="btn btn-primary" href="#estimate">無料現地調査を申し込む</a>
+              <a class="btn btn-line" href="#final-cta">LINEで相談する</a>
+            </div>
+            <ul class="hero-points" aria-label="訴求ポイント">
+              <li>見積の内訳を明確提示</li>
+              <li>近隣への配慮を徹底</li>
+              <li>工事後の保証付き</li>
+            </ul>
+          </div>
+          <aside class="hero-card" aria-label="初回相談の案内">
+            <h2>初回相談は0円</h2>
+            <p>最短2日で現地訪問。現況確認から概算まで当日中に目安提示します。</p>
+            <a class="btn btn-secondary" href="tel:0312345678">今すぐ電話相談</a>
+          </aside>
+        </div>
+      </section>
+
+      <section class="section" aria-labelledby="problems-title">
+        <div class="container">
+          <h2 id="problems-title">こんなお悩みありませんか？</h2>
+          <div class="card-grid">
+            <article class="problem-card">
+              <h3>雨漏りが止まらない</h3>
+              <p>天井や壁のシミ、カビが気になる。早急に原因を特定して直したい。</p>
+            </article>
+            <article class="problem-card">
+              <h3>外壁のひび割れ・色あせ</h3>
+              <p>見た目の劣化だけでなく、防水性能の低下も心配。</p>
+            </article>
+            <article class="problem-card">
+              <h3>間取りを変えて暮らしやすく</h3>
+              <p>家族構成の変化に合わせて、内装・動線を見直したい。</p>
+            </article>
+            <article class="problem-card">
+              <h3>耐震面が不安</h3>
+              <p>築年数が経ち、地震への備えを具体的に進めたい。</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="estimate" class="section section-alt" aria-labelledby="estimate-title">
+        <div class="container">
+          <h2 id="estimate-title">30秒かんたん概算見積</h2>
+          <p class="section-lead">3ステップ入力で、目安費用レンジをすぐ確認できます。</p>
+
+          <div class="progress-wrap" aria-label="フォーム進行状況">
+            <div class="progress-track" aria-hidden="true">
+              <div id="progressBar" class="progress-bar"></div>
+            </div>
+            <p id="progressText" class="progress-text" aria-live="polite">Step 1 / 3</p>
+          </div>
+
+          <form id="estimateForm" novalidate>
+            <fieldset class="step is-active" data-step="1" aria-labelledby="step1-title">
+              <legend id="step1-title">Step1 工事タイプ</legend>
+              <label for="workType">工事タイプを選択</label>
+              <select id="workType" name="workType" required>
+                <option value="">選択してください</option>
+                <option value="外壁">外壁</option>
+                <option value="屋根">屋根</option>
+                <option value="水回り">水回り</option>
+                <option value="内装">内装</option>
+                <option value="増改築">増改築</option>
+              </select>
+              <p class="error" id="errorStep1" aria-live="polite"></p>
+            </fieldset>
+
+            <fieldset class="step" data-step="2" aria-labelledby="step2-title" hidden>
+              <legend id="step2-title">Step2 規模と築年数</legend>
+              <label for="scale">工事規模</label>
+              <select id="scale" name="scale" required>
+                <option value="">選択してください</option>
+                <option value="小">小規模</option>
+                <option value="中">中規模</option>
+                <option value="大">大規模</option>
+              </select>
+
+              <label for="buildingAge">築年数（年）</label>
+              <input id="buildingAge" name="buildingAge" type="number" min="0" max="120" inputmode="numeric" required placeholder="例: 18" />
+              <p class="error" id="errorStep2" aria-live="polite"></p>
+            </fieldset>
+
+            <fieldset class="step" data-step="3" aria-labelledby="step3-title" hidden>
+              <legend id="step3-title">Step3 希望時期と連絡先</legend>
+              <label for="timing">希望時期</label>
+              <select id="timing" name="timing" required>
+                <option value="">選択してください</option>
+                <option value="急ぎ">急ぎ</option>
+                <option value="1ヶ月以内">1ヶ月以内</option>
+                <option value="未定">未定</option>
+              </select>
+
+              <label for="contact">連絡先（電話番号 or メール）</label>
+              <input id="contact" name="contact" type="text" required placeholder="09012345678 または sample@example.com" />
+              <p class="error" id="errorStep3" aria-live="polite"></p>
+            </fieldset>
+
+            <div class="form-nav">
+              <button type="button" id="prevBtn" class="btn btn-ghost" disabled>戻る</button>
+              <button type="button" id="nextBtn" class="btn btn-primary">次へ</button>
+              <button type="submit" id="submitBtn" class="btn btn-primary" hidden>概算を表示</button>
+            </div>
+          </form>
+
+          <section id="result" class="result" aria-live="polite" hidden>
+            <h3>あなたの概算レンジ</h3>
+            <p id="estimateRange" class="estimate-range"></p>
+            <p id="estimateSummary"></p>
+            <div class="result-cta">
+              <a href="#final-cta" class="btn btn-accent">この内容で無料現地調査を依頼する</a>
+            </div>
+          </section>
+        </div>
+      </section>
+
+      <section class="section" aria-labelledby="cases-title">
+        <div class="container">
+          <h2 id="cases-title">施工事例（ダミー）</h2>
+          <div class="case-grid">
+            <article class="case-card">
+              <h3>外壁補修・塗装</h3>
+              <p><strong>Before:</strong> ひび割れ、色褪せが目立つ状態</p>
+              <p><strong>After:</strong> 高耐候塗料で美観・防水性能を回復</p>
+            </article>
+            <article class="case-card">
+              <h3>キッチン改修</h3>
+              <p><strong>Before:</strong> 動線が悪く収納不足</p>
+              <p><strong>After:</strong> 家事効率を高めるレイアウトへ刷新</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section-alt" aria-labelledby="reasons-title">
+        <div class="container">
+          <h2 id="reasons-title">選ばれる3つの理由</h2>
+          <div class="reason-grid">
+            <article>
+              <h3>料金が透明</h3>
+              <p>工事項目ごとに費用を明示。追加費用の条件も事前に説明します。</p>
+            </article>
+            <article>
+              <h3>近隣配慮を徹底</h3>
+              <p>着工前のご挨拶や騒音時間の管理など、トラブル予防を重視。</p>
+            </article>
+            <article>
+              <h3>保証で施工後も安心</h3>
+              <p>工事内容に応じた保証制度を用意。アフターフォローも迅速です。</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" aria-labelledby="faq-title">
+        <div class="container">
+          <h2 id="faq-title">よくある質問</h2>
+          <div class="faq-list">
+            <details>
+              <summary>現地調査は本当に無料ですか？</summary>
+              <p>はい。調査・ご相談・概算見積の提示まで無料で対応しています。</p>
+            </details>
+            <details>
+              <summary>相見積もりでも相談できますか？</summary>
+              <p>もちろん可能です。比較しやすい形式で見積内訳をご案内します。</p>
+            </details>
+            <details>
+              <summary>小さな修繕でも依頼できますか？</summary>
+              <p>はい。小規模修繕から増改築まで幅広く対応可能です。</p>
+            </details>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <section id="final-cta" class="final-cta" aria-labelledby="final-cta-title">
+      <div class="container final-cta-inner">
+        <h2 id="final-cta-title">まずは無料で、現地調査と概算見積を。</h2>
+        <div class="cta-buttons">
+          <a class="btn btn-secondary" href="tel:0312345678">📞 電話で相談する</a>
+          <a class="btn btn-primary" href="#estimate">フォームから申し込む</a>
+        </div>
+      </div>
+    </section>
+
+    <div class="sticky-cta" role="region" aria-label="固定お問い合わせ">
+      <a href="tel:0312345678" class="sticky-btn phone">電話する</a>
+      <a href="#estimate" class="sticky-btn form">無料見積</a>
+    </div>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,351 @@
+:root {
+  --bg: #f7f9fc;
+  --surface: #ffffff;
+  --text: #1f2937;
+  --muted: #4b5563;
+  --primary: #0f62fe;
+  --primary-dark: #0043ce;
+  --accent: #ff7a00;
+  --line: #06c755;
+  --border: #d8e1ef;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Hiragino Kaku Gothic ProN", "Yu Gothic", sans-serif;
+  line-height: 1.7;
+  color: var(--text);
+  background: var(--bg);
+}
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: 0;
+  background: #000;
+  color: #fff;
+  padding: 8px;
+}
+
+.skip-link:focus {
+  left: 8px;
+  z-index: 999;
+}
+
+.container {
+  width: min(1080px, 92%);
+  margin: 0 auto;
+}
+
+.site-header {
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+}
+
+.header-inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 0;
+}
+
+.brand {
+  margin: 0;
+  font-weight: 700;
+}
+
+.header-phone {
+  color: var(--primary-dark);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.hero {
+  background: linear-gradient(140deg, #eaf2ff, #f8fbff 60%, #ffffff);
+  padding: 48px 0;
+}
+
+.hero-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: 2fr 1fr;
+}
+
+.pill {
+  display: inline-block;
+  margin: 0 0 8px;
+  background: #dce9ff;
+  color: #00318a;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+
+h1,
+h2,
+h3 {
+  line-height: 1.3;
+}
+
+.hero-lead {
+  color: var(--muted);
+}
+
+.hero-cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin: 20px 0;
+}
+
+.hero-points {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.hero-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 20px;
+  box-shadow: 0 10px 26px rgba(0, 30, 80, 0.08);
+}
+
+.btn {
+  display: inline-block;
+  border: 0;
+  border-radius: 10px;
+  padding: 12px 18px;
+  font-weight: 700;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.btn:focus-visible,
+input:focus-visible,
+select:focus-visible,
+summary:focus-visible {
+  outline: 3px solid #f59e0b;
+  outline-offset: 2px;
+}
+
+.btn-primary {
+  background: var(--primary);
+  color: #fff;
+}
+
+.btn-primary:hover {
+  background: var(--primary-dark);
+}
+
+.btn-secondary {
+  background: #13233f;
+  color: #fff;
+}
+
+.btn-line {
+  background: var(--line);
+  color: #fff;
+}
+
+.btn-ghost {
+  background: #edf2fa;
+  color: var(--text);
+}
+
+.btn-accent {
+  background: var(--accent);
+  color: #fff;
+}
+
+.section {
+  padding: 56px 0;
+}
+
+.section-alt {
+  background: #eef4ff;
+}
+
+.section-lead {
+  margin-top: -8px;
+  color: var(--muted);
+}
+
+.card-grid,
+.case-grid,
+.reason-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.problem-card,
+.case-card,
+.reason-grid article {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 18px;
+}
+
+.progress-wrap {
+  margin: 14px 0 22px;
+}
+
+.progress-track {
+  width: 100%;
+  height: 10px;
+  background: #d9e6ff;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-bar {
+  height: 100%;
+  width: 33.3%;
+  background: var(--primary);
+  transition: width 0.3s ease;
+}
+
+.progress-text {
+  margin: 8px 0 0;
+  font-weight: 600;
+}
+
+form {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 24px;
+}
+
+.step {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.step legend {
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+
+label {
+  display: block;
+  margin: 12px 0 6px;
+  font-weight: 600;
+}
+
+input,
+select {
+  width: 100%;
+  padding: 11px;
+  border: 1px solid #bccae2;
+  border-radius: 8px;
+  font-size: 1rem;
+}
+
+.error {
+  min-height: 1.2em;
+  color: #b91c1c;
+  margin-top: 8px;
+  font-size: 0.9rem;
+}
+
+.form-nav {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.result {
+  margin-top: 20px;
+  background: #fff7ed;
+  border: 1px solid #fed7aa;
+  border-radius: 12px;
+  padding: 16px;
+}
+
+.estimate-range {
+  font-size: 1.6rem;
+  font-weight: 800;
+  color: #9a3412;
+}
+
+.faq-list details {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px 14px;
+  margin-bottom: 10px;
+}
+
+.final-cta {
+  padding: 60px 0 92px;
+  background: #13233f;
+  color: #fff;
+}
+
+.final-cta-inner {
+  text-align: center;
+}
+
+.cta-buttons {
+  margin-top: 18px;
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.sticky-cta {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  z-index: 40;
+}
+
+.sticky-btn {
+  text-align: center;
+  text-decoration: none;
+  color: #fff;
+  font-weight: 800;
+  padding: 12px 10px;
+}
+
+.sticky-btn.phone {
+  background: #111827;
+}
+
+.sticky-btn.form {
+  background: var(--accent);
+}
+
+@media (max-width: 820px) {
+  .hero-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .form-nav {
+    flex-wrap: wrap;
+  }
+
+  .form-nav .btn {
+    flex: 1 1 48%;
+    text-align: center;
+  }
+}
+
+.final-cta.highlight {
+  box-shadow: inset 0 0 0 4px #f59e0b;
+  transition: box-shadow 0.2s ease;
+}


### PR DESCRIPTION
### Motivation
- 地元密着の建築工事会社向けに「無料現地調査」「概算見積」への申込みを最大化するため、外部ライブラリなしの静的LPを用意しました。
- 単一ページで申込み導線（ヒーロー、ステップフォーム、最終CTA）を完結させ、導線の離脱を減らすことを目的としています。

### Description
- 追加ファイル: `index.html`（構造と全セクション）、`styles.css`（レスポンシブ・アクセシビリティ対応のスタイル）、`app.js`（ステップフォーム制御・検証・概算計算・`localStorage`保存）。
- 3ステップ概算フォームを実装し、プログレスバー、次へ／戻る／送信、各ステップの入力検証、結果表示後のCTA強調（ハイライト）を実装しました。概算は `workType` × `scale` × `buildingAge` の簡易テーブルと係数で算出します。
- UX/アクセシビリティ改善として `skip-link`、`aria-live`、フォーカス可視化、固定（sticky）CTAを追加しました。
- スタイルはビジュアル優先でCTAを強調しつつモバイル対応を行い、JavaScriptは純粋なバニラで永続化と復元を行います。

### Testing
- サーバ起動: `python -m http.server 4173` によりローカルでページを配信してレンダリングを確認しました（成功）。
- 自動確認: Playwrightスクリプトで `http://localhost:4173` を開き、フルページのスクリーンショットを取得してUIを検証しました（成功）。
- 以上の自動チェックでページ表示・アセット読み込み・フォームUIの初期表示が正常であることを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ff2756a648329887e5acb042990e6)