### PR TITLE
Add Three.js 8x8x5 pathfinding visualization mock

### DIFF
--- a/route-3d-grid/index.html
+++ b/route-3d-grid/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>3D Grid Pathfinding Mock</title>
+    <script type="module" src="/src/main.js"></script>
+  </head>
+  <body>
+    <div id="app">
+      <div id="scene-container"></div>
+      <aside id="control-panel">
+        <h1>Route 3D Grid</h1>
+
+        <section>
+          <h2>Mode</h2>
+          <div id="mode-buttons" class="button-group"></div>
+        </section>
+
+        <section>
+          <h2>Height</h2>
+          <select id="height-select">
+            <option value="0">-2 (z=0)</option>
+            <option value="1">-1 (z=1)</option>
+            <option value="2" selected>0 (z=2)</option>
+            <option value="3">+1 (z=3)</option>
+            <option value="4">+2 (z=4)</option>
+          </select>
+        </section>
+
+        <section>
+          <h2>Search</h2>
+          <div class="button-group" id="search-buttons"></div>
+        </section>
+
+        <section>
+          <h2>Logs & JSON</h2>
+          <div class="button-group" id="log-buttons"></div>
+          <input id="json-import" type="file" accept="application/json" />
+        </section>
+
+        <section>
+          <h2>Selection</h2>
+          <pre id="selection-info">none</pre>
+        </section>
+
+        <section>
+          <h2>Logs</h2>
+          <div id="log-table-wrap">
+            <table id="log-table">
+              <thead>
+                <tr>
+                  <th>step</th><th>action</th><th>from</th><th>to</th>
+                  <th>heightDiff</th><th>cost</th><th>totalCost</th><th>result/reason</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </section>
+      </aside>
+    </div>
+  </body>
+</html>

--- a/route-3d-grid/package.json
+++ b/route-3d-grid/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "route-3d-grid",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "three": "^0.177.0"
+  },
+  "devDependencies": {
+    "vite": "^5.4.0"
+  }
+}

--- a/route-3d-grid/src/grid.js
+++ b/route-3d-grid/src/grid.js
@@ -1,0 +1,44 @@
+export const GRID_SIZE = { x: 8, y: 8, z: 5 };
+export const BASE_Z = 2;
+
+export function makeCell(x, y, z = BASE_Z) {
+  return { x, y, z, heightLevel: z - BASE_Z, blocked: false, type: "normal" };
+}
+
+export function createGrid() {
+  const cells = [];
+  for (let y = 0; y < GRID_SIZE.y; y++) {
+    const row = [];
+    for (let x = 0; x < GRID_SIZE.x; x++) row.push(makeCell(x, y));
+    cells.push(row);
+  }
+  return cells;
+}
+
+export function applySampleData(state) {
+  const high = [[2,2,3],[3,2,4],[4,2,3],[5,5,1],[5,6,0],[1,6,3]];
+  const blocked = [[3,3],[3,4],[4,4],[2,5]];
+  high.forEach(([x,y,z]) => updateCellHeight(state.cells[y][x], z));
+  blocked.forEach(([x,y]) => { state.cells[y][x].blocked = true; state.cells[y][x].type = "blocked";});
+}
+
+export function updateCellHeight(cell, z) {
+  cell.z = Math.max(0, Math.min(4, z));
+  cell.heightLevel = cell.z - BASE_Z;
+}
+
+export function inBounds(x, y) {
+  return x >= 0 && x < GRID_SIZE.x && y >= 0 && y < GRID_SIZE.y;
+}
+
+export function toSerializableState(state) {
+  return {
+    gridSize: GRID_SIZE,
+    baseZ: BASE_Z,
+    cells: state.cells.flat().map(({x,y,z,blocked}) => ({x,y,z,blocked})),
+    start: state.start,
+    goal: state.goal,
+    path: state.path,
+    logs: state.logs
+  };
+}

--- a/route-3d-grid/src/logger.js
+++ b/route-3d-grid/src/logger.js
@@ -1,0 +1,10 @@
+export class Logger {
+  constructor() { this.logs = []; this.step = 1; }
+  add(entry) { this.logs.push({ step: this.step++, ...entry }); }
+  clear() { this.logs = []; this.step = 1; }
+}
+
+export function formatCoord(c) {
+  if (!c) return "-";
+  return `(${c.x},${c.y},z${c.z}|h${c.heightLevel})`;
+}

