### PR TITLE
Implement pure HTML/CSS/JS local construction LP with auto-support chat

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,440 @@
+const services = [
+  { name: '外壁', desc: '塗装・ひび補修・防水まで、建物を長持ちさせる外壁メンテナンス。' },
+  { name: '屋根', desc: '雨漏り診断、カバー工法、葺き替えなど屋根の状態に合わせて対応。' },
+  { name: '水回り', desc: 'キッチン・浴室・トイレ・洗面台の交換や使い勝手改善。' },
+  { name: '内装', desc: 'クロス・床材・間取り変更など、暮らしに合わせた内装改修。' },
+  { name: '外構', desc: '門扉・フェンス・駐車場・アプローチの整備やデザイン提案。' },
+  { name: '小修繕', desc: '建具調整、コーキング、軽微な雨漏りなど小さなお困りごとにも対応。' }
+];
+
+const cases = [
+  { id: 1, title: '外壁塗装・防水改修', category: '外壁', area: '〇〇市中央', ageRange: '21〜30', costMin: 72, costMax: 98, durationDays: 14, highlights: ['高耐候塗料', 'ひび補修', '近隣挨拶'] },
+  { id: 2, title: '屋根カバー工法', category: '屋根', area: '△△町東', ageRange: '31〜', costMin: 88, costMax: 130, durationDays: 11, highlights: ['遮熱材', '雨漏り対策', '短工期'] },
+  { id: 3, title: '浴室リニューアル', category: '水回り', area: '□□区南', ageRange: '11〜20', costMin: 55, costMax: 94, durationDays: 7, highlights: ['断熱浴槽', '段差解消', '清掃性向上'] },
+  { id: 4, title: '店舗内装刷新', category: '店舗', area: '〇〇市駅前', ageRange: '11〜20', costMin: 120, costMax: 220, durationDays: 20, highlights: ['営業動線改善', '照明更新', '短期施工'] },
+  { id: 5, title: '外構フェンス新設', category: '外構', area: '△△町西', ageRange: '〜10', costMin: 38, costMax: 70, durationDays: 6, highlights: ['目隠し性向上', '防犯性', '景観調和'] },
+  { id: 6, title: '和室から洋室へ改装', category: '内装', area: '□□区北', ageRange: '21〜30', costMin: 48, costMax: 110, durationDays: 10, highlights: ['床断熱', '収納増設', 'バリアフリー'] },
+  { id: 7, title: '外壁部分補修', category: '外壁', area: '〇〇市西', ageRange: '31〜', costMin: 26, costMax: 48, durationDays: 4, highlights: ['漏水予防', '色合わせ', '最短着工'] },
+  { id: 8, title: '屋根塗装メンテナンス', category: '屋根', area: '△△町中央', ageRange: '11〜20', costMin: 40, costMax: 72, durationDays: 8, highlights: ['遮熱塗装', '下地洗浄', '足場設置'] },
+  { id: 9, title: 'キッチン入替工事', category: '水回り', area: '□□区中央', ageRange: '21〜30', costMin: 68, costMax: 140, durationDays: 9, highlights: ['収納改善', '省エネ設備', '配管更新'] },
+  { id: 10, title: 'マンション内装改修', category: '内装', area: '〇〇市南', ageRange: '31〜', costMin: 80, costMax: 170, durationDays: 16, highlights: ['騒音配慮', '工程管理', '共用部養生'] },
+  { id: 11, title: '駐車場土間打ち', category: '外構', area: '△△町北', ageRange: '〜10', costMin: 42, costMax: 90, durationDays: 5, highlights: ['排水勾配', '耐久仕上げ', '車止め設置'] },
+  { id: 12, title: '店舗ファサード補修', category: '店舗', area: '□□区駅前', ageRange: '31〜', costMin: 60, costMax: 120, durationDays: 7, highlights: ['意匠維持', '防水強化', '営業配慮'] }
+];
+
+const faq = [
+  { q: '見積は無料ですか？', a: 'はい、現地確認を含めて無料です。内容と費用を明確にご説明します。', tags: ['費用', '見積'] },
+  { q: '工期はどのくらいかかりますか？', a: '内容により異なりますが、外壁で1〜2週間、水回りで3日〜10日程度が目安です。', tags: ['工期'] },
+  { q: '保証はありますか？', a: '施工内容に応じて保証書を発行し、最長10年の保証に対応しています。', tags: ['保証'] },
+  { q: '近隣への配慮はしてくれますか？', a: '着工前のご挨拶、騒音時間帯の管理、日々の清掃を徹底しています。', tags: ['近隣', '騒音'] },
+  { q: '支払い方法を教えてください。', a: '銀行振込に対応しています。工事規模により分割タイミングをご相談いただけます。', tags: ['支払い'] },
+  { q: '小さな修繕でも頼めますか？', a: 'はい、ドア調整やコーキング補修などの小修繕も承ります。', tags: ['小修繕'] },
+  { q: '雨漏りの緊急対応は可能ですか？', a: '状況次第で当日対応も可能です。まずはお電話ください。', tags: ['屋根', '緊急'] },
+  { q: '工事中は在宅が必要ですか？', a: '外部工事は不在でも進められる場合があります。内装工事は工程ごとにご相談します。', tags: ['工期', '内装'] },
+  { q: '追加料金が心配です。', a: '追加が必要な場合は事前説明と合意を徹底し、勝手に進めることはありません。', tags: ['費用', '見積'] },
+  { q: '店舗工事の夜間対応はできますか？', a: '営業への影響を抑えるため、工程次第で夜間・休日対応をご提案できます。', tags: ['店舗', '工期'] }
+];
+
+const estimateMatrix = {
+  base: { 外壁: 60, 屋根: 50, 水回り: 40, 内装: 45, 外構: 35, 小修繕: 8 },
+  scale: { 小: 0.8, 中: 1.1, 大: 1.5 },
+  age: { '〜10': 0.95, '11〜20': 1.0, '21〜30': 1.15, '31〜': 1.3 },
+  property: { 戸建: 1.0, マンション: 1.12, 店舗: 1.25 }
+};
+
+const state = {
+  caseFilter: 'all',
+  chatOpen: false,
+  estimateDraft: { type: null, scale: null, age: null, property: null },
+  chatStep: 'menu'
+};
+
+const els = {
+  serviceCards: document.getElementById('service-cards'),
+  casesGrid: document.getElementById('cases-grid'),
+  filterBtns: document.querySelectorAll('.filter-btn'),
+  faqList: document.getElementById('faq-list'),
+  chatToggle: document.getElementById('chat-toggle'),
+  chatPanel: document.getElementById('chat-panel'),
+  chatClose: document.getElementById('chat-close'),
+  chatLog: document.getElementById('chat-log'),
+  chatActions: document.getElementById('chat-quick-actions'),
+  chatForm: document.getElementById('chat-form'),
+  chatInput: document.getElementById('chat-input'),
+  chatShortcut: document.getElementById('chat-shortcut'),
+  contactForm: document.getElementById('contact-form'),
+  toast: document.getElementById('toast')
+};
+
+const STORAGE_KEY = 'local-construction-chat';
+
+function init() {
+  renderServices();
+  renderCases();
+  bindCaseFilter();
+  renderFaq();
+  setupAccordion();
+  setupSmoothAnchors();
+  setupChat();
+  setupFormValidation();
+  setupReveals();
+}
+
+function renderServices() {
+  const frag = document.createDocumentFragment();
+  services.forEach((service) => {
+    const article = document.createElement('article');
+    article.className = 'card';
+    article.innerHTML = `<span class="service-badge">対応工事</span><h3>${service.name}</h3><p>${service.desc}</p>`;
+    frag.appendChild(article);
+  });
+  els.serviceCards.appendChild(frag);
+}
+
+function renderCases() {
+  const filtered = state.caseFilter === 'all' ? cases : cases.filter((item) => item.category === state.caseFilter);
+  const frag = document.createDocumentFragment();
+  filtered.forEach((item) => {
+    const article = document.createElement('article');
+    article.className = 'card';
+    article.innerHTML = `
+      <div class="placeholder-image"><span>${item.category} 施工写真</span></div>
+      <h3>${item.title}</h3>
+      <p class="case-meta">
+        <span>地域：${item.area}</span>
+        <span>築年数：${item.ageRange}</span>
+        <span>費用：${item.costMin}〜${item.costMax}万円</span>
+        <span>工期：約${item.durationDays}日</span>
+      </p>
+      <ul class="highlights">${item.highlights.map((h) => `<li>${h}</li>`).join('')}</ul>
+    `;
+    frag.appendChild(article);
+  });
+  els.casesGrid.replaceChildren(frag);
+}
+
+function bindCaseFilter() {
+  els.filterBtns.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      state.caseFilter = btn.dataset.filter;
+      els.filterBtns.forEach((item) => item.classList.toggle('active', item === btn));
+      renderCases();
+    });
+  });
+}
+
+function renderFaq() {
+  const frag = document.createDocumentFragment();
+  faq.forEach((item, index) => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'accordion-item';
+    wrapper.innerHTML = `
+      <h3>
+        <button class="accordion-trigger" type="button" aria-expanded="false" aria-controls="faq-panel-${index}" id="faq-trigger-${index}">
+          ${item.q}
+        </button>
+      </h3>
+      <div class="accordion-panel" id="faq-panel-${index}" role="region" aria-labelledby="faq-trigger-${index}" hidden>
+        ${item.a}
+      </div>
+    `;
+    frag.appendChild(wrapper);
+  });
+  els.faqList.appendChild(frag);
+}
+
+function setupAccordion() {
+  els.faqList.addEventListener('click', (event) => {
+    const trigger = event.target.closest('.accordion-trigger');
+    if (!trigger) return;
+    toggleAccordion(trigger);
+  });
+
+  els.faqList.addEventListener('keydown', (event) => {
+    const trigger = event.target.closest('.accordion-trigger');
+    if (!trigger) return;
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      toggleAccordion(trigger);
+    }
+  });
+}
+
+function toggleAccordion(trigger) {
+  const expanded = trigger.getAttribute('aria-expanded') === 'true';
+  const panel = document.getElementById(trigger.getAttribute('aria-controls'));
+  trigger.setAttribute('aria-expanded', String(!expanded));
+  panel.hidden = expanded;
+}
+
+function setupSmoothAnchors() {
+  document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
+    anchor.addEventListener('click', (event) => {
+      const targetId = anchor.getAttribute('href');
+      const target = document.querySelector(targetId);
+      if (!target) return;
+      event.preventDefault();
+      target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+  });
+}
+
+function setupChat() {
+  loadChatState();
+  renderInitialChat();
+
+  els.chatToggle.addEventListener('click', () => toggleChat());
+  els.chatClose.addEventListener('click', () => toggleChat(false));
+  els.chatShortcut.addEventListener('click', () => toggleChat(true));
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && state.chatOpen) toggleChat(false);
+  });
+
+  els.chatActions.addEventListener('click', (event) => {
+    const btn = event.target.closest('button[data-action]');
+    if (!btn) return;
+    handleChatAction(btn.dataset.action, btn.dataset.value);
+  });
+
+  els.chatForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const value = els.chatInput.value.trim();
+    if (!value) return;
+    appendChat('user', value);
+    els.chatInput.value = '';
+    replyFaqByKeyword(value);
+  });
+}
+
+function toggleChat(force) {
+  state.chatOpen = typeof force === 'boolean' ? force : !state.chatOpen;
+  els.chatPanel.hidden = !state.chatOpen;
+  els.chatToggle.setAttribute('aria-expanded', String(state.chatOpen));
+  if (state.chatOpen) {
+    els.chatInput.focus();
+  } else {
+    els.chatToggle.focus();
+  }
+  saveChatState();
+}
+
+function renderInitialChat() {
+  if (!els.chatLog.children.length) {
+    appendChat('bot', 'こんにちは。かんたん質問へようこそ。ご希望に合わせてすぐご案内します。');
+  }
+  renderMenuActions();
+  if (state.chatOpen) {
+    els.chatPanel.hidden = false;
+    els.chatToggle.setAttribute('aria-expanded', 'true');
+  }
+}
+
+function renderMenuActions() {
+  state.chatStep = 'menu';
+  els.chatActions.innerHTML = `
+    <button type="button" class="quick-btn" data-action="startEstimate">概算を知りたい</button>
+    <button type="button" class="quick-btn" data-action="recommendCases">近い施工事例を見たい</button>
+    <button type="button" class="quick-btn" data-action="showFaq">よくある質問</button>
+    <button type="button" class="quick-btn" data-action="goContact">オペレーターに相談</button>
+  `;
+}
+
+function handleChatAction(action, value = '') {
+  switch (action) {
+    case 'startEstimate':
+      appendChat('bot', '概算チェックを始めます。まず工事タイプを選んでください。');
+      state.chatStep = 'estimate_type';
+      renderOptions(['外壁', '屋根', '水回り', '内装', '外構', '小修繕'], 'estimateType');
+      break;
+    case 'estimateType':
+      state.estimateDraft.type = value;
+      appendChat('user', `工事タイプ：${value}`);
+      appendChat('bot', '規模を選んでください。');
+      state.chatStep = 'estimate_scale';
+      renderOptions(['小', '中', '大'], 'estimateScale');
+      break;
+    case 'estimateScale':
+      state.estimateDraft.scale = value;
+      appendChat('user', `規模：${value}`);
+      appendChat('bot', '築年数を選んでください。');
+      state.chatStep = 'estimate_age';
+      renderOptions(['〜10', '11〜20', '21〜30', '31〜'], 'estimateAge');
+      break;
+    case 'estimateAge':
+      state.estimateDraft.age = value;
+      appendChat('user', `築年数：${value}`);
+      appendChat('bot', '物件種別を選んでください。');
+      state.chatStep = 'estimate_property';
+      renderOptions(['戸建', 'マンション', '店舗'], 'estimateProperty');
+      break;
+    case 'estimateProperty':
+      state.estimateDraft.property = value;
+      appendChat('user', `物件種別：${value}`);
+      showEstimateResult();
+      saveChatState();
+      break;
+    case 'recommendCases':
+      appendChat('bot', '工事タイプ別のおすすめ事例を表示します。');
+      renderOptions(['外壁', '屋根', '水回り', '内装', '外構', '店舗'], 'pickCaseType');
+      break;
+    case 'pickCaseType':
+      appendChat('user', `事例タイプ：${value}`);
+      recommendCases(value);
+      break;
+    case 'showFaq':
+      appendChat('bot', '気になる項目を選んでください。');
+      renderOptions(['費用', '工期', '保証', '近隣', '支払い', '騒音'], 'faqTopic');
+      break;
+    case 'faqTopic':
+      appendChat('user', `質問カテゴリ：${value}`);
+      replyFaqByKeyword(value);
+      break;
+    case 'moreCases':
+      document.getElementById('cases').scrollIntoView({ behavior: 'smooth' });
+      state.caseFilter = value;
+      els.filterBtns.forEach((btn) => btn.classList.toggle('active', btn.dataset.filter === value));
+      renderCases();
+      appendChat('bot', `「${value}」の実績一覧へ移動しました。`);
+      renderMenuActions();
+      break;
+    case 'goContact':
+      appendChat('bot', '担当者へ引き継ぎます。お問い合わせフォームへご案内します。');
+      document.getElementById('contact').scrollIntoView({ behavior: 'smooth' });
+      renderMenuActions();
+      break;
+    default:
+      renderMenuActions();
+  }
+}
+
+function renderOptions(options, actionName) {
+  els.chatActions.innerHTML = options
+    .map((option) => `<button type="button" class="quick-btn" data-action="${actionName}" data-value="${option}">${option}</button>`)
+    .join('');
+}
+
+function showEstimateResult() {
+  const { type, scale, age, property } = state.estimateDraft;
+  const base = estimateMatrix.base[type];
+  const multiplier = estimateMatrix.scale[scale] * estimateMatrix.age[age] * estimateMatrix.property[property];
+  const center = base * multiplier;
+  const min = Math.round(center * 0.85);
+  const max = Math.round(center * 1.2);
+  appendChat('bot', `概算レンジ：${min}〜${max}万円です。\n※ 現地調査・下地状況で金額は変動します。`);
+  renderMenuActions();
+}
+
+function recommendCases(category) {
+  const picks = cases.filter((item) => item.category === category).slice(0, 3);
+  if (!picks.length) {
+    appendChat('bot', '条件に近い事例が見つかりませんでした。フォームからご相談ください。');
+    renderMenuActions();
+    return;
+  }
+
+  picks.forEach((item) => {
+    appendChat('bot', `${item.title}\n${item.area} / ${item.costMin}〜${item.costMax}万円 / 約${item.durationDays}日\n要点: ${item.highlights.join('・')}`);
+  });
+
+  els.chatActions.innerHTML = `<button type="button" class="quick-btn" data-action="moreCases" data-value="${category}">もっと見る</button>`;
+}
+
+function replyFaqByKeyword(input) {
+  const normalized = input.trim();
+  const matched = faq.find((item) => item.tags.some((tag) => normalized.includes(tag)) || item.q.includes(normalized));
+  if (matched) {
+    appendChat('bot', `${matched.q}\n${matched.a}`);
+  } else {
+    appendChat('bot', '該当回答が見つかりませんでした。内容を詳しく入力いただくか、フォームからご相談ください。');
+  }
+  renderMenuActions();
+}
+
+function appendChat(type, text) {
+  const msg = document.createElement('p');
+  msg.className = `chat-msg ${type}`;
+  msg.innerText = text;
+  els.chatLog.appendChild(msg);
+  els.chatLog.scrollTop = els.chatLog.scrollHeight;
+}
+
+function saveChatState() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify({
+    open: state.chatOpen,
+    estimateDraft: state.estimateDraft
+  }));
+}
+
+function loadChatState() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    const parsed = JSON.parse(raw);
+    state.chatOpen = Boolean(parsed.open);
+    if (parsed.estimateDraft) {
+      state.estimateDraft = { ...state.estimateDraft, ...parsed.estimateDraft };
+    }
+  } catch {
+    // ignore broken localStorage
+  }
+}
+
+function setupFormValidation() {
+  els.contactForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const data = new FormData(form);
+    const email = String(data.get('email') || '');
+    const consent = data.get('consent');
+
+    if (!form.checkValidity()) {
+      showToast('入力内容をご確認ください。必須項目が未入力です。');
+      form.reportValidity();
+      return;
+    }
+
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      showToast('メールアドレスの形式をご確認ください。');
+      return;
+    }
+
+    if (!consent) {
+      showToast('個人情報の取扱いへの同意が必要です。');
+      return;
+    }
+
+    form.reset();
+    showToast('送信しました。担当者よりご連絡します。');
+  });
+}
+
+function showToast(message) {
+  els.toast.textContent = message;
+  els.toast.hidden = false;
+  window.clearTimeout(showToast.timer);
+  showToast.timer = window.setTimeout(() => {
+    els.toast.hidden = true;
+  }, 2600);
+}
+
+function setupReveals() {
+  const revealTargets = document.querySelectorAll('.reveal');
+  if (!('IntersectionObserver' in window)) {
+    revealTargets.forEach((el) => el.classList.add('visible'));
+    return;
+  }
+
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('visible');
+        observer.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.08 });
+
+  revealTargets.forEach((el) => observer.observe(el));
+}
+
+init();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>〇〇市の外壁・屋根・リフォーム | まちの建築工事サポート</title>
+  <meta name="description" content="〇〇市・△△町・□□区対応。外壁・屋根・水回り・内装まで、地元密着の職人直営施工。最短対応・無料見積・近隣配慮。かんたん診断と即時回答の自動サポート付き。" />
+  <link rel="canonical" href="https://example.com/local-construction-lp" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="〇〇市の外壁・屋根・リフォーム" />
+  <meta property="og:description" content="地元密着の建築工事会社。無料見積・最短対応・近隣配慮。" />
+  <meta property="og:url" content="https://example.com/local-construction-lp" />
+  <meta property="og:image" content="https://example.com/ogp-placeholder.jpg" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <a class="skip-link" href="#main-content">本文へ移動</a>
+
+  <header class="site-header" id="top">
+    <div class="container header-inner">
+      <a href="#top" class="logo" aria-label="まちの建築工事サポート トップ">まちの建築工事サポート</a>
+      <nav aria-label="メインナビゲーション">
+        <ul class="nav-list">
+          <li><a href="#services">サービス</a></li>
+          <li><a href="#cases">施工実績</a></li>
+          <li><a href="#pricing">料金目安</a></li>
+          <li><a href="#faq">FAQ</a></li>
+          <li><a href="#contact">お問い合わせ</a></li>
+        </ul>
+      </nav>
+      <a href="tel:0312345678" class="btn btn-primary btn-small">お電話</a>
+    </div>
+  </header>
+
+  <main id="main-content">
+    <section class="hero reveal" id="hero">
+      <div class="container hero-grid">
+        <div>
+          <p class="badge">地域密着・職人直営</p>
+          <h1>〇〇市の外壁・屋根・リフォーム</h1>
+          <p class="hero-sub">最短当日ご連絡 / 見積無料 / 近隣配慮を徹底。住まいの工事を、わかりやすく丁寧にご案内します。</p>
+          <div class="hero-cta">
+            <a class="btn btn-primary" href="tel:0312345678">今すぐ電話する</a>
+            <a class="btn btn-outline" href="#contact">無料で相談する</a>
+          </div>
+          <ul class="hero-meta">
+            <li><strong>営業時間：</strong>8:30〜18:30（年中無休）</li>
+            <li><strong>対応エリア：</strong>〇〇市 / △△町 / □□区</li>
+          </ul>
+        </div>
+        <div class="hero-card" aria-hidden="true">
+          <div class="placeholder-image large">
+            <span>地域の施工写真エリア</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section reveal" id="strengths" aria-labelledby="strengths-heading">
+      <div class="container">
+        <h2 id="strengths-heading">選ばれる3つの強み</h2>
+        <div class="card-grid cols-3">
+          <article class="card">
+            <h3>地元密着で素早い対応</h3>
+            <p>現場まで近いから、急な不具合にも迅速に対応。地域の気候や建物特性を踏まえた提案が可能です。</p>
+          </article>
+          <article class="card">
+            <h3>職人直営の安心施工</h3>
+            <p>下請け任せにせず、経験豊富な職人が直接管理。伝達ロスが少なく、仕上がり品質を守ります。</p>
+          </article>
+          <article class="card">
+            <h3>見積の透明性</h3>
+            <p>工事項目と費用を明確化し、不要な追加請求を抑制。納得いただいてから着工します。</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section alt reveal" id="services" aria-labelledby="services-heading">
+      <div class="container">
+        <h2 id="services-heading">サービス一覧</h2>
+        <div class="card-grid cols-3" id="service-cards" aria-live="polite"></div>
+      </div>
+    </section>
+
+    <section class="section reveal" id="cases" aria-labelledby="cases-heading">
+      <div class="container">
+        <div class="section-head">
+          <h2 id="cases-heading">施工実績</h2>
+          <div class="filters" role="group" aria-label="施工実績フィルタ">
+            <button class="filter-btn active" data-filter="all" type="button">すべて</button>
+            <button class="filter-btn" data-filter="外壁" type="button">外壁</button>
+            <button class="filter-btn" data-filter="屋根" type="button">屋根</button>
+            <button class="filter-btn" data-filter="水回り" type="button">水回り</button>
+            <button class="filter-btn" data-filter="内装" type="button">内装</button>
+            <button class="filter-btn" data-filter="外構" type="button">外構</button>
+            <button class="filter-btn" data-filter="店舗" type="button">店舗</button>
+          </div>
+        </div>
+        <div id="cases-grid" class="card-grid cols-3" aria-live="polite"></div>
+      </div>
+    </section>
+
+    <section class="section alt reveal" id="pricing" aria-labelledby="pricing-heading">
+      <div class="container">
+        <h2 id="pricing-heading">料金目安</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr><th>メニュー</th><th>参考価格帯（税込）</th><th>内容目安</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>外壁塗装</td><td>60〜120万円</td><td>30坪戸建・下地補修含む</td></tr>
+              <tr><td>屋根補修</td><td>35〜90万円</td><td>部分補修〜葺き替え</td></tr>
+              <tr><td>水回り改修</td><td>25〜180万円</td><td>キッチン/浴室/トイレ</td></tr>
+              <tr><td>内装リフォーム</td><td>20〜140万円</td><td>クロス・床・間取り変更</td></tr>
+              <tr><td>外構工事</td><td>30〜200万円</td><td>門扉・駐車場・フェンス</td></tr>
+              <tr><td>小修繕</td><td>3〜25万円</td><td>雨漏り/建具/コーキング</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="note">※ 概算は目安です。建物状態・施工範囲により前後します。</p>
+      </div>
+    </section>
+
+    <section class="section reveal" id="flow" aria-labelledby="flow-heading">
+      <div class="container">
+        <h2 id="flow-heading">工事の流れ</h2>
+        <ol class="steps">
+          <li><span>1</span><div><h3>お問い合わせ</h3><p>電話・フォーム・かんたん質問から受付。</p></div></li>
+          <li><span>2</span><div><h3>現地確認</h3><p>状況を確認し、必要な工事範囲を共有。</p></div></li>
+          <li><span>3</span><div><h3>お見積ご提示</h3><p>明細付きでわかりやすくご案内。</p></div></li>
+          <li><span>4</span><div><h3>ご契約・着工</h3><p>近隣挨拶と安全対策を行い施工開始。</p></div></li>
+          <li><span>5</span><div><h3>完了・アフターフォロー</h3><p>お引き渡し後の点検・ご相談にも対応。</p></div></li>
+        </ol>
+      </div>
+    </section>
+
+    <section class="section alt reveal" id="trust" aria-labelledby="trust-heading">
+      <div class="container">
+        <h2 id="trust-heading">安心して任せられる理由</h2>
+        <ul class="trust-list">
+          <li>建設業許可（ダミー）：東京都知事 許可（般-00）第00000号</li>
+          <li>工事保険加入：請負業者賠償責任保険・生産物賠償責任保険</li>
+          <li>工事保証：施工内容に応じて最長10年保証</li>
+          <li>近隣配慮：着工前挨拶・騒音時間帯の配慮・清掃徹底</li>
+          <li>施工後フォロー：定期点検・メンテナンス相談窓口</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="section reveal" id="faq" aria-labelledby="faq-heading">
+      <div class="container">
+        <h2 id="faq-heading">よくあるご質問</h2>
+        <div id="faq-list" class="accordion" role="region" aria-label="よくある質問一覧"></div>
+      </div>
+    </section>
+
+    <section class="section alt reveal" id="contact" aria-labelledby="contact-heading">
+      <div class="container">
+        <h2 id="contact-heading">お問い合わせ</h2>
+        <p>ご相談内容を確認後、担当者よりご連絡します。概算は目安のため、現地調査で最終金額をご案内します。</p>
+        <form id="contact-form" novalidate>
+          <div class="form-grid">
+            <label>氏名*<input type="text" name="name" required /></label>
+            <label>電話番号*<input type="tel" name="phone" required /></label>
+            <label>メールアドレス*<input type="email" name="email" required /></label>
+            <label>住所（任意）<input type="text" name="address" /></label>
+            <label class="full">相談内容*<textarea name="message" rows="5" required></textarea></label>
+            <fieldset class="full inline-options">
+              <legend>希望連絡方法*</legend>
+              <label><input type="radio" name="contactMethod" value="電話" required /> 電話</label>
+              <label><input type="radio" name="contactMethod" value="メール" required /> メール</label>
+              <label><input type="radio" name="contactMethod" value="どちらでも" required /> どちらでも</label>
+            </fieldset>
+            <label class="full check"><input type="checkbox" name="consent" required /> 個人情報の取扱いに同意します*</label>
+          </div>
+          <button class="btn btn-primary" type="submit">送信する</button>
+          <p class="privacy-note">個人情報はお問い合わせ対応の目的にのみ利用します。</p>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-grid">
+      <section>
+        <h2>会社概要</h2>
+        <p>株式会社まちの建築工務店</p>
+        <p>〒100-0001 東京都〇〇市中央1-2-3</p>
+        <p>TEL: <a href="tel:0312345678">03-1234-5678</a> / MAIL: <a href="mailto:info@example.com">info@example.com</a></p>
+      </section>
+      <section>
+        <h2>対応エリア</h2>
+        <p>〇〇市 / △△町 / □□区 / 近隣エリア</p>
+      </section>
+      <section>
+        <h2>プライバシー・免責</h2>
+        <p>本サイトの概算・回答は目安です。最終的な契約条件は書面でご確認ください。</p>
+        <p class="small-note">自動サポート（AI/ルールベース併用）により即時回答を提供しています。</p>
+      </section>
+    </div>
+  </footer>
+
+  <div class="sticky-cta" aria-label="固定お問い合わせ導線">
+    <a href="tel:0312345678" class="btn btn-primary">電話</a>
+    <a href="#contact" class="btn btn-outline">無料見積</a>
+    <button id="chat-shortcut" class="btn btn-dark" type="button">かんたん質問</button>
+  </div>
+
+  <section id="chat-widget" class="chat-widget" aria-label="自動サポートチャット">
+    <button id="chat-toggle" class="chat-toggle" aria-expanded="false" aria-controls="chat-panel" type="button">かんたん質問</button>
+    <div id="chat-panel" class="chat-panel" role="dialog" aria-modal="false" aria-labelledby="chat-title" hidden>
+      <div class="chat-header">
+        <h2 id="chat-title">住まいの自動サポート</h2>
+        <button id="chat-close" class="icon-btn" type="button" aria-label="チャットを閉じる">×</button>
+      </div>
+      <div id="chat-log" class="chat-log" tabindex="0" aria-live="polite"></div>
+      <div id="chat-quick-actions" class="chat-actions"></div>
+      <form id="chat-form" class="chat-input-wrap">
+        <label for="chat-input" class="sr-only">質問を入力</label>
+        <input id="chat-input" name="chatInput" type="text" placeholder="例：保証はありますか？" autocomplete="off" />
+        <button type="submit" class="btn btn-primary btn-small">送信</button>
+      </form>
+    </div>
+  </section>
+
+  <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
+
+  <script src="app.js" defer></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,248 @@
+:root {
+  --bg: #f7f9fc;
+  --surface: #ffffff;
+  --text: #1f2937;
+  --muted: #6b7280;
+  --line: #d8dee9;
+  --accent: #0b6cc4;
+  --accent-dark: #084f8f;
+  --shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+  --radius: 12px;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Kaku Gothic ProN", "Yu Gothic", sans-serif;
+  color: var(--text);
+  background: var(--bg);
+  line-height: 1.6;
+}
+
+a { color: var(--accent); }
+a:hover { color: var(--accent-dark); }
+
+.container { width: min(1100px, 92%); margin: 0 auto; }
+.section { padding: 64px 0; }
+.section.alt { background: #eef3f8; }
+h1, h2, h3 { line-height: 1.3; margin-top: 0; }
+h1 { font-size: clamp(1.8rem, 3vw, 2.6rem); margin-bottom: 12px; }
+h2 { font-size: clamp(1.4rem, 2.5vw, 2rem); margin-bottom: 24px; }
+
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  background: #fff;
+  padding: 8px;
+}
+.skip-link:focus { left: 12px; z-index: 9999; }
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 900;
+  background: rgba(255,255,255,0.95);
+  border-bottom: 1px solid var(--line);
+  backdrop-filter: blur(6px);
+}
+.header-inner { display: flex; align-items: center; justify-content: space-between; gap: 18px; padding: 10px 0; }
+.logo { text-decoration: none; font-weight: 700; color: var(--text); }
+.nav-list { display: flex; list-style: none; gap: 14px; padding: 0; margin: 0; }
+.nav-list a { text-decoration: none; font-size: .95rem; }
+
+.hero { padding: 70px 0 56px; background: linear-gradient(140deg, #fff 0%, #ecf5ff 100%); }
+.hero-grid { display: grid; grid-template-columns: 1.2fr 1fr; gap: 28px; align-items: center; }
+.badge {
+  display: inline-block;
+  font-size: .85rem;
+  color: var(--accent-dark);
+  background: #dbeeff;
+  border-radius: 999px;
+  padding: 4px 12px;
+  margin-bottom: 12px;
+}
+.hero-sub { color: var(--muted); font-size: 1.05rem; max-width: 60ch; }
+.hero-cta { display: flex; flex-wrap: wrap; gap: 10px; margin: 24px 0; }
+.hero-meta { list-style: none; padding: 0; margin: 0; color: var(--muted); }
+.hero-card { background: #fff; border: 1px solid var(--line); border-radius: var(--radius); padding: 14px; box-shadow: var(--shadow); }
+
+.placeholder-image {
+  min-height: 180px;
+  border-radius: 10px;
+  border: 1px dashed #a7b4c8;
+  background: linear-gradient(135deg, #cad9ea, #e8f0f8);
+  display: grid;
+  place-items: center;
+  color: #39506b;
+  font-size: 0.9rem;
+  text-align: center;
+  padding: 14px;
+}
+.placeholder-image.large { min-height: 320px; }
+
+.card-grid { display: grid; gap: 16px; }
+.card-grid.cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.card {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 18px;
+  box-shadow: 0 2px 8px rgba(15,23,42,0.04);
+}
+.service-badge { font-size: .78rem; color: var(--accent-dark); background: #e7f2ff; border-radius: 999px; padding: 3px 10px; display:inline-block; margin-bottom: 8px; }
+
+.section-head { display: flex; justify-content: space-between; align-items: flex-end; gap: 12px; flex-wrap: wrap; }
+.filters { display: flex; flex-wrap: wrap; gap: 8px; }
+.filter-btn {
+  border: 1px solid var(--line);
+  background: #fff;
+  color: var(--text);
+  border-radius: 999px;
+  padding: 6px 12px;
+  cursor: pointer;
+}
+.filter-btn.active,
+.filter-btn:hover { background: var(--accent); border-color: var(--accent); color: #fff; }
+
+.case-meta { font-size: .88rem; color: var(--muted); margin: 10px 0; display: grid; gap: 4px; }
+.highlights { display: flex; flex-wrap: wrap; gap: 6px; padding: 0; list-style: none; margin: 0; }
+.highlights li { font-size: .78rem; background: #eef4fb; color: #345; padding: 4px 8px; border-radius: 999px; }
+
+.table-wrap { overflow-x: auto; }
+table { width: 100%; border-collapse: collapse; background: #fff; border: 1px solid var(--line); }
+th, td { padding: 12px 10px; border-bottom: 1px solid var(--line); text-align: left; }
+th { background: #f4f8fc; }
+.note { color: var(--muted); font-size: .9rem; margin-top: 8px; }
+
+.steps { list-style: none; padding: 0; margin: 0; display: grid; gap: 12px; }
+.steps li { display: flex; gap: 12px; background: #fff; border: 1px solid var(--line); padding: 14px; border-radius: var(--radius); }
+.steps span {
+  width: 30px; height: 30px;
+  border-radius: 999px;
+  display: grid; place-items: center;
+  color: #fff; background: var(--accent);
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.trust-list { padding-left: 18px; margin: 0; display: grid; gap: 10px; }
+
+.accordion-item { background: #fff; border: 1px solid var(--line); border-radius: var(--radius); margin-bottom: 10px; overflow: hidden; }
+.accordion-trigger {
+  width: 100%; text-align: left;
+  padding: 14px; border: 0; background: #fff;
+  font-size: 1rem; cursor: pointer;
+}
+.accordion-panel { padding: 0 14px 14px; color: #374151; }
+
+.form-grid { display: grid; gap: 12px; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+label, fieldset { display: grid; gap: 6px; font-size: .95rem; }
+input, textarea {
+  border: 1px solid #b8c2d1;
+  border-radius: 8px;
+  padding: 10px;
+  font-size: 1rem;
+  background: #fff;
+}
+.full { grid-column: 1 / -1; }
+.inline-options { border: 1px solid var(--line); border-radius: 8px; padding: 10px; }
+.inline-options label { display: inline-flex; margin-right: 16px; align-items: center; gap: 6px; }
+.check { display: flex; align-items: flex-start; gap: 10px; }
+
+.site-footer { background: #0f172a; color: #dbe3f1; padding: 36px 0 90px; }
+.site-footer a { color: #9eceff; }
+.footer-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+.site-footer h2 { font-size: 1rem; margin-bottom: 10px; }
+.small-note { color: #b2bfd4; font-size: .82rem; }
+
+.btn {
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 10px 14px;
+  text-decoration: none;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  cursor: pointer;
+}
+.btn-small { padding: 7px 10px; font-size: .9rem; }
+.btn-primary { background: var(--accent); color: #fff; }
+.btn-primary:hover { background: var(--accent-dark); color: #fff; }
+.btn-outline { background: #fff; border-color: #9cb8d8; color: #1c3f61; }
+.btn-dark { background: #111827; color: #fff; }
+
+.sticky-cta {
+  position: fixed;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: 10px;
+  z-index: 950;
+  background: rgba(255,255,255,0.96);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  box-shadow: var(--shadow);
+  padding: 8px;
+  display: flex;
+  gap: 8px;
+}
+
+.chat-widget { position: fixed; right: 16px; bottom: 76px; z-index: 980; }
+.chat-toggle { border: 0; background: var(--accent); color: #fff; border-radius: 999px; padding: 12px 14px; font-weight: 700; cursor: pointer; }
+.chat-panel {
+  width: min(92vw, 360px);
+  height: 520px;
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  display: grid;
+  grid-template-rows: auto 1fr auto auto;
+  margin-top: 10px;
+}
+.chat-header { display: flex; justify-content: space-between; align-items: center; padding: 10px 12px; border-bottom: 1px solid var(--line); }
+.chat-header h2 { font-size: 1rem; margin: 0; }
+.icon-btn { border: 0; background: none; font-size: 1.3rem; cursor: pointer; color: #445; }
+.chat-log { padding: 12px; overflow-y: auto; background: #fafcff; }
+.chat-msg { margin-bottom: 10px; max-width: 94%; border-radius: 10px; padding: 9px 10px; font-size: .93rem; }
+.chat-msg.bot { background: #e8f2ff; color: #163b62; }
+.chat-msg.user { background: #1f2937; color: #fff; margin-left: auto; }
+.chat-actions { padding: 8px; display: flex; flex-wrap: wrap; gap: 6px; border-top: 1px solid var(--line); }
+.quick-btn { background: #f2f6fd; border: 1px solid #c7d7eb; border-radius: 999px; padding: 6px 10px; font-size: .83rem; cursor: pointer; }
+.chat-input-wrap { display: flex; gap: 8px; padding: 8px; border-top: 1px solid var(--line); }
+.chat-input-wrap input { flex: 1; }
+
+.toast {
+  position: fixed;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: 86px;
+  background: #0f172a;
+  color: #fff;
+  padding: 10px 14px;
+  border-radius: 999px;
+  z-index: 999;
+}
+
+.sr-only { position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0; border: 0; clip: rect(0 0 0 0); overflow: hidden; }
+:focus-visible { outline: 3px solid #ef9c00; outline-offset: 2px; }
+
+.reveal { opacity: 0; transform: translateY(10px); transition: opacity .4s ease, transform .4s ease; }
+.reveal.visible { opacity: 1; transform: translateY(0); }
+
+@media (max-width: 940px) {
+  .nav-list { display: none; }
+  .hero-grid, .card-grid.cols-3, .footer-grid { grid-template-columns: 1fr 1fr; }
+}
+
+@media (max-width: 700px) {
+  .section { padding: 48px 0; }
+  .hero-grid, .card-grid.cols-3, .footer-grid, .form-grid { grid-template-columns: 1fr; }
+  .chat-widget { right: 10px; }
+  .sticky-cta { width: calc(100% - 16px); justify-content: space-between; border-radius: 12px; }
+  .btn { flex: 1; }
+}


### PR DESCRIPTION
### Motivation
- Provide a self-contained, production-feasible static landing page for a local construction company using only pure HTML, vanilla JS, and CSS with no external libraries, while keeping the "自動サポート/かんたん診断/即時回答" feature subtle and helpful. 
- Ensure accessibility, performance, and mobile usability by using semantic markup, ARIA attributes, keyboard support, visible focus rings, and minimal JS for interactions.
- Enable a differentiation point with a small chat widget that offers guided flows (概算診断/事例レコメンド/FAQ) without relying on external AI APIs.

### Description
- Added `index.html`, `styles.css`, `app.js`, and an `assets/` folder with placeholders, implementing all required LP sections (hero, 3つの強み, サービス, 施工実績 with filters, 料金目安表, 工事の流れ, 安心情報, FAQ accordion, お問い合わせフォーム, footer note). 
- Implemented a right-bottom chat widget (accessible toggle with `aria-expanded`, dialog region, `Esc` to close, focus handling) that provides a guided menu and three feature flows: A) 概算診断 (type/scale/築年数/物件 →レンジ算出 via `estimateMatrix`), B) 事例レコメンド (最大3件＋「もっと見る」導線 that scrolls & filters the main cases), and C) FAQ即答 (keyword/tag lookup); the widget persists open state and last draft in `localStorage`. 
- JavaScript implements services/cases/faq datasets (`services`, `cases` (12 items), `faq` (10+ items), `estimateMatrix`), case filtering, FAQ accordion with keyboard support and ARIA, smooth-anchor scrolling, form validation (required checks, email regex, consent), toast feedback, and a lightweight reveal animation using `IntersectionObserver`. 
- Styling is responsive and image-agnostic (CSS placeholders / gradients), emphasizes trust (white + single accent), keeps focus-visible outlines, and includes fixed CTAs for phone/estimate/chat optimized for mobile.

### Testing
- Ran `node --check app.js` to validate JS syntax and it succeeded. 
- Ran `python -m py_compile app.js` by mistake (attempted Python compile on a JS file) and that check failed for the expected reason (irrelevant to JS correctness). 
- Started a local static server with `python -m http.server 4173` and verified the page loads. 
- Captured a full-page screenshot via Playwright to validate visual output and interaction-ready state (screenshot saved during verification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a000a5216883299830c79582872f11)