### PR TITLE
Add 1-page warm-toned landing page for local construction company (HTML/CSS/JS)

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,425 @@
+:root {
+  --bg: #fdf7ef;
+  --bg-alt: #f4e8d8;
+  --text: #3e2f26;
+  --muted: #6b5648;
+  --primary: #bf6a43;
+  --primary-dark: #a15434;
+  --line: #d8c3b0;
+  --card: #fffaf3;
+  --focus: #1f6feb;
+  --radius: 14px;
+  --shadow: 0 4px 12px rgba(62, 47, 38, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+body {
+  margin: 0;
+  font-family: "Hiragino Kaku Gothic ProN", "Yu Gothic", "Meiryo", system-ui, -apple-system, sans-serif;
+  color: var(--text);
+  background: var(--bg);
+  line-height: 1.7;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+  border-radius: 12px;
+}
+
+.container {
+  width: min(1100px, 92%);
+  margin-inline: auto;
+}
+
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 8px;
+  background: #fff;
+  color: #000;
+  padding: 8px;
+  z-index: 1000;
+}
+
+.skip-link:focus {
+  top: 8px;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  background: rgba(253, 247, 239, 0.95);
+  backdrop-filter: blur(3px);
+  border-bottom: 1px solid var(--line);
+  z-index: 20;
+}
+
+.header-inner {
+  display: grid;
+  gap: 8px 24px;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  padding: 12px 0;
+}
+
+.logo {
+  margin: 0;
+  font-weight: 700;
+  font-size: 1.2rem;
+}
+
+.header-contact {
+  text-align: right;
+}
+
+.business-hours,
+.phone-link {
+  margin: 0;
+  font-size: 0.92rem;
+}
+
+.phone-link {
+  color: var(--primary-dark);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.global-nav {
+  grid-column: 1 / -1;
+}
+
+.menu-toggle {
+  display: none;
+}
+
+.global-nav ul {
+  display: flex;
+  flex-wrap: wrap;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  gap: 16px;
+}
+
+.global-nav a {
+  text-decoration: none;
+  color: var(--text);
+  font-weight: 600;
+}
+
+.hero {
+  position: relative;
+  padding: 72px 0;
+  background:
+    radial-gradient(circle at 20% 30%, rgba(255, 255, 255, 0.65) 0, rgba(255, 255, 255, 0) 35%),
+    linear-gradient(130deg, #f6e8d8 0%, #f3dfcc 40%, #e9d2bc 100%);
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: repeating-linear-gradient(45deg, transparent 0 12px, rgba(191, 106, 67, 0.05) 12px 14px);
+  pointer-events: none;
+}
+
+.hero-inner,
+.hero-text {
+  position: relative;
+  z-index: 1;
+}
+
+.hero h1 {
+  line-height: 1.3;
+}
+
+.hero-lead {
+  font-weight: 700;
+  color: var(--primary-dark);
+}
+
+.hero-cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.btn {
+  display: inline-block;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 10px 18px;
+  text-decoration: none;
+  font-weight: 700;
+  box-shadow: var(--shadow);
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+  cursor: pointer;
+}
+
+.btn-primary {
+  background: var(--primary);
+  color: #fff;
+}
+
+.btn-primary:hover,
+.btn-primary:focus-visible {
+  background: var(--primary-dark);
+}
+
+.btn-secondary {
+  background: #fff;
+  color: var(--text);
+  border-color: var(--line);
+}
+
+.btn-line {
+  background: #fbefe4;
+  color: #4e3d31;
+  border-color: #cc9b7f;
+}
+
+.section {
+  padding: 68px 0;
+}
+
+.section.alt {
+  background: var(--bg-alt);
+}
+
+.grid {
+  display: grid;
+  gap: 16px;
+}
+
+.cards-3 {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.cards-4 {
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+}
+
+.card,
+.service-card,
+.work-card,
+.voice-card,
+.faq-item {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 18px;
+}
+
+.filter-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.filter-btn {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: #fff;
+  padding: 8px 14px;
+  cursor: pointer;
+}
+
+.filter-btn.active {
+  background: var(--primary);
+  color: #fff;
+  border-color: var(--primary);
+}
+
+.work-card[hidden] {
+  display: none;
+}
+
+.voice-card {
+  margin: 0;
+}
+
+.voice-card cite {
+  display: block;
+  margin-top: 8px;
+  color: var(--muted);
+  font-style: normal;
+}
+
+.flow-list {
+  display: grid;
+  gap: 10px;
+  padding-left: 20px;
+}
+
+.faq-question {
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text);
+  cursor: pointer;
+  padding: 0;
+}
+
+.faq-answer {
+  margin-top: 12px;
+}
+
+.company-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.form-grid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.form-field.full-width {
+  grid-column: 1 / -1;
+}
+
+input,
+textarea,
+fieldset {
+  font: inherit;
+}
+
+input,
+textarea {
+  border: 1px solid #bfa994;
+  border-radius: 10px;
+  padding: 10px;
+  background: #fff;
+}
+
+fieldset {
+  border: 1px solid #bfa994;
+  border-radius: 10px;
+  padding: 10px;
+}
+
+.checkbox-wrap label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.error-message {
+  min-height: 1.2em;
+  margin: 0;
+  color: #9f2d23;
+  font-size: 0.9rem;
+}
+
+.note {
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.site-footer {
+  padding: 24px 0;
+  border-top: 1px solid var(--line);
+}
+
+.footer-inner {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.footer-inner ul {
+  display: flex;
+  gap: 14px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: grid;
+  place-items: center;
+  padding: 16px;
+}
+
+.modal-content {
+  width: min(520px, 100%);
+  background: #fff;
+  border-radius: 14px;
+  padding: 22px;
+}
+
+:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 2px;
+}
+
+@media (max-width: 860px) {
+  .menu-toggle {
+    display: inline-block;
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    background: #fff;
+    padding: 7px 12px;
+    margin-bottom: 8px;
+  }
+
+  .global-nav ul {
+    display: none;
+    flex-direction: column;
+    background: #fffdf9;
+    border: 1px solid var(--line);
+    padding: 12px;
+    border-radius: 12px;
+  }
+
+  .global-nav ul.open {
+    display: flex;
+  }
+
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero {
+    padding: 56px 0;
+  }
+}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -380,6 +380,10 @@ fieldset {
   padding: 16px;
 }
 
+.modal[hidden] {
+  display: none !important;
+}
+
 .modal-content {
   width: min(520px, 100%);
   background: #fff;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,191 @@
+(() => {
+  'use strict';
+
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const navToggle = document.querySelector('.menu-toggle');
+  const navList = document.getElementById('nav-list');
+
+  if (navToggle && navList) {
+    navToggle.addEventListener('click', () => {
+      const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+      navToggle.setAttribute('aria-expanded', String(!expanded));
+      navList.classList.toggle('open');
+    });
+  }
+
+  const navLinks = document.querySelectorAll('a[href^="#"]');
+  navLinks.forEach((link) => {
+    link.addEventListener('click', (event) => {
+      const targetId = link.getAttribute('href');
+      if (!targetId || targetId === '#') {
+        return;
+      }
+
+      const targetElement = document.querySelector(targetId);
+      if (!targetElement) {
+        return;
+      }
+
+      event.preventDefault();
+      targetElement.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth', block: 'start' });
+
+      if (navList && navList.classList.contains('open')) {
+        navList.classList.remove('open');
+      }
+      if (navToggle) {
+        navToggle.setAttribute('aria-expanded', 'false');
+      }
+    });
+  });
+
+  const filterButtons = document.querySelectorAll('.filter-btn');
+  const workCards = document.querySelectorAll('.work-card');
+
+  filterButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const selected = button.dataset.filter || 'all';
+
+      filterButtons.forEach((btn) => {
+        const isActive = btn === button;
+        btn.classList.toggle('active', isActive);
+        btn.setAttribute('aria-selected', String(isActive));
+      });
+
+      workCards.forEach((card) => {
+        const category = card.dataset.category;
+        const shouldShow = selected === 'all' || category === selected;
+        card.hidden = !shouldShow;
+      });
+    });
+  });
+
+  const faqQuestions = document.querySelectorAll('.faq-question');
+  faqQuestions.forEach((question) => {
+    question.addEventListener('click', () => {
+      const expanded = question.getAttribute('aria-expanded') === 'true';
+      question.setAttribute('aria-expanded', String(!expanded));
+      const answer = question.closest('.faq-item')?.querySelector('.faq-answer');
+      if (answer) {
+        answer.hidden = expanded;
+      }
+    });
+  });
+
+  const form = document.getElementById('contact-form');
+  const modal = document.getElementById('modal');
+  const modalClose = document.getElementById('modal-close');
+
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  function setError(fieldName, message) {
+    const errorNode = document.getElementById(`error-${fieldName}`);
+    if (errorNode) {
+      errorNode.textContent = message;
+    }
+  }
+
+  function clearErrors() {
+    const errorNodes = document.querySelectorAll('.error-message');
+    errorNodes.forEach((node) => {
+      node.textContent = '';
+    });
+  }
+
+  function openModal() {
+    if (!modal) {
+      return;
+    }
+
+    modal.hidden = false;
+    modal.setAttribute('aria-hidden', 'false');
+    document.body.style.overflow = 'hidden';
+    if (modalClose) {
+      modalClose.focus();
+    }
+  }
+
+  function closeModal() {
+    if (!modal) {
+      return;
+    }
+
+    modal.hidden = true;
+    modal.setAttribute('aria-hidden', 'true');
+    document.body.style.overflow = '';
+  }
+
+  if (modalClose) {
+    modalClose.addEventListener('click', closeModal);
+  }
+
+  if (modal) {
+    modal.addEventListener('click', (event) => {
+      if (event.target === modal) {
+        closeModal();
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && !modal.hidden) {
+        closeModal();
+      }
+    });
+  }
+
+  if (form) {
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      clearErrors();
+
+      let hasError = false;
+
+      const name = form.elements.namedItem('name');
+      const phone = form.elements.namedItem('phone');
+      const email = form.elements.namedItem('email');
+      const message = form.elements.namedItem('message');
+      const consent = form.elements.namedItem('consent');
+      const methodChecked = form.querySelector('input[name="contactMethod"]:checked');
+
+      if (!(name instanceof HTMLInputElement) || !name.value.trim()) {
+        setError('name', '氏名を入力してください。');
+        hasError = true;
+      }
+
+      if (!(phone instanceof HTMLInputElement) || !phone.value.trim()) {
+        setError('phone', '電話番号を入力してください。');
+        hasError = true;
+      }
+
+      if (!(email instanceof HTMLInputElement) || !email.value.trim()) {
+        setError('email', 'メールアドレスを入力してください。');
+        hasError = true;
+      } else if (!emailPattern.test(email.value.trim())) {
+        setError('email', 'メールアドレスの形式をご確認ください。');
+        hasError = true;
+      }
+
+      if (!(message instanceof HTMLTextAreaElement) || !message.value.trim()) {
+        setError('message', 'ご相談内容を入力してください。');
+        hasError = true;
+      }
+
+      if (!methodChecked) {
+        setError('contactMethod', '希望連絡方法を選択してください。');
+        hasError = true;
+      }
+
+      if (!(consent instanceof HTMLInputElement) || !consent.checked) {
+        setError('consent', '同意チェックが必要です。');
+        hasError = true;
+      }
+
+      if (hasError) {
+        return;
+      }
+
+      form.reset();
+      openModal();
+    });
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,328 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>○○市のリフォーム・外壁塗装なら まちの建設工務店</title>
+  <meta name="description" content="○○市・近隣エリアの住宅リフォーム、外壁塗装、屋根修繕、内装改修に対応。地元密着で丁寧にご相談を承ります。">
+  <meta name="format-detection" content="telephone=no">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="ja_JP">
+  <meta property="og:title" content="○○市のリフォーム・外壁塗装なら まちの建設工務店">
+  <meta property="og:description" content="地元密着で住まいの改修を丁寧にご提案。電話・フォーム・LINEで相談できます。">
+  <meta property="og:url" content="https://example.com/">
+  <meta property="og:image" content="https://example.com/ogp-placeholder.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="stylesheet" href="assets/css/style.css">
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": ["LocalBusiness", "ConstructionCompany"],
+      "name": "まちの建設工務店",
+      "description": "○○市を中心に住宅・小規模店舗の改修工事に対応する地元密着の建設会社です。",
+      "url": "https://example.com/",
+      "telephone": "000-1234-5678",
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "○○市",
+        "addressRegion": "○○県",
+        "streetAddress": "中央1-2-3",
+        "postalCode": "000-0000"
+      },
+      "areaServed": ["○○市", "△△町", "□□市"],
+      "openingHours": "Mo-Sa 08:30-18:00",
+      "priceRange": "¥¥",
+      "sameAs": [
+        "https://line.me/"
+      ]
+    }
+  </script>
+  <script defer src="assets/js/main.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main-content">本文へスキップ</a>
+
+  <header class="site-header" id="top">
+    <div class="container header-inner">
+      <p class="logo" aria-label="まちの建設工務店 ロゴ">まちの建設工務店</p>
+      <div class="header-contact">
+        <p class="business-hours">営業時間 8:30〜18:00（日祝除く）</p>
+        <a class="phone-link" href="tel:00012345678" aria-label="電話で相談する 000-1234-5678">TEL 000-1234-5678</a>
+      </div>
+      <nav class="global-nav" aria-label="ページ内ナビゲーション">
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="nav-list">メニュー</button>
+        <ul id="nav-list">
+          <li><a href="#reasons">選ばれる理由</a></li>
+          <li><a href="#services">サービス</a></li>
+          <li><a href="#works">施工事例</a></li>
+          <li><a href="#flow">流れ</a></li>
+          <li><a href="#faq">FAQ</a></li>
+          <li><a href="#contact">お問い合わせ</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main-content">
+    <section class="hero" aria-labelledby="hero-title">
+      <div class="container hero-inner">
+        <div class="hero-text">
+          <p class="hero-lead">○○市で住まいのことを、相談しやすく。</p>
+          <h1 id="hero-title">リフォーム・外壁塗装・屋根工事を<br>地元密着で丁寧に対応します。</h1>
+          <p>一般住宅から小規模店舗まで、現地状況を確認したうえで、わかりやすい説明と無理のない計画をご提案します。</p>
+          <div class="hero-cta" aria-label="主要な問い合わせ導線">
+            <a class="btn btn-primary" href="tel:00012345678">電話で相談する</a>
+            <a class="btn btn-secondary" href="#contact">フォームで相談する</a>
+            <a class="btn btn-line" href="https://line.me/" target="_blank" rel="noopener noreferrer" aria-label="LINEで相談する（ダミー）">LINEで相談（ダミー）</a>
+          </div>
+          <p class="note">※ 資格・許認可の詳細は個別案件ごとに要確認となります。</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section alt" id="reasons" aria-labelledby="reasons-title">
+      <div class="container">
+        <h2 id="reasons-title">選ばれる理由</h2>
+        <div class="grid cards-4">
+          <article class="card">
+            <h3>自社施工で情報が伝わりやすい</h3>
+            <p>ご相談内容を施工担当まで共有し、行き違いを減らせる体制を心がけています。</p>
+          </article>
+          <article class="card">
+            <h3>見積の内訳を丁寧に説明</h3>
+            <p>工事項目ごとに費用の根拠をお伝えし、必要性を確認しながら進めます。</p>
+          </article>
+          <article class="card">
+            <h3>近隣への配慮</h3>
+            <p>工事前のご挨拶や作業時間の調整など、地域環境に配慮した進行を行います。</p>
+          </article>
+          <article class="card">
+            <h3>工事後の相談窓口</h3>
+            <p>引き渡し後も気になる点をご相談いただけるよう、連絡しやすさを重視しています。</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="services" aria-labelledby="services-title">
+      <div class="container">
+        <h2 id="services-title">対応サービス</h2>
+        <div class="grid cards-3">
+          <article class="service-card"><h3>住宅リフォーム</h3><p>水回り、間取り変更、部分改修まで幅広く対応。</p></article>
+          <article class="service-card"><h3>外壁塗装</h3><p>劣化状況に応じた塗料と工程を提案します。</p></article>
+          <article class="service-card"><h3>屋根工事</h3><p>補修・葺き替え・雨漏りの点検相談に対応。</p></article>
+          <article class="service-card"><h3>内装改装</h3><p>壁紙、床、照明など店舗・住宅の印象改善に。</p></article>
+          <article class="service-card"><h3>耐震・断熱</h3><p>住み心地と安全性の向上を目的とした改修。</p></article>
+          <article class="service-card"><h3>バリアフリー</h3><p>手すり設置や段差解消など生活導線を見直します。</p></article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section alt" id="works" aria-labelledby="works-title">
+      <div class="container">
+        <h2 id="works-title">施工事例</h2>
+        <div class="filter-buttons" role="tablist" aria-label="施工事例カテゴリ">
+          <button class="filter-btn active" type="button" data-filter="all" aria-selected="true">すべて</button>
+          <button class="filter-btn" type="button" data-filter="reform" aria-selected="false">リフォーム</button>
+          <button class="filter-btn" type="button" data-filter="painting" aria-selected="false">外壁塗装</button>
+          <button class="filter-btn" type="button" data-filter="roof" aria-selected="false">屋根</button>
+        </div>
+        <div class="grid cards-3 works-grid" aria-live="polite">
+          <article class="work-card" data-category="reform">
+            <img src="https://via.placeholder.com/640x400/f4eadd/7c5a41?text=Reform+01" alt="キッチン改修の施工事例" loading="lazy">
+            <h3>築20年住宅の水回り改修</h3>
+            <p>家事動線を見直し、使い勝手を改善。</p>
+          </article>
+          <article class="work-card" data-category="painting">
+            <img src="https://via.placeholder.com/640x400/eed8c4/7c5a41?text=Painting+01" alt="外壁塗装の施工事例" loading="lazy">
+            <h3>外壁の塗り替え工事</h3>
+            <p>色味を抑えた仕上げで周辺景観に配慮。</p>
+          </article>
+          <article class="work-card" data-category="roof">
+            <img src="https://via.placeholder.com/640x400/e9d6c2/7c5a41?text=Roof+01" alt="屋根補修の施工事例" loading="lazy">
+            <h3>雨漏り対策の屋根補修</h3>
+            <p>原因箇所を調査し、必要範囲で対応。</p>
+          </article>
+          <article class="work-card" data-category="reform">
+            <img src="https://via.placeholder.com/640x400/f8ede1/7c5a41?text=Reform+02" alt="店舗内装改装の施工事例" loading="lazy">
+            <h3>小規模店舗の内装改装</h3>
+            <p>営業に配慮した短期工程で施工。</p>
+          </article>
+          <article class="work-card" data-category="painting">
+            <img src="https://via.placeholder.com/640x400/f1dfcd/7c5a41?text=Painting+02" alt="外壁の部分補修事例" loading="lazy">
+            <h3>外壁の部分補修</h3>
+            <p>ひび割れ箇所を中心に補修・塗装。</p>
+          </article>
+          <article class="work-card" data-category="roof">
+            <img src="https://via.placeholder.com/640x400/edd8c8/7c5a41?text=Roof+02" alt="屋根カバー工法の施工事例" loading="lazy">
+            <h3>屋根カバー工法</h3>
+            <p>住みながらの施工計画を重視。</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" aria-labelledby="voice-title">
+      <div class="container">
+        <h2 id="voice-title">お客様の声</h2>
+        <div class="grid cards-3">
+          <blockquote class="voice-card">
+            <p>「工事内容を一つずつ説明してくれたので安心できました。急かされる感じがなかったのも良かったです。」</p>
+            <cite>○○市 / 40代 ご家庭</cite>
+          </blockquote>
+          <blockquote class="voice-card">
+            <p>「外壁の色選びで迷っていたとき、周辺の家並みも踏まえて提案してもらえて助かりました。」</p>
+            <cite>△△町 / 50代 ご家庭</cite>
+          </blockquote>
+          <blockquote class="voice-card">
+            <p>「店舗改装の工程を営業日に合わせて調整してくれ、負担を抑えられました。」</p>
+            <cite>□□市 / 飲食店オーナー</cite>
+          </blockquote>
+        </div>
+      </div>
+    </section>
+
+    <section class="section alt" id="flow" aria-labelledby="flow-title">
+      <div class="container">
+        <h2 id="flow-title">ご相談から工事までの流れ</h2>
+        <ol class="flow-list">
+          <li>ご相談（電話・フォーム・LINE）</li>
+          <li>現地調査</li>
+          <li>お見積り・ご説明</li>
+          <li>ご契約後、施工</li>
+          <li>お引き渡し</li>
+          <li>アフター相談</li>
+        </ol>
+      </div>
+    </section>
+
+    <section class="section" aria-labelledby="price-title">
+      <div class="container">
+        <h2 id="price-title">料金の目安</h2>
+        <div class="grid cards-3">
+          <article class="card"><h3>外壁塗装</h3><p>80万円〜150万円</p></article>
+          <article class="card"><h3>屋根補修</h3><p>20万円〜120万円</p></article>
+          <article class="card"><h3>内装改修</h3><p>15万円〜200万円</p></article>
+        </div>
+        <p class="note">※ 建物の状態・面積・使用材料・足場条件により費用は変動します。現地調査のうえで正式なお見積りをご案内します。</p>
+      </div>
+    </section>
+
+    <section class="section alt" id="faq" aria-labelledby="faq-title">
+      <div class="container">
+        <h2 id="faq-title">よくある質問</h2>
+        <div class="faq-list">
+          <article class="faq-item">
+            <h3>
+              <button class="faq-question" type="button" aria-expanded="false">相談だけでも可能ですか？</button>
+            </h3>
+            <div class="faq-answer" hidden>
+              <p>はい、可能です。まずは現状やご希望をお聞きし、必要な対応をご一緒に整理します。</p>
+            </div>
+          </article>
+          <article class="faq-item">
+            <h3>
+              <button class="faq-question" type="button" aria-expanded="false">工事中は家にいないといけませんか？</button>
+            </h3>
+            <div class="faq-answer" hidden>
+              <p>工事内容によります。事前に立ち会いが必要なタイミングをお伝えします。</p>
+            </div>
+          </article>
+          <article class="faq-item">
+            <h3>
+              <button class="faq-question" type="button" aria-expanded="false">資格や許認可はありますか？</button>
+            </h3>
+            <div class="faq-answer" hidden>
+              <p>案件により必要な資格・許認可は異なります。個別案件ごとに要確認のうえご説明します。</p>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" aria-labelledby="company-title">
+      <div class="container">
+        <h2 id="company-title">会社情報</h2>
+        <div class="company-grid">
+          <div>
+            <h3>所在地・対応エリア</h3>
+            <p>所在地：○○県○○市中央1-2-3</p>
+            <p>対応エリア：○○市 / △△町 / □□市（周辺はご相談ください）</p>
+          </div>
+          <div>
+            <h3>スタッフ紹介</h3>
+            <p><strong>現場担当：山田 太郎（ダミー）</strong></p>
+            <p>地元での施工経験を活かし、近隣配慮と丁寧な説明を大切にしています。</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section alt" id="contact" aria-labelledby="contact-title">
+      <div class="container">
+        <h2 id="contact-title">お問い合わせ</h2>
+        <p>ご相談内容が未整理でも問題ありません。わかる範囲でご記入ください。</p>
+
+        <form id="contact-form" novalidate aria-label="お問い合わせフォーム">
+          <div class="form-grid">
+            <div class="form-field">
+              <label for="name">氏名 <span aria-hidden="true">*</span></label>
+              <input id="name" name="name" type="text" required autocomplete="name">
+              <p class="error-message" id="error-name" aria-live="polite"></p>
+            </div>
+            <div class="form-field">
+              <label for="phone">電話番号 <span aria-hidden="true">*</span></label>
+              <input id="phone" name="phone" type="tel" required autocomplete="tel">
+              <p class="error-message" id="error-phone" aria-live="polite"></p>
+            </div>
+            <div class="form-field">
+              <label for="email">メールアドレス <span aria-hidden="true">*</span></label>
+              <input id="email" name="email" type="email" required autocomplete="email">
+              <p class="error-message" id="error-email" aria-live="polite"></p>
+            </div>
+            <div class="form-field">
+              <label for="address">住所（任意）</label>
+              <input id="address" name="address" type="text" autocomplete="street-address">
+            </div>
+            <div class="form-field full-width">
+              <label for="message">ご相談内容 <span aria-hidden="true">*</span></label>
+              <textarea id="message" name="message" rows="5" required></textarea>
+              <p class="error-message" id="error-message" aria-live="polite"></p>
+            </div>
+            <fieldset class="form-field full-width">
+              <legend>希望連絡方法 <span aria-hidden="true">*</span></legend>
+              <label><input type="radio" name="contactMethod" value="電話" required> 電話</label>
+              <label><input type="radio" name="contactMethod" value="メール"> メール</label>
+              <label><input type="radio" name="contactMethod" value="どちらでも"> どちらでも</label>
+              <p class="error-message" id="error-contactMethod" aria-live="polite"></p>
+            </fieldset>
+            <div class="form-field full-width checkbox-wrap">
+              <label for="consent"><input id="consent" name="consent" type="checkbox" required> プライバシーポリシーに同意する <span aria-hidden="true">*</span></label>
+              <p class="error-message" id="error-consent" aria-live="polite"></p>
+            </div>
+          </div>
+          <button class="btn btn-primary" type="submit">送信する（ダミー）</button>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p>© 2026 まちの建設工務店</p>
+      <ul>
+        <li><a href="#">プライバシーポリシー</a></li>
+        <li><a href="#">免責事項</a></li>
+      </ul>
+    </div>
+  </footer>
+
+  <div id="modal" class="modal" hidden aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+    <div class="modal-content">
+      <h2 id="modal-title">送信内容を受け付けました（ダミー）</h2>
+      <p>担当より折り返しのご連絡を差し上げます。</p>
+      <button id="modal-close" class="btn btn-secondary" type="button">閉じる</button>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a single-file, framework-free landing page for a small local construction company implemented in pure HTML/CSS/JS with a warm (beige/terracotta/cream/brown) visual tone. 
- Meet accessibility, performance, SEO and security constraints: accessible controls, `prefers-reduced-motion` support, lazy-loaded images, no server-side form submission, and safe DOM handling.