--- a/route-3d-grid/src/main.js
+++ b/route-3d-grid/src/main.js
@@ -1,0 +1,104 @@
+import './styles.css';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { BASE_Z, createGrid, applySampleData, toSerializableState, updateCellHeight } from './grid.js';
+import { Logger } from './logger.js';
+import { runAStarSteps } from './pathfinding.js';
+import { setupUI, renderLogs, renderSelection } from './ui.js';
+
+const state = { cells:createGrid(), start:{x:0,y:0}, goal:{x:7,y:7}, path:[], logs:[], mode:'block', closed:[] };
+applySampleData(state);
+const logger = new Logger();
+
+const scene = new THREE.Scene(); scene.background = new THREE.Color(0x10141d);
+const camera = new THREE.PerspectiveCamera(60,1,0.1,1000); camera.position.set(10,14,14);
+const renderer = new THREE.WebGLRenderer({antialias:true});
+const container = document.querySelector('#scene-container'); container.appendChild(renderer.domElement);
+const controls = new OrbitControls(camera, renderer.domElement); controls.target.set(3.5,0,3.5);
+scene.add(new THREE.AmbientLight(0xffffff,0.7)); const dl=new THREE.DirectionalLight(0xffffff,0.8); dl.position.set(8,12,4); scene.add(dl);
+
+const root = new THREE.Group(); scene.add(root);
+let pathLine = null;
+const raycaster = new THREE.Raycaster(); const pointer = new THREE.Vector2();
+
+function cellColor(c) {
+  if (state.start.x===c.x && state.start.y===c.y) return 0x26c281;
+  if (state.goal.x===c.x && state.goal.y===c.y) return 0xe74c3c;
+  if (c.blocked) return 0x1b1b1b;
+  if (state.path.some(p=>p.x===c.x&&p.y===c.y)) return 0xffd166;
+  if (state.closed.some(p=>p.x===c.x&&p.y===c.y)) return 0x7fb3ff;
+  return c.z === BASE_Z ? 0x7d8ca3 : (c.z > BASE_Z ? 0x9dbf9e : 0x6f7a92);
+}
+
+function redrawGrid() {
+  root.clear();
+  const gridHelper = new THREE.GridHelper(8,8,0x58657d,0x293141); gridHelper.position.set(3.5,0,3.5); scene.add(gridHelper);
+  state.cells.flat().forEach(c=>{
+    const h = 0.2 + c.z * 0.45;
+    const g = new THREE.BoxGeometry(0.9,h,0.9);
+    const m = new THREE.MeshStandardMaterial({ color: cellColor(c) });
+    const mesh = new THREE.Mesh(g,m);
+    mesh.position.set(c.x, h/2, c.y);
+    mesh.userData = { x:c.x, y:c.y };
+    root.add(mesh);
+  });
+  if (pathLine) scene.remove(pathLine);
+  if (state.path.length > 1) {
+    const pts = state.path.map(p => new THREE.Vector3(p.x, 0.25 + state.cells[p.y][p.x].z*0.45, p.y));
+    const geom = new THREE.BufferGeometry().setFromPoints(pts);
+    pathLine = new THREE.Line(geom, new THREE.LineBasicMaterial({ color:0xffff00 }));
+    scene.add(pathLine);
+  }
+}
+
+function doSearch() {
+  logger.clear();
+  const result = runAStarSteps(state, logger);
+  state.closed = result.closedOrder;
+  state.path = result.path;
+  state.logs = logger.logs;
+  redrawGrid(); renderLogs(state.logs);
+}
+
+renderer.domElement.addEventListener('click', (ev)=>{
+  const rect = renderer.domElement.getBoundingClientRect();
+  pointer.x = ((ev.clientX - rect.left) / rect.width) * 2 - 1;
+  pointer.y = -((ev.clientY - rect.top) / rect.height) * 2 + 1;
+  raycaster.setFromCamera(pointer, camera);
+  const hit = raycaster.intersectObjects(root.children)[0];
+  if (!hit) return;
+  const {x,y} = hit.object.userData;
+  const c = state.cells[y][x];
+  if (state.mode==='start') state.start = {x,y};
+  else if (state.mode==='goal') state.goal = {x,y};
+  else if (state.mode==='block') { c.blocked=!c.blocked; c.type=c.blocked?'blocked':'normal'; }
+  else if (state.mode==='height') updateCellHeight(c, Number(document.querySelector('#height-select').value));
+  else if (state.mode==='normal') { c.blocked=false; c.type='normal'; updateCellHeight(c, BASE_Z); }
+  renderSelection(c); redrawGrid();
+});
+
+setupUI(state, {
+  run: doSearch,
+  step: doSearch,
+  auto: doSearch,
+  reset: ()=>{state.path=[];state.closed=[];logger.clear();state.logs=[]; redrawGrid(); renderLogs([]);},
+  clear: ()=>{ state.cells=createGrid(); applySampleData(state); state.start={x:0,y:0}; state.goal={x:7,y:7}; state.path=[]; state.closed=[]; logger.clear(); state.logs=[]; redrawGrid(); renderLogs([]); },
+  clearLogs: ()=>{ logger.clear(); state.logs=[]; renderLogs([]); },
+  exportJson: ()=>{
+    const data = JSON.stringify(toSerializableState({...state, logs:state.logs}), null, 2);
+    const a = document.createElement('a'); a.href = URL.createObjectURL(new Blob([data],{type:'application/json'})); a.download='route3d.json'; a.click();
+  },
+  importJson: (e)=>{
+    const file = e.target.files[0]; if (!file) return;
+    const r = new FileReader(); r.onload = ()=>{
+      const d = JSON.parse(r.result);
+      d.cells.forEach(cc=>{ const c = state.cells[cc.y][cc.x]; c.z=cc.z; c.heightLevel=cc.z-BASE_Z; c.blocked=cc.blocked; });
+      state.start=d.start; state.goal=d.goal; state.path=d.path ?? []; state.logs=d.logs ?? []; state.closed=[];
+      renderLogs(state.logs); redrawGrid();
+    }; r.readAsText(file);
+  }
+});
+
+function resize(){ const w=container.clientWidth,h=container.clientHeight; renderer.setSize(w,h); camera.aspect=w/h; camera.updateProjectionMatrix(); }
+window.addEventListener('resize', resize); resize(); redrawGrid();
+(function animate(){ requestAnimationFrame(animate); controls.update(); renderer.render(scene,camera); })();

