### PR TITLE
焼酎夜性診断の静的Webモックを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# mock-private
-private mockup
+# 焼酎診断Webモック
+
+Pure HTML / CSS / Vanilla JavaScript で作成した、スマホ優先の診断LPモックです。
+
+## ファイル構成
+
+- `index.html`
+- `assets/css/style.css`
+- `assets/js/app.js`
+
+## 使い方
+
+`index.html` をブラウザで開くだけで動作します。

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,113 @@
+:root {
+  --bg: #140f0b;
+  --bg-sub: #1d1611;
+  --card: rgba(35, 25, 18, 0.88);
+  --amber: #d49a4c;
+  --amber-soft: #efc98e;
+  --text: #f7f1e8;
+  --muted: #cdbca7;
+  --shadow: 0 18px 36px rgba(0, 0, 0, 0.35);
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Hiragino Kaku Gothic ProN", "Yu Gothic", sans-serif;
+  background: radial-gradient(circle at top right, #2a1d14, var(--bg));
+  color: var(--text);
+}
+
+.background-grain {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: linear-gradient(rgba(255,255,255,0.02), rgba(255,255,255,0.02)),
+    repeating-linear-gradient(45deg, transparent 0 2px, rgba(255,255,255,0.02) 2px 3px);
+}
+
+.app-shell {
+  position: relative;
+  z-index: 1;
+  width: min(100%, 460px);
+  margin: 0 auto;
+  padding: 24px 18px 40px;
+}
+
+.screen { display: none; animation: fade .45s ease; }
+.screen.active { display: block; }
+
+.badge {
+  display: inline-block;
+  letter-spacing: .14em;
+  font-size: .72rem;
+  padding: 6px 10px;
+  border: 1px solid rgba(239, 201, 142, .4);
+  border-radius: 999px;
+  color: var(--amber-soft);
+}
+
+h1 { font-size: 2rem; margin: 14px 0 12px; line-height: 1.3; }
+.lead { color: var(--muted); line-height: 1.8; margin-bottom: 34px; }
+.notice { color: #aa9a88; font-size: .75rem; margin-top: 18px; line-height: 1.6; }
+
+.btn {
+  width: 100%;
+  border: none;
+  border-radius: 14px;
+  padding: 14px 16px;
+  color: var(--text);
+  background: #2b2118;
+  box-shadow: var(--shadow);
+  font-size: 1rem;
+}
+.btn:active { transform: translateY(1px); }
+.btn-primary {
+  background: linear-gradient(135deg, #a96e2f, #d49a4c);
+  color: #1f140d;
+  font-weight: 700;
+}
+
+.progress-wrap { margin: 12px 0 18px; }
+#progress-label { color: var(--muted); font-size: .85rem; }
+.progress-track {
+  height: 7px;
+  border-radius: 999px;
+  background: rgba(255,255,255,.12);
+  overflow: hidden;
+}
+#progress-bar {
+  display: block;
+  height: 100%;
+  width: 12.5%;
+  background: linear-gradient(90deg, #c37e2e, #f0c27d);
+  transition: width .3s ease;
+}
+
+.question-card,
+.result-card {
+  background: var(--card);
+  border: 1px solid rgba(239, 201, 142, .16);
+  border-radius: 20px;
+  padding: 20px;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(4px);
+}
+
+.question-eyebrow { color: var(--amber-soft); font-size: .8rem; margin: 0; }
+#question-text { font-size: 1.25rem; line-height: 1.6; margin: 12px 0 22px; }
+.answer-grid { display: grid; gap: 12px; }
+.answer.secondary { background: #3a2b1e; }
+.answer { text-align: left; line-height: 1.6; }
+
+.result-label { color: var(--amber-soft); margin: 0; }
+.result-header h2 { margin: 8px 0 12px; font-size: 1.8rem; }
+.result-copy { color: var(--muted); line-height: 1.7; margin-bottom: 20px; }
+.result-grid { display: grid; gap: 14px; }
+.result-grid h3 { margin: 0 0 4px; font-size: .9rem; color: var(--amber-soft); }
+.result-grid p { margin: 0; line-height: 1.65; }
+
+@keyframes fade {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,142 @@
+const questions = [
+  {
+    text: "夜に落ち着く場所は？",
+    options: [
+      { label: "暖色の灯りがある小さな店", score: { aroma: 1, temperature: 1, mood: -1, body: 1 } },
+      { label: "風が抜けるテラスや明るい席", score: { aroma: -1, temperature: -1, mood: 1, body: -1 } }
+    ]
+  },
+  {
+    text: "料理で惹かれるのは？",
+    options: [
+      { label: "炭火、煮込み、味噌、脂の旨み", score: { body: 1, temperature: 1, aroma: 1, mood: -1 } },
+      { label: "塩、刺身、出汁、軽い前菜", score: { body: -1, temperature: -1, aroma: -1, mood: 1 } }
+    ]
+  },
+  {
+    text: "お酒の香りは？",
+    options: [
+      { label: "個性がある方が記憶に残って好き", score: { aroma: 1, body: 1, mood: -1, temperature: 1 } },
+      { label: "食事を邪魔しない穏やかさが好き", score: { aroma: -1, body: -1, mood: 1, temperature: -1 } }
+    ]
+  },
+  {
+    text: "飲み方として惹かれるのは？",
+    options: [
+      { label: "お湯割り、前割り、ぬる燗", score: { temperature: 1, body: 1, mood: -1, aroma: 1 } },
+      { label: "ロック、ソーダ、水割り", score: { temperature: -1, body: -1, mood: 1, aroma: -1 } }
+    ]
+  },
+  {
+    text: "飲み会の後半は？",
+    options: [
+      { label: "もう少し語りたい", score: { mood: 1, aroma: 1, body: 1, temperature: 1 } },
+      { label: "静かに余韻へ入りたい", score: { mood: -1, aroma: -1, body: -1, temperature: -1 } }
+    ]
+  },
+  {
+    text: "味わいの好みは？",
+    options: [
+      { label: "しっかり、濃い、深い", score: { body: 1, aroma: 1, temperature: 1, mood: -1 } },
+      { label: "すっきり、軽い、爽やか", score: { body: -1, aroma: -1, temperature: -1, mood: 1 } }
+    ]
+  },
+  {
+    text: "旅先で飲むなら？",
+    options: [
+      { label: "土地のクセがある酒", score: { aroma: 1, body: 1, mood: -1, temperature: 1 } },
+      { label: "誰とでも合わせやすい酒", score: { aroma: -1, body: -1, mood: 1, temperature: -1 } }
+    ]
+  },
+  {
+    text: "食事との関係は？",
+    options: [
+      { label: "酒そのものも主役であってほしい", score: { aroma: 1, body: 1, mood: -1, temperature: 1 } },
+      { label: "料理を引き立てる酒がいい", score: { aroma: -1, body: -1, mood: 1, temperature: -1 } }
+    ]
+  }
+];
+
+const resultTypes = [
+  { name: "焚火芋焼酎型", category: "芋焼酎", copy: "深い香りを湯気でほどいて、夜の対話をゆっくり育てるタイプ。", profile: "香り高め / 温度は温 / 没入寄り / 重厚", drink: "お湯割り、前割り燗", food: "炭火焼、豚の角煮、味噌料理", brands: "黒霧島、伊佐美、村尾系", comment: "湯気の奥から立つ香りを、少し低めの温度で長く楽しんで。", match: s => s.aroma >= 0 && s.temperature >= 0 && s.mood < 0 && s.body >= 0 },
+  { name: "香ばし麦ロック型", category: "麦焼酎", copy: "香ばしさはありつつ軽快。会話の流れを止めないスマートな一杯。", profile: "香り中庸 / 冷寄り / 会話寄り / 軽快", drink: "ロック、ソーダ", food: "焼き鳥、唐揚げ、塩味料理", brands: "いいちこ、中々、兼八系", comment: "最初の一杯はソーダ、後半はロックで温度差を楽しむのがおすすめ。", match: s => s.body <= 0 && s.temperature <= 0 && s.mood >= 0 && s.aroma >= 0 },
+  { name: "静謐米焼酎型", category: "米焼酎", copy: "透明感のある香りと余韻。料理の輪郭を静かに引き立てるタイプ。", profile: "香り穏やか / 温冷どちらも可 / 没入寄り / 軽やか", drink: "水割り、ぬる燗、少量ストレート", food: "刺身、出汁、白身魚、米料理", brands: "鳥飼、白岳しろ、球磨焼酎系", comment: "一口ごとに香りの層を感じるよう、細身グラスでゆっくり。", match: s => s.aroma < 0 && s.body <= 0 && s.mood < 0 },
+  { name: "南風黒糖ソーダ型", category: "黒糖焼酎", copy: "やわらかな甘みを風のように。軽快で親しみやすい夜向け。", profile: "香りやや華やか / 冷寄り / 会話寄り / 軽快", drink: "ソーダ、ロック", food: "鶏料理、スパイス料理、柑橘系", brands: "れんと、里の曙、朝日系", comment: "氷は大きめを選び、香りを開かせるようにひと混ぜ。", match: s => s.temperature <= 0 && s.mood >= 0 && s.body <= 0 },
+  { name: "深夜泡盛型", category: "泡盛", copy: "芯の強さと余韻の長さ。深夜にじわっと効いてくる存在感。", profile: "香り個性派 / 温冷どちらも可 / 没入寄り / 重厚", drink: "ロック、ストレート、水割り", food: "ラフテー、豆腐よう、脂のある料理", brands: "瑞泉、菊之露、久米仙系", comment: "チェイサーを添えて、余韻をひとつずつ確かめるのが吉。", match: s => s.aroma >= 0 && s.body >= 0 && s.mood < 0 },
+  { name: "乾いたそば焼酎型", category: "そば焼酎", copy: "キレのよさと静かな香ばしさ。食中酒として頼れるバランス型。", profile: "香り控えめ / 冷寄り / 会話寄り / 中軽量", drink: "ロック、水割り", food: "蕎麦、天ぷら、山菜、和惣菜", brands: "雲海、そば雲海系", comment: "料理の温度に合わせて、割り材の比率を少しだけ調整してみて。", match: _ => true }
+];
+
+const state = { index: 0, scores: { aroma: 0, temperature: 0, mood: 0, body: 0 } };
+
+const screens = {
+  hero: document.getElementById("hero-screen"),
+  question: document.getElementById("question-screen"),
+  result: document.getElementById("result-screen")
+};
+
+const questionText = document.getElementById("question-text");
+const optionA = document.getElementById("option-a");
+const optionB = document.getElementById("option-b");
+const progressLabel = document.getElementById("progress-label");
+const progressBar = document.getElementById("progress-bar");
+
+function showScreen(key) {
+  Object.values(screens).forEach((el) => el.classList.remove("active"));
+  screens[key].classList.add("active");
+}
+
+function renderQuestion() {
+  const q = questions[state.index];
+  questionText.textContent = q.text;
+  optionA.textContent = q.options[0].label;
+  optionB.textContent = q.options[1].label;
+  progressLabel.textContent = `Question ${state.index + 1} / ${questions.length}`;
+  progressBar.style.width = `${((state.index + 1) / questions.length) * 100}%`;
+}
+
+function applyScore(score) {
+  Object.entries(score).forEach(([axis, delta]) => {
+    state.scores[axis] += delta;
+  });
+}
+
+function pickResult() {
+  return resultTypes.find((r) => r.match(state.scores));
+}
+
+function renderResult() {
+  const result = pickResult();
+  document.getElementById("result-name").textContent = result.name;
+  document.getElementById("result-copy").textContent = result.copy;
+  document.getElementById("result-category").textContent = result.category;
+  document.getElementById("result-profile").textContent = result.profile;
+  document.getElementById("result-drink").textContent = result.drink;
+  document.getElementById("result-food").textContent = result.food;
+  document.getElementById("result-brands").textContent = result.brands;
+  document.getElementById("result-comment").textContent = result.comment;
+}
+
+function handleAnswer(optionIndex) {
+  applyScore(questions[state.index].options[optionIndex].score);
+  state.index += 1;
+  if (state.index >= questions.length) {
+    renderResult();
+    showScreen("result");
+    return;
+  }
+  renderQuestion();
+}
+
+document.getElementById("start-btn").addEventListener("click", () => {
+  showScreen("question");
+  renderQuestion();
+});
+
+optionA.addEventListener("click", () => handleAnswer(0));
+optionB.addEventListener("click", () => handleAnswer(1));
+
+document.getElementById("retry-btn").addEventListener("click", () => {
+  state.index = 0;
+  state.scores = { aroma: 0, temperature: 0, mood: 0, body: 0 };
+  showScreen("hero");
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>焼酎夜性診断</title>
+    <link rel="stylesheet" href="assets/css/style.css" />
+  </head>
+  <body>
+    <div class="background-grain"></div>
+    <main class="app-shell">
+      <section id="hero-screen" class="screen active">
+        <p class="badge">SHOCHU NIGHT PROFILE</p>
+        <h1>焼酎夜性診断</h1>
+        <p class="lead">あなたの夜に合う一杯を、香り・温度・余韻から見つける。</p>
+        <button id="start-btn" class="btn btn-primary">診断をはじめる</button>
+        <p class="notice">お酒は20歳になってから。体質に合わない場合は飲酒を控えてください。</p>
+      </section>
+
+      <section id="question-screen" class="screen" aria-live="polite">
+        <div class="progress-wrap">
+          <p id="progress-label">Question 1 / 8</p>
+          <div class="progress-track"><span id="progress-bar"></span></div>
+        </div>
+
+        <article class="question-card">
+          <p class="question-eyebrow">夜の気分を教えてください</p>
+          <h2 id="question-text"></h2>
+          <div class="answer-grid">
+            <button id="option-a" class="btn answer"></button>
+            <button id="option-b" class="btn answer secondary"></button>
+          </div>
+        </article>
+      </section>
+
+      <section id="result-screen" class="screen" aria-live="polite">
+        <p class="badge">YOUR SHOCHU PROFILE</p>
+        <article class="result-card">
+          <div class="result-header">
+            <p class="result-label">診断結果</p>
+            <h2 id="result-name"></h2>
+            <p id="result-copy" class="result-copy"></p>
+          </div>
+
+          <div class="result-grid">
+            <div><h3>焼酎カテゴリ</h3><p id="result-category"></p></div>
+            <div><h3>味わい傾向</h3><p id="result-profile"></p></div>
+            <div><h3>おすすめの飲み方</h3><p id="result-drink"></p></div>
+            <div><h3>合う料理</h3><p id="result-food"></p></div>
+            <div><h3>銘柄例</h3><p id="result-brands"></p></div>
+            <div><h3>今日の一杯コメント</h3><p id="result-comment"></p></div>
+          </div>
+        </article>
+        <button id="retry-btn" class="btn btn-primary">もう一度診断する</button>
+      </section>
+    </main>
+
+    <script src="assets/js/app.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- スマホ優先かつビルド不要のフロントエンド静的モックを作成し、焼酎初心者〜中級者が数問の診断で好みの焼酎タイプを見つけられるようにする。 
- デザインは和モダン／暗めの琥珀色トーンで、カードレイアウト・余白・穏やかなアニメーションを重視して雰囲気を整える。 

### Description
- 追加した `index.html` は Hero／質問（1問ずつ、計8問の2択）／結果（タイプ名・コピー・カテゴリ・味わい・飲み方・料理・銘柄例・今日の一杯・再診断）の3画面構成を実装しています。 
- 追加した `assets/css/style.css` はダークウォームな琥珀色テーマ、グレイン背景、カードスタイル、モバイル幅制約（iPhone想定）および軽いアニメーションを含みます。 
- 追加した `assets/js/app.js` に質問データと4軸スコアリングロジック（`aroma` / `temperature` / `mood` / `body`）、回答ごとの `+1/-1` 加点、進捗表示、結果タイプ判定（6タイプ）・描画・再診断フローを実装し、将来 `questions.json` / `types.json` に分離しやすい構造にしています。 
- `README.md` を更新してファイル構成と利用方法（ブラウザで `index.html` を開くだけ）を記載しました。 

### Testing
- ファイル作成とコミットは自動化コマンドで確認済みで、`git add . && git commit -m "Create shochu diagnosis web mock with mobile-first UI" && git status --short` が正常終了しました。 
- 作成ファイルの中身は `find .` と `nl -ba index.html assets/css/style.css assets/js/app.js README.md` で出力確認済みです。 
- 外部自動UIテストは未実行で、動作確認はブラウザで `index.html` を開いて確認する想定です。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0110a7a2288329bf3a129e9ea10e3e)