### Description
- Added the full LP markup in `index.html` including required sections: header, hero, reasons, services,施工事例 (filterable gallery), お客様の声, 流れ, 料金の目安, FAQ (accordion), 会社情報, お問い合わせ form, footer, OGP/meta and JSON-LD (`LocalBusiness` / `ConstructionCompany`).
- Implemented styling in `assets/css/style.css` with warm color variables, responsive layout, focus-visible outlines, reduced-motion rules and accessible spacing/cards/buttons.
- Implemented interactions in `assets/js/main.js` (vanilla JS) covering mobile nav toggle, smooth scrolling (respects `prefers-reduced-motion`), FAQ accordion, work-category filter, and contact form validation plus a safe dummy modal; the code avoids `innerHTML` to prevent injecting user input.
- Performance/security choices: `script` loaded with `defer`, images marked `loading="lazy"`, form is client-side dummy-only and user input is not inserted back into the DOM, and qualification/permit statements are shown as "要確認" rather than claims.

### Testing
- Ran `node --check assets/js/main.js` to validate JS syntax, which completed successfully. 
- Started a local HTTP server with `python -m http.server 4173 --directory /workspace/mock-private` and verified rendering via an automated Playwright script that captured a screenshot, which succeeded. 
- No automated test failures were observed for the implemented behaviors (syntax and visual render check passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa11b694f4832986cb922b091a31f0)