--- a/route-3d-grid/src/pathfinding.js
+++ b/route-3d-grid/src/pathfinding.js
@@ -1,0 +1,66 @@
+import { inBounds } from './grid.js';
+
+const dirs = [[1,0],[-1,0],[0,1],[0,-1]];
+
+const key = (x,y) => `${x},${y}`;
+
+function heuristic(a, b, az, bz) {
+  return Math.abs(a.x - b.x) + Math.abs(a.y - b.y) + Math.abs(az - bz) * 0.4;
+}
+
+function moveCost(from, to) {
+  const diff = to.z - from.z;
+  if (diff > 0) return 1 + diff;
+  if (diff < 0) return 1 + 0.5 * Math.abs(diff);
+  return 1;
+}
+
+export function runAStarSteps(state, logger) {
+  const start = state.cells[state.start.y][state.start.x];
+  const goal = state.cells[state.goal.y][state.goal.x];
+  const open = [{ x:start.x, y:start.y, f:0, g:0 }];
+  const gScore = new Map([[key(start.x,start.y), 0]]);
+  const came = new Map();
+  const closedOrder = [];
+
+  while (open.length) {
+    open.sort((a,b)=>a.f-b.f);
+    const cur = open.shift();
+    const curCell = state.cells[cur.y][cur.x];
+    closedOrder.push({x:cur.x,y:cur.y});
+    logger.add({ action:'EVAL', from:curCell, to:curCell, heightDiff:0, cost:0, totalCost:cur.g, result:'OK' });
+
+    if (cur.x === goal.x && cur.y === goal.y) {
+      const path = [];
+      let ck = key(cur.x,cur.y);
+      while (ck) {
+        const [x,y] = ck.split(',').map(Number);
+        const c = state.cells[y][x];
+        path.push({x,y,z:c.z});
+        ck = came.get(ck);
+      }
+      path.reverse();
+      return { found:true, closedOrder, path };
+    }
+
+    for (const [dx,dy] of dirs) {
+      const nx = cur.x + dx, ny = cur.y + dy;
+      if (!inBounds(nx,ny)) continue;
+      const next = state.cells[ny][nx];
+      const diff = next.z - curCell.z;
+      if (next.blocked) { logger.add({ action:'BLOCKED', from:curCell, to:next, reason:'blocked' }); continue; }
+      if (Math.abs(diff) > 1) { logger.add({ action:'BLOCKED', from:curCell, to:next, reason:'height_diff_over_limit' }); continue; }
+
+      const tentativeG = cur.g + moveCost(curCell, next);
+      const nk = key(nx,ny);
+      if (tentativeG < (gScore.get(nk) ?? Infinity)) {
+        came.set(nk, key(cur.x,cur.y));
+        gScore.set(nk, tentativeG);
+        const f = tentativeG + heuristic({x:nx,y:ny}, goal, next.z, goal.z);
+        if (!open.some(n=>n.x===nx&&n.y===ny)) open.push({x:nx,y:ny,g:tentativeG,f});
+        logger.add({ action:'MOVE', from:curCell, to:next, heightDiff:diff, cost:tentativeG-cur.g, totalCost:tentativeG, result:'OK' });
+      }
+    }
+  }
+  return { found:false, closedOrder, path:[] };
+}

