### PR TITLE
Add iPad-oriented order & serving management mock UI (single-file HTML)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,1028 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>飲食店スタッフ向け 注文・提供管理モック</title>
+    <style>
+      :root {
+        --bg: #111311;
+        --panel: #171a18;
+        --panel-strong: #1d211f;
+        --panel-soft: #222826;
+        --line: rgba(212, 193, 132, 0.2);
+        --line-strong: rgba(212, 193, 132, 0.38);
+        --text: #f6f1e6;
+        --muted: #b7b0a1;
+        --accent: #d4c184;
+        --accent-deep: #8d7440;
+        --green: #315641;
+        --green-soft: rgba(78, 123, 94, 0.2);
+        --cream: #efe5d0;
+        --danger: #8c4a3f;
+        --shadow: 0 16px 40px rgba(0, 0, 0, 0.24);
+        --radius-xl: 24px;
+        --radius-lg: 18px;
+        --radius-md: 14px;
+        --radius-sm: 10px;
+        --transition: 180ms ease;
+        --status-new: #c48f3e;
+        --status-cooking: #5f8f6c;
+        --status-ready: #8f6b32;
+        --status-served: #626f68;
+      }
+
+      * { box-sizing: border-box; }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: Inter, "Noto Sans JP", "Hiragino Sans", "Yu Gothic UI", sans-serif;
+        background:
+          radial-gradient(circle at top left, rgba(212, 193, 132, 0.12), transparent 22%),
+          linear-gradient(135deg, #0d0f0e 0%, #141816 48%, #0f1110 100%);
+        color: var(--text);
+      }
+
+      button, input {
+        font: inherit;
+      }
+
+      .app-shell {
+        display: grid;
+        grid-template-columns: 248px minmax(0, 1.6fr) minmax(300px, 0.95fr);
+        gap: 18px;
+        min-height: 100vh;
+        padding: 18px;
+      }
+
+      .panel {
+        background: linear-gradient(180deg, rgba(27, 31, 29, 0.96), rgba(18, 20, 19, 0.96));
+        border: 1px solid var(--line);
+        box-shadow: var(--shadow);
+        border-radius: var(--radius-xl);
+      }
+
+      .sidebar {
+        padding: 24px 18px;
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+      }
+
+      .brand {
+        padding: 16px;
+        border-radius: var(--radius-lg);
+        background: linear-gradient(180deg, rgba(212, 193, 132, 0.14), rgba(212, 193, 132, 0.04));
+        border: 1px solid rgba(212, 193, 132, 0.18);
+      }
+
+      .brand small {
+        display: block;
+        color: var(--accent);
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        margin-bottom: 8px;
+      }
+
+      .brand h1 {
+        margin: 0;
+        font-size: 28px;
+        font-weight: 700;
+      }
+
+      .brand p {
+        margin: 8px 0 0;
+        color: var(--muted);
+        line-height: 1.5;
+        font-size: 14px;
+      }
+
+      .nav-list {
+        display: grid;
+        gap: 10px;
+      }
+
+      .nav-item {
+        border: 1px solid transparent;
+        background: rgba(255, 255, 255, 0.02);
+        color: var(--text);
+        border-radius: var(--radius-md);
+        min-height: 56px;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 0 16px;
+        cursor: pointer;
+        transition: background var(--transition), border-color var(--transition), transform var(--transition);
+      }
+
+      .nav-item:hover {
+        border-color: rgba(212, 193, 132, 0.2);
+        background: rgba(255, 255, 255, 0.04);
+      }
+
+      .nav-item.active {
+        background: linear-gradient(90deg, rgba(212, 193, 132, 0.2), rgba(212, 193, 132, 0.06));
+        border-color: var(--line-strong);
+        transform: translateX(2px);
+      }
+
+      .nav-icon {
+        width: 34px;
+        height: 34px;
+        border-radius: 10px;
+        display: grid;
+        place-items: center;
+        background: rgba(212, 193, 132, 0.12);
+        color: var(--accent);
+        font-size: 16px;
+        flex: 0 0 auto;
+      }
+
+      .sidebar-footer {
+        margin-top: auto;
+        padding: 16px;
+        border-radius: var(--radius-lg);
+        background: rgba(49, 86, 65, 0.12);
+        border: 1px solid rgba(96, 140, 110, 0.16);
+      }
+
+      .sidebar-footer h2,
+      .content-header h2,
+      .detail-placeholder h2,
+      .detail-card h2 {
+        margin: 0;
+        font-size: 18px;
+      }
+
+      .sidebar-footer p,
+      .content-header p,
+      .filter-summary,
+      .detail-placeholder p,
+      .detail-meta,
+      .detail-note,
+      .line-items li span:last-child,
+      .empty-state p {
+        color: var(--muted);
+      }
+
+      .content-area,
+      .detail-area {
+        padding: 22px;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+      }
+
+      .content-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: 16px;
+        margin-bottom: 18px;
+      }
+
+      .summary-badges {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+      }
+
+      .summary-badge {
+        min-width: 100px;
+        padding: 12px 14px;
+        border-radius: var(--radius-md);
+        background: rgba(255, 255, 255, 0.035);
+        border: 1px solid rgba(255, 255, 255, 0.06);
+      }
+
+      .summary-badge strong {
+        display: block;
+        font-size: 22px;
+        margin-bottom: 6px;
+      }
+
+      .toolbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 14px;
+        padding: 14px;
+        border-radius: var(--radius-lg);
+        background: rgba(255, 255, 255, 0.03);
+        border: 1px solid rgba(255, 255, 255, 0.06);
+        margin-bottom: 16px;
+      }
+
+      .filter-group {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+      }
+
+      .filter-chip,
+      .quick-action,
+      .status-button,
+      .detail-toggle {
+        border: 1px solid rgba(255, 255, 255, 0.09);
+        background: rgba(255, 255, 255, 0.03);
+        color: var(--text);
+        border-radius: 999px;
+        min-height: 44px;
+        padding: 0 16px;
+        cursor: pointer;
+        transition: background var(--transition), border-color var(--transition), transform var(--transition);
+      }
+
+      .filter-chip.active,
+      .quick-action:hover,
+      .status-button:hover,
+      .detail-toggle:hover {
+        background: rgba(212, 193, 132, 0.14);
+        border-color: rgba(212, 193, 132, 0.34);
+      }
+
+      .filter-chip.active {
+        color: var(--cream);
+      }
+
+      .toolbar-right {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        margin-left: auto;
+      }
+
+      .search-box {
+        position: relative;
+        min-width: 220px;
+      }
+
+      .search-box input {
+        width: 100%;
+        min-height: 46px;
+        border-radius: 999px;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        background: rgba(11, 12, 12, 0.66);
+        color: var(--text);
+        padding: 0 18px 0 42px;
+        outline: none;
+      }
+
+      .search-box::before {
+        content: "⌕";
+        position: absolute;
+        left: 16px;
+        top: 11px;
+        color: var(--muted);
+        font-size: 18px;
+      }
+
+      .cards-wrap {
+        overflow: auto;
+        padding-right: 4px;
+      }
+
+      .cards-grid {
+        display: grid;
+        gap: 14px;
+      }
+
+      .order-card {
+        border-radius: 20px;
+        background: linear-gradient(180deg, rgba(36, 40, 38, 0.96), rgba(27, 30, 29, 0.96));
+        border: 1px solid rgba(255, 255, 255, 0.06);
+        padding: 18px;
+        display: grid;
+        gap: 14px;
+        cursor: pointer;
+        transition: transform var(--transition), border-color var(--transition), box-shadow var(--transition);
+      }
+
+      .order-card:hover {
+        transform: translateY(-1px);
+        border-color: rgba(212, 193, 132, 0.22);
+      }
+
+      .order-card.selected {
+        border-color: rgba(212, 193, 132, 0.48);
+        box-shadow: 0 0 0 1px rgba(212, 193, 132, 0.22), 0 18px 30px rgba(0,0,0,0.18);
+      }
+
+      .card-top,
+      .card-meta,
+      .card-bottom,
+      .detail-header,
+      .detail-status-row,
+      .line-items li,
+      .detail-section {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+      }
+
+      .card-top,
+      .detail-header {
+        align-items: flex-start;
+      }
+
+      .table-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 12px;
+        border-radius: 999px;
+        background: rgba(212, 193, 132, 0.12);
+        color: var(--cream);
+        font-weight: 700;
+      }
+
+      .order-id,
+      .meta-label,
+      .detail-label,
+      .empty-state span {
+        color: var(--muted);
+        font-size: 13px;
+        letter-spacing: 0.04em;
+      }
+
+      .item-summary {
+        font-size: 18px;
+        font-weight: 700;
+      }
+
+      .meta-group {
+        display: grid;
+        gap: 4px;
+      }
+
+      .status-pill {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 92px;
+        padding: 8px 12px;
+        border-radius: 999px;
+        font-size: 13px;
+        font-weight: 700;
+        border: 1px solid transparent;
+      }
+
+      .status-new { background: rgba(196, 143, 62, 0.18); color: #f2c173; border-color: rgba(196, 143, 62, 0.22); }
+      .status-cooking { background: rgba(95, 143, 108, 0.18); color: #9fd8af; border-color: rgba(95, 143, 108, 0.24); }
+      .status-ready { background: rgba(165, 123, 57, 0.18); color: #edcb91; border-color: rgba(165, 123, 57, 0.22); }
+      .status-served { background: rgba(98, 111, 104, 0.22); color: #d4ddd8; border-color: rgba(98, 111, 104, 0.22); }
+
+      .quick-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .quick-action {
+        min-height: 40px;
+        padding: 0 14px;
+      }
+
+      .quick-action.recommended {
+        background: rgba(49, 86, 65, 0.22);
+        border-color: rgba(95, 143, 108, 0.36);
+      }
+
+      .detail-area {
+        position: relative;
+      }
+
+      .detail-card,
+      .detail-placeholder,
+      .empty-state {
+        border-radius: 20px;
+        border: 1px solid rgba(255, 255, 255, 0.06);
+        background: rgba(255, 255, 255, 0.03);
+      }
+
+      .detail-card,
+      .detail-placeholder {
+        padding: 20px;
+      }
+
+      .detail-card {
+        display: grid;
+        gap: 18px;
+      }
+
+      .detail-placeholder,
+      .empty-state {
+        display: grid;
+        place-items: center;
+        text-align: center;
+        min-height: 280px;
+      }
+
+      .detail-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+      }
+
+      .detail-stat {
+        padding: 14px;
+        border-radius: 16px;
+        background: rgba(0, 0, 0, 0.16);
+        border: 1px solid rgba(255, 255, 255, 0.05);
+      }
+
+      .detail-stat strong {
+        display: block;
+        margin-top: 8px;
+        font-size: 16px;
+      }
+
+      .line-items {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: grid;
+        gap: 10px;
+      }
+
+      .line-items li {
+        align-items: center;
+        padding: 12px 14px;
+        border-radius: 14px;
+        background: rgba(0, 0, 0, 0.16);
+      }
+
+      .detail-note {
+        padding: 14px 16px;
+        border-radius: 14px;
+        background: rgba(212, 193, 132, 0.08);
+        border: 1px solid rgba(212, 193, 132, 0.14);
+        line-height: 1.7;
+      }
+
+      .status-button-group {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+      }
+
+      .status-button.active {
+        background: rgba(212, 193, 132, 0.14);
+        border-color: rgba(212, 193, 132, 0.38);
+      }
+
+      .empty-state {
+        padding: 40px 20px;
+      }
+
+      .empty-state strong {
+        margin-top: 10px;
+        display: block;
+        font-size: 24px;
+      }
+
+      .detail-toggle {
+        display: none;
+        align-self: flex-end;
+        margin-bottom: 12px;
+      }
+
+      .status-flash {
+        animation: pulse 520ms ease;
+      }
+
+      @keyframes pulse {
+        0% { transform: scale(1); }
+        45% { transform: scale(1.02); }
+        100% { transform: scale(1); }
+      }
+
+      @media (max-width: 1180px) {
+        .app-shell {
+          grid-template-columns: 216px minmax(0, 1fr);
+        }
+
+        .detail-area {
+          position: fixed;
+          top: 18px;
+          right: 18px;
+          bottom: 18px;
+          width: min(360px, calc(100vw - 36px));
+          z-index: 20;
+          transform: translateX(calc(100% + 18px));
+          transition: transform var(--transition);
+        }
+
+        .detail-area.open {
+          transform: translateX(0);
+        }
+
+        .detail-toggle {
+          display: inline-flex;
+        }
+      }
+
+      @media (max-width: 820px) {
+        .app-shell {
+          grid-template-columns: 1fr;
+          padding: 12px;
+        }
+
+        .sidebar {
+          gap: 14px;
+        }
+
+        .nav-list {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+
+        .content-header,
+        .toolbar {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        .toolbar-right,
+        .summary-badges {
+          justify-content: flex-start;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="app-shell">
+      <aside class="panel sidebar">
+        <section class="brand">
+          <small>WAMODERN TABLET</small>
+          <h1>花暦 供応台帳</h1>
+          <p>注文確認から提供完了まで、現場スタッフが迷わず扱える和モダン業務UI。</p>
+        </section>
+
+        <nav class="nav-list" aria-label="サイドメニュー">
+          <button class="nav-item" type="button"><span class="nav-icon">◫</span><span>ダッシュボード</span></button>
+          <button class="nav-item active" type="button"><span class="nav-icon">注</span><span>注文一覧</span></button>
+          <button class="nav-item" type="button"><span class="nav-icon">提</span><span>提供管理</span></button>
+          <button class="nav-item" type="button"><span class="nav-icon">在</span><span>在庫</span></button>
+          <button class="nav-item" type="button"><span class="nav-icon">設</span><span>設定</span></button>
+        </nav>
+
+        <section class="sidebar-footer">
+          <h2>本日の運用メモ</h2>
+          <p>17:00〜19:00は来店集中帯。提供待ちの注文を優先表示し、テーブル18番のアレルギー注記に注意。</p>
+        </section>
+      </aside>
+
+      <main class="panel content-area">
+        <header class="content-header">
+          <div>
+            <h2>注文・提供管理</h2>
+            <p>一覧確認、ステータス更新、詳細確認を3タップ以内で完結できるレイアウトです。</p>
+          </div>
+          <div class="summary-badges" id="summaryBadges"></div>
+        </header>
+
+        <section class="toolbar" aria-label="絞り込みと検索">
+          <div class="filter-group" id="filterGroup"></div>
+          <div class="toolbar-right">
+            <div class="search-box">
+              <label for="searchInput" class="sr-only" style="position:absolute;left:-9999px;">検索</label>
+              <input id="searchInput" type="search" placeholder="テーブル番号・注文ID・商品名で検索" />
+            </div>
+            <button class="detail-toggle" id="detailToggle" type="button">詳細を表示</button>
+          </div>
+        </section>
+
+        <div class="filter-summary" id="filterSummary" aria-live="polite"></div>
+        <section class="cards-wrap">
+          <div class="cards-grid" id="orderList" aria-live="polite"></div>
+        </section>
+      </main>
+
+      <aside class="panel detail-area" id="detailPane">
+        <button class="detail-toggle" id="detailClose" type="button">詳細を閉じる</button>
+        <div id="detailContent"></div>
+      </aside>
+    </div>
+
+    <script>
+      const orders = [
+        {
+          id: 'OD-240319-101',
+          table: '2',
+          time: '17:08',
+          items: ['だし巻き卵', '焼き鳥盛り合わせ', '生ビール'],
+          quantity: 5,
+          status: '新規',
+          memo: '焼き鳥は塩多め希望。',
+          staff: '斎藤',
+        },
+        {
+          id: 'OD-240319-102',
+          table: '5',
+          time: '17:11',
+          items: ['唐揚げ', 'ポテトサラダ', '烏龍茶'],
+          quantity: 4,
+          status: '調理中',
+          memo: 'お子様連れ。提供はまとめて。',
+          staff: '中村',
+        },
+        {
+          id: 'OD-240319-103',
+          table: '8',
+          time: '17:15',
+          items: ['お刺身盛り合わせ', '日本酒 一合', '枝豆'],
+          quantity: 3,
+          status: '提供待ち',
+          memo: '日本酒は常温。',
+          staff: '小川',
+        },
+        {
+          id: 'OD-240319-104',
+          table: '12',
+          time: '17:19',
+          items: ['焼き魚定食', '味噌汁'],
+          quantity: 2,
+          status: '提供済み',
+          memo: '食後に温かいお茶。',
+          staff: '山口',
+        },
+        {
+          id: 'OD-240319-105',
+          table: '14',
+          time: '17:22',
+          items: ['天ぷら盛り合わせ', '白ごはん', '赤だし'],
+          quantity: 4,
+          status: '調理中',
+          memo: '海老アレルギーのため野菜天のみ。',
+          staff: '高橋',
+        },
+        {
+          id: 'OD-240319-106',
+          table: '18',
+          time: '17:24',
+          items: ['鯖の塩焼き', '冷奴', '日本酒 二合'],
+          quantity: 4,
+          status: '新規',
+          memo: '落ち着いた席のため呼び出し後に提供。',
+          staff: '伊藤',
+        },
+        {
+          id: 'OD-240319-107',
+          table: '21',
+          time: '17:27',
+          items: ['海鮮丼', '茶碗蒸し'],
+          quantity: 2,
+          status: '提供待ち',
+          memo: '茶碗蒸しは熱さに注意。',
+          staff: '青木',
+        },
+        {
+          id: 'OD-240319-108',
+          table: '24',
+          time: '17:31',
+          items: ['牛すじ煮込み', 'だし茶漬け', '瓶ビール'],
+          quantity: 3,
+          status: '調理中',
+          memo: '瓶ビールはグラス2つ。',
+          staff: '吉田',
+        },
+        {
+          id: 'OD-240319-109',
+          table: '26',
+          time: '17:35',
+          items: ['季節の小鉢三種', '梅酒ソーダ'],
+          quantity: 2,
+          status: '提供済み',
+          memo: '追加注文の可能性あり。',
+          staff: '佐々木',
+        },
+      ];
+
+      const statusOrder = ['新規', '調理中', '提供待ち', '提供済み'];
+      const statusClassMap = {
+        '新規': 'status-new',
+        '調理中': 'status-cooking',
+        '提供待ち': 'status-ready',
+        '提供済み': 'status-served',
+      };
+
+      const filterOptions = ['全件', ...statusOrder];
+      const state = {
+        selectedOrderId: orders[0].id,
+        filter: '全件',
+        query: '',
+      };
+
+      const orderList = document.getElementById('orderList');
+      const detailContent = document.getElementById('detailContent');
+      const filterGroup = document.getElementById('filterGroup');
+      const filterSummary = document.getElementById('filterSummary');
+      const summaryBadges = document.getElementById('summaryBadges');
+      const searchInput = document.getElementById('searchInput');
+      const detailPane = document.getElementById('detailPane');
+      const detailToggle = document.getElementById('detailToggle');
+      const detailClose = document.getElementById('detailClose');
+
+      function getRecommendedNextStatus(currentStatus) {
+        const currentIndex = statusOrder.indexOf(currentStatus);
+        if (currentIndex === -1 || currentIndex === statusOrder.length - 1) return null;
+        return statusOrder[currentIndex + 1];
+      }
+
+      function getFilteredOrders() {
+        return orders.filter((order) => {
+          const matchesFilter = state.filter === '全件' || order.status === state.filter;
+          const query = state.query.trim().toLowerCase();
+          const searchTarget = [order.table, order.id, ...order.items].join(' ').toLowerCase();
+          const matchesSearch = !query || searchTarget.includes(query);
+          return matchesFilter && matchesSearch;
+        });
+      }
+
+      function createButton(label, className, onClick) {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = className;
+        button.textContent = label;
+        button.addEventListener('click', onClick);
+        return button;
+      }
+
+      function renderSummary() {
+        summaryBadges.textContent = '';
+        const counts = {
+          全件: orders.length,
+          新規: orders.filter((order) => order.status === '新規').length,
+          調理中: orders.filter((order) => order.status === '調理中').length,
+          提供待ち: orders.filter((order) => order.status === '提供待ち').length,
+          提供済み: orders.filter((order) => order.status === '提供済み').length,
+        };
+
+        ['全件', '新規', '調理中', '提供待ち'].forEach((label) => {
+          const badge = document.createElement('div');
+          badge.className = 'summary-badge';
+          const strong = document.createElement('strong');
+          strong.textContent = String(counts[label]);
+          const small = document.createElement('span');
+          small.textContent = label === '全件' ? '現在の注文数' : `${label}の件数`;
+          badge.append(strong, small);
+          summaryBadges.appendChild(badge);
+        });
+      }
+
+      function renderFilters() {
+        filterGroup.textContent = '';
+        filterOptions.forEach((option) => {
+          const button = createButton(option, `filter-chip${state.filter === option ? ' active' : ''}`, () => {
+            state.filter = option;
+            const visibleOrders = getFilteredOrders();
+            if (!visibleOrders.some((order) => order.id === state.selectedOrderId)) {
+              state.selectedOrderId = visibleOrders[0]?.id || null;
+            }
+            renderApp();
+          });
+          filterGroup.appendChild(button);
+        });
+      }
+
+      function renderOrderCard(order) {
+        const card = document.createElement('article');
+        const selected = order.id === state.selectedOrderId;
+        card.className = `order-card${selected ? ' selected' : ''}`;
+        card.tabIndex = 0;
+        card.setAttribute('role', 'button');
+        card.setAttribute('aria-pressed', String(selected));
+        card.addEventListener('click', () => selectOrder(order.id));
+        card.addEventListener('keydown', (event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            selectOrder(order.id);
+          }
+        });
+
+        const top = document.createElement('div');
+        top.className = 'card-top';
+
+        const leftTop = document.createElement('div');
+        const tableBadge = document.createElement('div');
+        tableBadge.className = 'table-badge';
+        tableBadge.textContent = `テーブル ${order.table}`;
+        const orderId = document.createElement('div');
+        orderId.className = 'order-id';
+        orderId.textContent = order.id;
+        leftTop.append(tableBadge, orderId);
+
+        const status = document.createElement('div');
+        status.className = `status-pill ${statusClassMap[order.status]}`;
+        status.textContent = order.status;
+
+        top.append(leftTop, status);
+
+        const summary = document.createElement('div');
+        summary.className = 'item-summary';
+        summary.textContent = `${order.items[0]}${order.items.length > 1 ? ` ほか${order.items.length - 1}品` : ''}`;
+
+        const meta = document.createElement('div');
+        meta.className = 'card-meta';
+        const timeGroup = document.createElement('div');
+        timeGroup.className = 'meta-group';
+        timeGroup.innerHTML = `<span class="meta-label">注文時刻</span><strong>${order.time}</strong>`;
+        const qtyGroup = document.createElement('div');
+        qtyGroup.className = 'meta-group';
+        qtyGroup.innerHTML = `<span class="meta-label">合計点数</span><strong>${order.quantity}点</strong>`;
+        meta.append(timeGroup, qtyGroup);
+
+        const bottom = document.createElement('div');
+        bottom.className = 'card-bottom';
+        const memo = document.createElement('div');
+        memo.className = 'meta-group';
+        memo.innerHTML = `<span class="meta-label">メモ</span><strong>${order.memo}</strong>`;
+
+        const quickActions = document.createElement('div');
+        quickActions.className = 'quick-actions';
+        statusOrder.forEach((nextStatus) => {
+          if (nextStatus === order.status) return;
+          const action = createButton(
+            `${nextStatus}へ`,
+            `quick-action${getRecommendedNextStatus(order.status) === nextStatus ? ' recommended' : ''}`,
+            (event) => {
+              event.stopPropagation();
+              updateOrderStatus(order.id, nextStatus);
+            }
+          );
+          quickActions.appendChild(action);
+        });
+
+        bottom.append(memo, quickActions);
+        card.append(top, summary, meta, bottom);
+        return card;
+      }
+
+      function renderOrders() {
+        const filteredOrders = getFilteredOrders();
+        orderList.textContent = '';
+
+        const summaryText = `${state.filter}：${filteredOrders.length}件表示 / 全${orders.length}件`;
+        filterSummary.textContent = state.query ? `${summaryText} / 検索「${state.query}」` : summaryText;
+
+        if (filteredOrders.length === 0) {
+          const empty = document.createElement('div');
+          empty.className = 'empty-state';
+          const icon = document.createElement('span');
+          icon.textContent = '○';
+          const strong = document.createElement('strong');
+          strong.textContent = '該当する注文はありません';
+          const text = document.createElement('p');
+          text.textContent = '絞り込み条件または検索語を変更すると、注文カードが表示されます。';
+          empty.append(icon, strong, text);
+          orderList.appendChild(empty);
+          return;
+        }
+
+        filteredOrders.forEach((order) => {
+          orderList.appendChild(renderOrderCard(order));
+        });
+      }
+
+      function renderDetail() {
+        detailContent.textContent = '';
+        const selectedOrder = orders.find((order) => order.id === state.selectedOrderId);
+
+        if (!selectedOrder) {
+          const placeholder = document.createElement('section');
+          placeholder.className = 'detail-placeholder';
+          const title = document.createElement('h2');
+          title.textContent = '注文カードを選択してください';
+          const text = document.createElement('p');
+          text.textContent = '右側にテーブル情報、商品一覧、メモ、担当者、ステータス更新を表示します。';
+          placeholder.append(title, text);
+          detailContent.appendChild(placeholder);
+          return;
+        }
+
+        const card = document.createElement('section');
+        card.className = 'detail-card status-flash';
+
+        const header = document.createElement('div');
+        header.className = 'detail-header';
+        const headingGroup = document.createElement('div');
+        const title = document.createElement('h2');
+        title.textContent = `テーブル ${selectedOrder.table}`;
+        const meta = document.createElement('div');
+        meta.className = 'detail-meta';
+        meta.textContent = `${selectedOrder.id} ・ 注文時刻 ${selectedOrder.time}`;
+        headingGroup.append(title, meta);
+        const status = document.createElement('div');
+        status.className = `status-pill ${statusClassMap[selectedOrder.status]}`;
+        status.textContent = selectedOrder.status;
+        header.append(headingGroup, status);
+
+        const stats = document.createElement('div');
+        stats.className = 'detail-grid';
+        [
+          ['合計点数', `${selectedOrder.quantity}点`],
+          ['担当者', selectedOrder.staff],
+          ['提供優先度', selectedOrder.status === '提供待ち' ? '高' : '標準'],
+          ['現在操作', getRecommendedNextStatus(selectedOrder.status) ? `${getRecommendedNextStatus(selectedOrder.status)}へ更新可能` : '対応完了'],
+        ].forEach(([label, value]) => {
+          const stat = document.createElement('div');
+          stat.className = 'detail-stat';
+          const small = document.createElement('span');
+          small.className = 'detail-label';
+          small.textContent = label;
+          const strong = document.createElement('strong');
+          strong.textContent = value;
+          stat.append(small, strong);
+          stats.appendChild(stat);
+        });
+
+        const itemsSection = document.createElement('section');
+        const itemsTitle = document.createElement('h3');
+        itemsTitle.textContent = '注文商品一覧';
+        itemsTitle.style.margin = '0 0 12px';
+        const lineItems = document.createElement('ul');
+        lineItems.className = 'line-items';
+        selectedOrder.items.forEach((item, index) => {
+          const li = document.createElement('li');
+          const itemName = document.createElement('strong');
+          itemName.textContent = item;
+          const itemCount = document.createElement('span');
+          itemCount.textContent = `商品 ${index + 1}`;
+          li.append(itemName, itemCount);
+          lineItems.appendChild(li);
+        });
+        itemsSection.append(itemsTitle, lineItems);
+
+        const memoSection = document.createElement('section');
+        const memoTitle = document.createElement('h3');
+        memoTitle.textContent = '共有メモ';
+        memoTitle.style.margin = '0 0 12px';
+        const note = document.createElement('div');
+        note.className = 'detail-note';
+        note.textContent = selectedOrder.memo;
+        memoSection.append(memoTitle, note);
+
+        const actionSection = document.createElement('section');
+        const actionTitle = document.createElement('h3');
+        actionTitle.textContent = 'ステータス変更';
+        actionTitle.style.margin = '0 0 12px';
+        const buttonGroup = document.createElement('div');
+        buttonGroup.className = 'status-button-group';
+        statusOrder.forEach((statusName) => {
+          const button = createButton(statusName, `status-button${selectedOrder.status === statusName ? ' active' : ''}`, () => {
+            updateOrderStatus(selectedOrder.id, statusName);
+          });
+          buttonGroup.appendChild(button);
+        });
+        actionSection.append(actionTitle, buttonGroup);
+
+        card.append(header, stats, itemsSection, memoSection, actionSection);
+        detailContent.appendChild(card);
+      }
+
+      function selectOrder(orderId) {
+        state.selectedOrderId = orderId;
+        renderApp();
+        if (window.innerWidth <= 1180) {
+          detailPane.classList.add('open');
+        }
+      }
+
+      function updateOrderStatus(orderId, nextStatus) {
+        const target = orders.find((order) => order.id === orderId);
+        if (!target || target.status === nextStatus) return;
+        target.status = nextStatus;
+        renderApp();
+      }
+
+      function renderApp() {
+        renderSummary();
+        renderFilters();
+        renderOrders();
+        renderDetail();
+      }
+
+      searchInput.addEventListener('input', (event) => {
+        state.query = event.target.value;
+        const visibleOrders = getFilteredOrders();
+        if (!visibleOrders.some((order) => order.id === state.selectedOrderId)) {
+          state.selectedOrderId = visibleOrders[0]?.id || null;
+        }
+        renderApp();
+      });
+
+      detailToggle.addEventListener('click', () => {
+        detailPane.classList.add('open');
+      });
+
+      detailClose.addEventListener('click', () => {
+        detailPane.classList.remove('open');
+      });
+
+      renderApp();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a high-fidelity, interactive tablet mock for restaurant staff to view and update orders from a single HTML file. 
- Support quick, low-cognitive operations (3 taps or fewer) with clear status transitions and an approachable UI for non‑engineer staff. 
- Demonstrate a production-like layout (left sidebar, center card list, right detail pane) with a Japanese "和モダン" visual language and readable typography fallbacks. 

### Description
- Add `index.html` containing a self-contained HTML/CSS/JS mock implementing a three-pane (sidebar / cards / detail) iPad‑landscape UI with CSS variables for colors, radii and responsive breakpoints. 
- Provide 9 naturalistic dummy orders (table, order ID, time, items, quantity, status, memo, staff) and a status workflow `['新規','調理中','提供待ち','提供済み']` with mapped status pill styles. 
- Implement client-side UI features: status filters, search (`searchInput`), summary badges, itemized order cards, right-side detail pane (`detailPane`), one-tap status updates from both cards and detail, recommended next-action highlight, empty-state UI, and responsive toggling of the detail pane for narrow screens. 
- Keep JavaScript small and DOM-driven (helper `createButton`, safe DOM construction, minimal `innerHTML` usage), and add accessibility attributes (roles, `aria-live`) and keyboard activation for cards. 

### Testing
- Verified local HTTP serve and fetch using `python3 -m http.server 8123` and `curl -I http://127.0.0.1:8123/index.html` which returned HTTP 200 OK. 
- Performed static content checks with a Node script confirming presence of required UI labels and hooks (checked strings like `ダッシュボード`, `注文一覧`, `提供管理`, `在庫`, `設定`, `const orders = [`, `提供待ち`, `detailPane`, `searchInput`) and the script passed. 
- Manual smoke-run in the generated file confirmed filter/search, selection, and immediate status updates reflect in both list and detail panes (all checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb91bbd6cc8329a3fc45a14f0821f0)