--- a/route-3d-grid/src/styles.css
+++ b/route-3d-grid/src/styles.css
@@ -1,0 +1,14 @@
+:root { color-scheme: dark; font-family: Inter, system-ui, sans-serif; }
+body { margin: 0; }
+#app { display: grid; grid-template-columns: 1fr 380px; height: 100vh; }
+#scene-container { background: #0e1116; }
+#control-panel { padding: 12px; overflow: auto; background: #181d26; }
+h1,h2 { margin: 8px 0; }
+section { margin-bottom: 10px; border: 1px solid #293141; padding: 8px; border-radius: 8px; }
+.button-group { display: flex; flex-wrap: wrap; gap: 6px; }
+button { border: 1px solid #465268; background:#232b3a; color:#e8f0ff; padding:6px 8px; border-radius:6px; cursor:pointer; }
+button.active { background:#3a7bd5; }
+#log-table-wrap { max-height: 280px; overflow:auto; }
+table { border-collapse: collapse; width:100%; font-size:12px; }
+th,td { border: 1px solid #3a455b; padding: 4px; }
+pre { margin: 0; white-space: pre-wrap; }

--- a/route-3d-grid/src/ui.js
+++ b/route-3d-grid/src/ui.js
@@ -1,0 +1,36 @@
+import { formatCoord } from './logger.js';
+
+export function setupUI(state, handlers) {
+  const modes = ['start','goal','block','height','normal'];
+  const labels = {start:'Start設定',goal:'Goal設定',block:'障害物切替',height:'高さ変更',normal:'通常セル化'};
+  const modeWrap = document.querySelector('#mode-buttons');
+  modes.forEach(m=>{
+    const b = document.createElement('button'); b.textContent = labels[m];
+    b.onclick=()=>{ state.mode=m; [...modeWrap.children].forEach(c=>c.classList.remove('active')); b.classList.add('active');};
+    if (m===state.mode) b.classList.add('active'); modeWrap.appendChild(b);
+  });
+
+  const searchOps = [['Run A*','run'],['Step実行','step'],['Auto再生','auto'],['Reset Search','reset'],['Clear All','clear']];
+  const sw = document.querySelector('#search-buttons');
+  searchOps.forEach(([t,k])=>{ const b=document.createElement('button'); b.textContent=t; b.onclick=handlers[k]; sw.appendChild(b); });
+
+  const logOps = [['ログクリア','clearLogs'],['JSONエクスポート','exportJson']];
+  const lw = document.querySelector('#log-buttons');
+  logOps.forEach(([t,k])=>{ const b=document.createElement('button'); b.textContent=t; b.onclick=handlers[k]; lw.appendChild(b); });
+
+  document.querySelector('#json-import').addEventListener('change', handlers.importJson);
+}
+
+export function renderLogs(logs) {
+  const tbody = document.querySelector('#log-table tbody');
+  tbody.innerHTML = '';
+  logs.forEach(l=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${l.step ?? ''}</td><td>${l.action ?? ''}</td><td>${formatCoord(l.from)}</td><td>${formatCoord(l.to)}</td><td>${l.heightDiff ?? ''}</td><td>${l.cost ?? ''}</td><td>${l.totalCost ?? ''}</td><td>${l.result ?? l.reason ?? ''}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+export function renderSelection(c) {
+  document.querySelector('#selection-info').textContent = c ? JSON.stringify(c, null, 2) : 'none';
+}


### PR DESCRIPTION
### Motivation
- Provide an interactive frontend mock that visualizes A* pathfinding on an 8×8 grid with 5 discrete height levels and height-aware movement rules.
- Make exploration, final path, movement costs and a step-by-step log visible so the algorithm and decisions can be inspected visually.
- Keep simulation/state, pathfinding, logging and rendering separated to ease later porting and testing (`grid.js`, `pathfinding.js`, `logger.js`, `main.js`).

### Description
- Scaffolded a Vite-based frontend app under `route-3d-grid` and added `index.html`, `package.json` and entry `src/main.js` with Three.js + `OrbitControls` for 3D rendering and interaction.
- Implemented `grid.js` with `GRID_SIZE`, `BASE_Z`, `createGrid`, `applySampleData`, `updateCellHeight`, `inBounds` and `toSerializableState` for state management and JSON serialization.
- Implemented `pathfinding.js` with an A* search that enforces 4-directional movement, ±1 height-difference movement limit, asymmetric climb/descent costs, and a Manhattan-like heuristic; logging hooks are emitted for `EVAL` / `MOVE` / `BLOCKED` events.
- Added `logger.js` for structured logs, `ui.js` for control panel (mode switching, height select, search actions, log export/import) and `styles.css`; `main.js` wires rendering, click-editing (start/goal/block/height), path line drawing and JSON import/export; note that `Step` and `Auto` buttons currently trigger a full run as an initial mock behavior.

### Testing
- There are no automated unit/integration tests included in this patch (no test harness added).
- An attempt to install/run dependencies with `cd route-3d-grid && npm install` was performed but failed with `403 Forbidden` from the npm registry, so runtime verification in this environment was limited and the app was not launched here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5ad9ba73483298b789fc45f1088ce)